### PR TITLE
Fix electron artifact url

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,7 +261,7 @@ jobs:
           npm_config_arch: ${{ matrix.architecture }}
           npm_config_target_arch: ${{ matrix.target_architecture }}
           npm_config_target: ${{ matrix.electron }}
-          npm_config_disturl: https://atom.io/download/electron
+          npm_config_disturl: https://artifacts.electronjs.org/headers/dist
           npm_config_runtime: electron
           CFLAGS: ${{ matrix.extra_compile_flags }}
           CPPFLAGS: ${{ matrix.extra_compile_flags }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update npm dist url to the new url for electron builds
+
 ## [2.3.0] - 2022-05-04
 
 ### Added


### PR DESCRIPTION
According to this blog entry atom.io is dprecated and the new url should be used. https://www.electronjs.org/blog/s3-bucket-change

Fixes #167