### PR TITLE
Add strikethrough implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Strikethough implementation in text object
+- Strikethrough implementation in text object
 - Add electron 23.2.
 - Recipe infos to readme
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Strikethough implementation in text object
 - Add electron 23.2.
 - Recipe infos to readme
 

--- a/lib/recipe/htmlToTextObjects.js
+++ b/lib/recipe/htmlToTextObjects.js
@@ -85,6 +85,7 @@ function parseNode(node) {
     isBold: isBoldTag(node.tagName),
     isItalic: isItalicTag(node.tagName),
     underline: node.tagName == "u",
+    strikeOut: node.tagName == "del",
     attributes,
     styles,
     needsLineBreaker: needsLineBreaker(node.tagName),

--- a/lib/recipe/text.js
+++ b/lib/recipe/text.js
@@ -368,6 +368,18 @@ exports.text = function text(text = "", x, y, options = {}) {
         }
       };
 
+      const addStrikeOut = (x, y, ctx, options) => {
+        // strikethrough implementation
+        if (options.strikeOut) {
+          const strikeOutY = y + options.textHeight * 0.2;
+          const width = options.lineWidth;
+          ctx
+            .q()
+            .drawPath(x, strikeOutY, x + width, strikeOutY, options)
+            .Q();
+        }
+      };
+
       const addTextTraits = (ctx, options) => {
         ctx.Tf(options.font, options.size);
         ctx.Tc(options.charSpace);
@@ -390,6 +402,7 @@ exports.text = function text(text = "", x, y, options = {}) {
         ctx.ET();
 
         addUnderline(x, y, ctx, options);
+        addStrikeOut(x, y, ctx, options);
       };
 
       const justifyText = (left, x, wto, textBox, ctx, options, callback) => {
@@ -420,7 +433,7 @@ exports.text = function text(text = "", x, y, options = {}) {
           return next_x;
         }
 
-        if (options.underline) {
+        if (options.underline || options.strikeOut) {
           options.lineWidth = wto.lineWidth;
         }
 
@@ -798,6 +811,9 @@ exports._layoutText = function _layoutText(textObjects, textBox, pathOptions) {
         child.underline = textObject.underline
           ? textObject.underline
           : child.underline;
+        child.strikeOut = textObject.strikeOut
+          ? textObject.strikeOut
+          : child.strikeOut;
 
         child.lineID = textObject.lineID;
         writeValue(child);
@@ -1075,6 +1091,7 @@ function makeTextObjects(self, textObject = {}, pathOptions, textBox = {}) {
     color: textObject.styles.color,
     opacity: parseFloat(textObject.styles.opacity || pathOptions.opacity || 1),
     underline: textObject.underline || pathOptions.underline,
+    strikeOut: textObject.strikeOut || pathOptions.strikeOut,
     size: textObject.size,
     alignHorizontal: alignHorizontal,
     alignVertical: alignVertical,

--- a/lib/recipe/text.js
+++ b/lib/recipe/text.js
@@ -425,7 +425,7 @@ exports.text = function text(text = "", x, y, options = {}) {
 
       const writeText = (context, x, y, wto) => {
         const options = wto.writeOptions;
-        const { lineHeight, text, baseline } = wto;
+        const { lineWidth, lineHeight, text, baseline } = wto;
         let next_x = 0;
 
         if (text === "") {
@@ -434,7 +434,7 @@ exports.text = function text(text = "", x, y, options = {}) {
         }
 
         if (options.underline || options.strikeOut) {
-          options.lineWidth = wto.lineWidth;
+          options.lineWidth = lineWidth;
         }
 
         // Produce a hilite under words?

--- a/lib/recipe/vector.helper.js
+++ b/lib/recipe/vector.helper.js
@@ -16,6 +16,7 @@ exports._getPathOptions = function _getPathOptions(
     size: options.size || this.current.defaultFontSize,
     charSpace: options.charSpace || 0,
     underline: false,
+    strikeOut: false,
     color: this._transformColor(options.color, {
       colorspace: colorspace,
       colorName: options.colorName,

--- a/muhammara.d.ts
+++ b/muhammara.d.ts
@@ -263,6 +263,7 @@ declare module "muhammara" {
 
   export interface WriteTextOptions extends FontOptions, ColorOptions {
     underline?: boolean;
+    strikeOut?: boolean;
     lineWidth?: number;
   }
 

--- a/tests/TestMaterials/recipe/text.html
+++ b/tests/TestMaterials/recipe/text.html
@@ -4,13 +4,11 @@
 <h3>H3 Header</h3>
 <br />
 <h3>
-  <span
-    >Lorem ipsum dolor sit amet, consectetur adipisicing elit, squis nostrud
+  <span>Lorem ipsum dolor sit amet, consectetur adipisicing elit, squis nostrud
     exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
     aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
     fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-    in culpa qui officia deserunt mollit anim id est laborum.</span
-  >
+    in culpa qui officia deserunt mollit anim id est laborum.</span>
 </h3>
 <br />
 <p><b>Some bold text</b><span>some other regular text</span></p>
@@ -22,11 +20,7 @@
 </p>
 <p><i></i></p>
 <p style="font-size: medium">
-  <i
-    ><i
-      ><b><u>Some Bold and Italic and underline</u></b></i
-    ></i
-  >
+  <i><i><b><u>Some Bold and Italic and underline</u></b></i></i>
 </p>
 <p style="font-size: medium">
   <i>

--- a/tests/TestMaterials/recipe/text.html
+++ b/tests/TestMaterials/recipe/text.html
@@ -4,11 +4,13 @@
 <h3>H3 Header</h3>
 <br />
 <h3>
-  <span>Lorem ipsum dolor sit amet, consectetur adipisicing elit, squis nostrud
+  <span
+    >Lorem ipsum dolor sit amet, consectetur adipisicing elit, squis nostrud
     exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
     aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
     fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-    in culpa qui officia deserunt mollit anim id est laborum.</span>
+    in culpa qui officia deserunt mollit anim id est laborum.</span
+  >
 </h3>
 <br />
 <p><b>Some bold text</b><span>some other regular text</span></p>
@@ -20,15 +22,17 @@
 </p>
 <p><i></i></p>
 <p style="font-size: medium">
-  <i><i><b><u>Some Bold and Italic and underline</u></b></i></i>
+  <i
+    ><i
+      ><b><u>Some Bold and Italic and underline</u></b></i
+    ></i
+  >
 </p>
 <p style="font-size: medium">
   <i>
     <b>
       <u>
-        <del>
-          Some Bold and Italic and underline and strikethrough
-        </del>
+        <del> Some Bold and Italic and underline and strikethrough </del>
       </u>
     </b>
   </i>

--- a/tests/TestMaterials/recipe/text.html
+++ b/tests/TestMaterials/recipe/text.html
@@ -16,6 +16,7 @@
 <p><b>Some bold text</b><span>some other regular text</span></p>
 <p><i>Some Italic text</i></p>
 <p><u>Some Underline</u></p>
+<p><del>Some Strikethrough</del></p>
 <p>
   <i><b>Some Bold and Italic</b></i>
 </p>
@@ -26,6 +27,17 @@
       ><b><u>Some Bold and Italic and underline</u></b></i
     ></i
   >
+</p>
+<p style="font-size: medium">
+  <i>
+    <b>
+      <u>
+        <del>
+          Some Bold and Italic and underline and strikethrough
+        </del>
+      </u>
+    </b>
+  </i>
 </p>
 <ul style="color: #ff0000; font-size: medium">
   <u><i></i></u>


### PR DESCRIPTION
This works similarly to the addUnderline() method
Here is an example when you pass text containing ```<del>``` tags into text()
[pdf-strikethrough.pdf](https://github.com/julianhille/MuhammaraJS/files/11070623/pdf-strikethrough.pdf)
Please let me know if you have any suggestions