### PR TITLE
Add test cases for text box underline, strikethrough, and highlight features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Tests for bold, italic, underline, strikethrough, and highlights in textboxes
+
 ## [5.0.0] - 2024-09-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,15 +50,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Underline in text object
 - Recipe type / arg documentation
 - Add missing type `userPassword` to `EncryptOptions`
+- Underline in text object
 
 ### Added
 
-- Strikethrough implementation in text object
 - Add electron 23.2., 23.3
 - Recipe infos to readme
+- Strikethrough implementation in text object
 - Electron v24.1, 24.2, 24.3, 24.4, 24.5, 24.6
 - Add node 20.x
 - Add electron v25.0, 25.1, 25.2, 25.3

--- a/lib/recipe/htmlToTextObjects.js
+++ b/lib/recipe/htmlToTextObjects.js
@@ -1,12 +1,12 @@
 const DOMParser = require("@xmldom/xmldom").DOMParser;
 
-exports.htmlToTextObjects = function (htmlCodes) {
+exports.htmlToTextObjects = function (htmlCodes, options = {}) {
   htmlCodes = htmlCodes.replace(/<br\/?>/g, "<p>[@@DONOT_RENDER_THIS@@]</p>");
   const nodes = new DOMParser().parseFromString(
     `<html>${htmlCodes}</html>`,
     "text/html",
   );
-  const textObjects = parseNode(nodes).childs[0].childs;
+  const textObjects = parseNode(nodes, options).childs[0].childs;
   return textObjects;
 };
 
@@ -40,7 +40,7 @@ function isItalicTag(tagName = "") {
   return italicTags.includes(tagName);
 }
 
-function parseNode(node) {
+function parseNode(node, options) {
   const attributes = [];
   const styles = {};
   for (let i in node.attributes) {
@@ -82,6 +82,7 @@ function parseNode(node) {
   const parsedData = {
     value,
     tag: node.tagName,
+    font: options.font,
     isBold: isBoldTag(node.tagName),
     isItalic: isItalicTag(node.tagName),
     underline: node.tagName == "u",
@@ -89,12 +90,14 @@ function parseNode(node) {
     attributes,
     styles,
     needsLineBreaker: needsLineBreaker(node.tagName),
+    size: options.size,
     sizeRatio: getFontSizeRatio(node.tagName),
+    sizeRatios: [getFontSizeRatio(node.tagName)],
     link: node.tagName == "a" ? node.attributes[0].value : null,
     childs: [],
   };
   for (let num in node.childNodes) {
-    parsedData.childs.push(parseNode(node.childNodes[num]));
+    parsedData.childs.push(parseNode(node.childNodes[num], options));
   }
   const ignoreValue = ["\n", "\n\n"];
   parsedData.childs = parsedData.childs.filter((item) => {

--- a/lib/recipe/text.js
+++ b/lib/recipe/text.js
@@ -208,6 +208,7 @@ exports._makeTextBox = function _makeTextBox(options) {
  * @param {Object|Boolean} [options.highlight] - Text markup annotation.
  * @param {Object|Boolean} [options.underline] - Text markup annotation.
  * @param {Object|Boolean} [options.strikeOut] - Text markup annotation.
+ * @param {Boolean} [options.html] - Interpret text as html
  * @param {Boolean} [options.flow=false] - Used to activate/deactivate text flow which is the
  * ability to use multiple calls to 'text' to create an overall text box.
  * @param {number|string} [options.layout] - An identifier of the layout to be associated with given text.
@@ -274,7 +275,7 @@ exports.text = function text(text = "", x, y, options = {}) {
   this._textOptions = this._flow ? options : { textBox: {} };
 
   const textObjects = options.html
-    ? htmlToTextObjects(text)
+    ? htmlToTextObjects(text, options)
     : this._makeTextObject(text, pathOptions.size, options);
   const textBox = this._makeTextBox(options);
 

--- a/muhammara.d.ts
+++ b/muhammara.d.ts
@@ -973,6 +973,7 @@ declare module "muhammara" {
       highlight?: boolean;
       underline?: boolean;
       strikeOut?: boolean;
+      html?: boolean;
       hilite?:
         | boolean
         | {

--- a/tests/recipe/text.js
+++ b/tests/recipe/text.js
@@ -214,4 +214,473 @@ describe("Text", () => {
       .endPage()
       .endPDF(done);
   });
+
+  it("Add text with bolded text inside textbox", (done) => {
+    const src = "new"; //path.join(__dirname, '../TestMaterials/recipe/test.pdf');
+    const output = path.join(
+      __dirname,
+      "../output/Add text with bolded format inside textbox.pdf"
+    );
+    const recipe = new HummusRecipe(src, output);
+    const textContent =
+      `${Date.now()} Lorem Ipsum is simply dummy text of the printing and typesetting industry. This <b>word</b> should be bolded. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. <b>This entire sentence should be bolded.</b> <b>It was popularised in the 1960s with the release </b>of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ` +
+      `${Date.now()} It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. <b>The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English.</b> Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).`;
+
+    recipe
+      .createPage("letter")
+      .circle("center", 400, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text(textContent, "center", 400, {
+        textBox: {
+          width: 500,
+          lineHeight: 16,
+          minHeight: 300,
+          textAlign: "center",
+          padding: [15, 30, 30],
+          style: {
+            lineWidth: 5,
+            fill: "#813b00",
+            stroke: "#ff0000",
+            opacity: 0.3,
+          },
+        },
+        html: true,
+        // flow: true,
+        font: "Helvetica",
+        size: 14,
+        color: "#813b00",
+        align: "center bottom",
+      })
+      .circle(500, 550, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text(textContent, 500, 550, {
+        html: true,
+        // flow: true,
+        font: "Roboto",
+        color: "#000000",
+        align: "right",
+        size: 12,
+        opacity: 0.8,
+        textBox: {
+          width: 400,
+          lineHeight: 30,
+          minHeight: 300,
+          padding: 15,
+          textAlign: "right",
+          style: {
+            lineWidth: 1,
+            stroke: "#0000ff",
+            fill: "#ffff00",
+            dash: [10, 10],
+            opacity: 0.3,
+          },
+        },
+      })
+      .circle(350, 450, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text("Fix height 200", 350, 450, {
+        textBox: {
+          width: 200,
+          lineHeight: 16,
+          height: 200,
+          padding: [5, 15],
+          textAlign: "left",
+          style: {
+            lineWidth: 1,
+            stroke: "#00ff00",
+            fill: "#ff0000",
+            dash: [20, 20],
+            opacity: 0.1,
+          },
+        },
+        font: "Roboto",
+        size: 30,
+        color: "#000000",
+      })
+      .endPage()
+      .endPDF(done);
+  });
+
+  it("Add text with italic text inside textbox", (done) => {
+    const src = "new"; //path.join(__dirname, '../TestMaterials/recipe/test.pdf');
+    const output = path.join(
+      __dirname,
+      "../output/Add text with italic format inside textbox.pdf"
+    );
+    const recipe = new HummusRecipe(src, output);
+    const textContent =
+      `${Date.now()} Lorem Ipsum is simply dummy text of the printing and typesetting industry. This <i>word</i> should have the italic format. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. <i>This entire sentence should be italicized.</i> <i>It was popularised in the 1960s with the release </i>of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ` +
+      `${Date.now()} It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. <i>The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English.</i> Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).`;
+
+    recipe
+      .createPage("letter")
+      .circle("center", 400, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text(textContent, "center", 400, {
+        textBox: {
+          width: 500,
+          lineHeight: 16,
+          minHeight: 300,
+          textAlign: "center",
+          padding: [15, 30, 30],
+          style: {
+            lineWidth: 5,
+            fill: "#813b00",
+            stroke: "#ff0000",
+            opacity: 0.3,
+          },
+        },
+        html: true,
+        // flow: true,
+        font: "Helvetica",
+        size: 14,
+        color: "#813b00",
+        align: "center bottom",
+      })
+      .circle(500, 550, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text(textContent, 500, 550, {
+        html: true,
+        // flow: true,
+        font: "Roboto",
+        color: "#000000",
+        align: "right",
+        size: 12,
+        opacity: 0.8,
+        textBox: {
+          width: 400,
+          lineHeight: 30,
+          minHeight: 300,
+          padding: 15,
+          textAlign: "right",
+          style: {
+            lineWidth: 1,
+            stroke: "#0000ff",
+            fill: "#ffff00",
+            dash: [10, 10],
+            opacity: 0.3,
+          },
+        },
+      })
+      .circle(350, 450, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text("Fix height 200", 350, 450, {
+        textBox: {
+          width: 200,
+          lineHeight: 16,
+          height: 200,
+          padding: [5, 15],
+          textAlign: "left",
+          style: {
+            lineWidth: 1,
+            stroke: "#00ff00",
+            fill: "#ff0000",
+            dash: [20, 20],
+            opacity: 0.1,
+          },
+        },
+        font: "Roboto",
+        size: 30,
+        color: "#000000",
+      })
+      .endPage()
+      .endPDF(done);
+  });
+
+  it("Add text with underline inside textbox", (done) => {
+    const src = "new"; //path.join(__dirname, '../TestMaterials/recipe/test.pdf');
+    const output = path.join(
+      __dirname,
+      "../output/Add text with underline inside textbox.pdf"
+    );
+    const recipe = new HummusRecipe(src, output);
+    const textContent =
+      `${Date.now()} Lorem Ipsum is simply dummy text of the printing and typesetting industry. This <u>word</u> should be underlined. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. <u>This entire sentence should be underlined.</u> It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ` +
+      `${Date.now()} It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).`;
+
+    recipe
+      .createPage("letter")
+      .circle("center", 400, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text(textContent, "center", 400, {
+        textBox: {
+          width: 500,
+          lineHeight: 16,
+          minHeight: 300,
+          textAlign: "center",
+          padding: [15, 30, 30],
+          style: {
+            lineWidth: 5,
+            fill: "#813b00",
+            stroke: "#ff0000",
+            opacity: 0.3,
+          },
+        },
+        html: true,
+        // flow: true,
+        font: "Helvetica",
+        size: 14,
+        color: "#813b00",
+        align: "center bottom",
+      })
+      .circle(500, 550, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text(textContent, 500, 550, {
+        html: true,
+        // flow: true,
+        font: "Roboto",
+        color: "#000000",
+        align: "right",
+        size: 12,
+        opacity: 0.8,
+        textBox: {
+          width: 400,
+          lineHeight: 30,
+          minHeight: 300,
+          padding: 15,
+          textAlign: "right",
+          style: {
+            lineWidth: 1,
+            stroke: "#0000ff",
+            fill: "#ffff00",
+            dash: [10, 10],
+            opacity: 0.3,
+          },
+        },
+      })
+      .circle(350, 450, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text("Fix height 200", 350, 450, {
+        textBox: {
+          width: 200,
+          lineHeight: 16,
+          height: 200,
+          padding: [5, 15],
+          textAlign: "left",
+          style: {
+            lineWidth: 1,
+            stroke: "#00ff00",
+            fill: "#ff0000",
+            dash: [20, 20],
+            opacity: 0.1,
+          },
+        },
+        font: "Roboto",
+        size: 30,
+        color: "#000000",
+      })
+      .endPage()
+      .endPDF(done);
+  });
+
+  it("Add text with strikethrough effect inside textbox", (done) => {
+    const src = "new"; //path.join(__dirname, '../TestMaterials/recipe/test.pdf');
+    const output = path.join(
+      __dirname,
+      "../output/Add text with strikethrough effect inside textbox.pdf"
+    );
+    const recipe = new HummusRecipe(src, output);
+    const textContent =
+      `${Date.now()} Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. This <del>word</del> should have the strikethrough effect. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ` +
+      `${Date.now()} It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. <del>This entire sentence should have the strikethrough format.</del> The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).`;
+
+    recipe
+      .createPage("letter")
+      .circle("center", 400, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text(textContent, "center", 400, {
+        html: true,
+        textBox: {
+          width: 500,
+          lineHeight: 16,
+          minHeight: 300,
+          textAlign: "center",
+          padding: [15, 30, 30],
+          style: {
+            lineWidth: 5,
+            fill: "#813b00",
+            stroke: "#ff0000",
+            opacity: 0.3,
+          },
+        },
+        font: "Helvetica",
+        size: 14,
+        color: "#813b00",
+        align: "center bottom",
+      })
+      .circle(500, 550, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text(textContent, 500, 550, {
+        html: true,
+        textBox: {
+          width: 400,
+          lineHeight: 30,
+          minHeight: 300,
+          padding: 15,
+          textAlign: "right",
+          style: {
+            lineWidth: 1,
+            stroke: "#0000ff",
+            fill: "#ffff00",
+            dash: [10, 10],
+            opacity: 0.3,
+          },
+        },
+        font: "Roboto",
+        size: 12,
+        color: "#000000",
+        align: "right",
+      })
+      .circle(350, 450, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text("Fix height 200", 350, 450, {
+        textBox: {
+          width: 200,
+          lineHeight: 16,
+          height: 200,
+          padding: [5, 15],
+          textAlign: "left",
+          style: {
+            lineWidth: 1,
+            stroke: "#00ff00",
+            fill: "#ff0000",
+            dash: [20, 20],
+            opacity: 0.1,
+          },
+        },
+        font: "Roboto",
+        size: 30,
+        color: "#000000",
+      })
+      .endPage()
+      .endPDF(done);
+  });
+
+  it("Add text with highlight inside textbox", (done) => {
+    const src = "new"; //path.join(__dirname, '../TestMaterials/recipe/test.pdf');
+    const output = path.join(
+      __dirname,
+      "../output/Add text with highlight inside textbox.pdf"
+    );
+    const recipe = new HummusRecipe(src, output);
+    const textContent =
+      `${Date.now()} Lorem Ipsum is simply dummy text of the printing and typesetting industry. This <mark>word</mark> should have the highlight format. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ` +
+      `${Date.now()} It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. <mark>This entire sentence should have the highlight format.</mark> The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).`;
+
+    recipe
+      .createPage("letter")
+      .circle("center", 400, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text(textContent, "center", 400, {
+        html: true,
+        textBox: {
+          width: 500,
+          lineHeight: 16,
+          minHeight: 300,
+          textAlign: "center",
+          padding: [15, 30, 30],
+          style: {
+            lineWidth: 5,
+            fill: "#813b00",
+            stroke: "#ff0000",
+            opacity: 0.3,
+          },
+        },
+        font: "Helvetica",
+        size: 14,
+        color: "#813b00",
+        align: "center bottom",
+      })
+      .circle(500, 550, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text(textContent, 500, 550, {
+        html: true,
+        textBox: {
+          width: 400,
+          lineHeight: 30,
+          minHeight: 300,
+          padding: 15,
+          textAlign: "right",
+          style: {
+            lineWidth: 1,
+            stroke: "#0000ff",
+            fill: "#ffff00",
+            dash: [10, 10],
+            opacity: 0.3,
+          },
+        },
+        font: "Roboto",
+        size: 12,
+        color: "#000000",
+        align: "right",
+      })
+      .circle(350, 450, 10, {
+        stroke: "#3b7721",
+        fill: "#0e0e0e",
+        opacity: 0.4,
+      })
+      .text("Fix height 200", 350, 450, {
+        textBox: {
+          width: 200,
+          lineHeight: 16,
+          height: 200,
+          padding: [5, 15],
+          textAlign: "left",
+          style: {
+            lineWidth: 1,
+            stroke: "#00ff00",
+            fill: "#ff0000",
+            dash: [20, 20],
+            opacity: 0.1,
+          },
+        },
+        font: "Roboto",
+        size: 30,
+        color: "#000000",
+      })
+      .endPage()
+      .endPDF(done);
+  });
 });

--- a/tests/recipe/text.js
+++ b/tests/recipe/text.js
@@ -219,7 +219,7 @@ describe("Text", () => {
     const src = "new"; //path.join(__dirname, '../TestMaterials/recipe/test.pdf');
     const output = path.join(
       __dirname,
-      "../output/Add text with bolded format inside textbox.pdf"
+      "../output/Add text with bolded format inside textbox.pdf",
     );
     const recipe = new HummusRecipe(src, output);
     const textContent =
@@ -314,7 +314,7 @@ describe("Text", () => {
     const src = "new"; //path.join(__dirname, '../TestMaterials/recipe/test.pdf');
     const output = path.join(
       __dirname,
-      "../output/Add text with italic format inside textbox.pdf"
+      "../output/Add text with italic format inside textbox.pdf",
     );
     const recipe = new HummusRecipe(src, output);
     const textContent =
@@ -409,7 +409,7 @@ describe("Text", () => {
     const src = "new"; //path.join(__dirname, '../TestMaterials/recipe/test.pdf');
     const output = path.join(
       __dirname,
-      "../output/Add text with underline inside textbox.pdf"
+      "../output/Add text with underline inside textbox.pdf",
     );
     const recipe = new HummusRecipe(src, output);
     const textContent =
@@ -504,7 +504,7 @@ describe("Text", () => {
     const src = "new"; //path.join(__dirname, '../TestMaterials/recipe/test.pdf');
     const output = path.join(
       __dirname,
-      "../output/Add text with strikethrough effect inside textbox.pdf"
+      "../output/Add text with strikethrough effect inside textbox.pdf",
     );
     const recipe = new HummusRecipe(src, output);
     const textContent =
@@ -596,7 +596,7 @@ describe("Text", () => {
     const src = "new"; //path.join(__dirname, '../TestMaterials/recipe/test.pdf');
     const output = path.join(
       __dirname,
-      "../output/Add text with highlight inside textbox.pdf"
+      "../output/Add text with highlight inside textbox.pdf",
     );
     const recipe = new HummusRecipe(src, output);
     const textContent =


### PR DESCRIPTION
Had to make some modifications to lib/recipe/htmlToTextObjects.js and lib/recipe/text.js to make tests pass when 
```
html: true
```
is set as an option when invoking .text()