### PR TITLE
Update g++ from 4.8 to 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - g++-4.8
       - libgconf-2-4
 services:
   - docker
@@ -73,7 +72,6 @@ matrix:
     - os: linux
       env: ELECTRON_VERSION="2.0.7" ELECTRON_MOCHA=true MOCHA_RUNTIME_VERSION="8"
 before_install:
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
   - if [[ $ELECTRON_VERSION ]]; then
     export npm_config_target=$ELECTRON_VERSION;
     export npm_config_target_arch=x64;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* Update the g++ compiler from 4.8 to 5.4 (default on xenial) for linux builds
+
 ## [1.5.1] - 2020-10-10
 
 ### Fixed


### PR DESCRIPTION
This makes use of the default compiler on xenial and builds the systems with it.
This is a prerequisite to compile muhammara for electron 11 on linux.