### PR TITLE
Fix memory leak in ByteReaderWithPositionDriver::Read()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Pre builts for arm64 / musl architecture (M1 using alpine)
 
+### Fixed
+
+- Memory leak in ByteReaderWithPositionDriver when reading PDF files
+
 ## [3.5.0] - 2022-12-07
 
 ### Added

--- a/src/ByteReaderWithPositionDriver.cpp
+++ b/src/ByteReaderWithPositionDriver.cpp
@@ -111,6 +111,8 @@ METHOD_RETURN_TYPE ByteReaderWithPositionDriver::Read(const ARGS_TYPE& args)
     for(LongBufferSizeType i=0;i<bufferSize;++i)
         outBuffer->Set(GET_CURRENT_CONTEXT, NEW_NUMBER(i),NEW_NUMBER(buffer[i]));
     
+    delete[] buffer;
+
     SET_FUNCTION_RETURN_VALUE(outBuffer)
 }
 


### PR DESCRIPTION
Previously, every PDF file that was read in by the library would leak a full copy into memory, as the temporary buffer wasn't cleaned up.