### PR TITLE
Update type for PDFStreamForResponse to accept any writable stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update TypeScript declaration for `PDFStreamForResponse` to accept any writable stream as an argument, not just `PDFRStreamForFile`
+
 ## [3.0.0] - 2022-07-19
 
 ### Fixed

--- a/muhammara.d.ts
+++ b/muhammara.d.ts
@@ -251,7 +251,7 @@ declare module 'muhammara' {
   }
 
   export interface PDFStreamForResponse extends WriteStream {
-    new (res: PDFRStreamForFile): PDFStreamForResponse;
+    new (res: NodeJS.WritableStream): PDFStreamForResponse;
   }
 	
   export interface PDFWStreamForBuffer extends WriteStream {


### PR DESCRIPTION
As per the note the in the custom stream documentation, this method can be used with any writable, not just response streams.
https://github.com/julianhille/MuhammaraJS/blob/develop/docs/Custom-streams.md#available-streams