### PR TITLE
Remove pre building for mac M1 (arm64) for node < v15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -450,6 +450,18 @@ jobs:
             architecture: ia32
           - os: ubuntu-18.04
             architecture: ia32
+          - os: macos-11
+            node: 11.2.0
+            architecture: arm64
+          - os: macos-11
+            node: 12.0.0
+            architecture: arm64
+          - os: macos-11
+            node: 13.14.0
+            architecture: arm64
+          - os: macos-11
+            node: 14.0.0
+            architecture: arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update xmldom to new 0.8.6 and fix security issues
 - Fix arm64 on mac builds
 
+### Removed
+
+- Pre-builts for macos on arm for node < 15 (eg 14, 12, 10 etc)
+
 ## [3.6.0] - 2023-01-24
 
 ### Added


### PR DESCRIPTION
Node < v15 does not have header for m1 macs and only starts experimental implementation of m1 with node on v15