### PR TITLE
Disable deprecation warnings on msvs builds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 * Return code fixed for builds on app veyor.
+* Winwdows builds successfully with electron 10.x
 
 ## [1.4.2] - 2020-08-27
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -12,6 +12,19 @@
                 './src/deps/PDFWriter',
                 './src/deps/FreeType/include'
             ],
+            'conditions': [
+          ['OS=="win"', {
+            'defines!': [
+              'V8_DEPRECATION_WARNINGS=1',
+              'V8_DEPRECATION_WARNINGS',
+              'V8_IMMINENT_DEPRECATION_WARNINGS',
+              'V8_IMMINENT_DEPRECATION_WARNINGS=1'
+            ],
+          }, { # OS != "win",
+            'defines': [
+            ],
+          }]
+        ],
            'sources': [
                 './src/ConstructorsHolder.cpp',
                 './src/PDFStreamDriver.cpp',


### PR DESCRIPTION
These deprecation warnings do not really work with vs2015 nor vs2017.
The __decl(deprecated(..)) aliasing does not seem to work here.
So the easiest way for now is disabling it as macos, linux etc
would still complain about imminent deprecation, i think this is reasonable way to go.