### PR TITLE
Types should be included in the published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "author": "Julian <j.hille484@gmail.com>",
   "main": "./muhammara.js",
+  "types": "./muhammara.d.ts",
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build $EXTRA_NODE_PRE_GYP_FLAGS",
     "test": "mocha -R tap ./tests/*.js --timeout 15000",
@@ -25,6 +26,7 @@
   "files": [
     "src",
     "muhammara.js",
+    "muhammara.d.ts",
     "binding.gyp",
     "PDFRStreamForFile.js",
     "PDFStreamForResponse.js",


### PR DESCRIPTION
In order for types to be available to users of this package, they should be published as part of the package on npm.

See https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package