### PR TITLE
Update `PDFRStreamForBuffer` to read buffer without copying all at once

### DIFF
--- a/lib/PDFRStreamForBuffer.js
+++ b/lib/PDFRStreamForBuffer.js
@@ -5,17 +5,16 @@
 */
 
 function PDFRStreamForBuffer(buffer) {
-  this.innerArray = Array.prototype.slice.call(buffer, 0);
+  this.buffer = buffer;
   this.rposition = 0;
-  this.fileSize = this.innerArray.length;
+  this.fileSize = this.buffer.length;
   this.mStartPosition = 0;
 }
 
 PDFRStreamForBuffer.prototype.read = function (inAmount) {
   var amountToRead = inAmount;
-  var arr = this.innerArray.slice(
-    this.rposition,
-    this.rposition + amountToRead
+  var arr = Array.from(
+    this.buffer.subarray(this.rposition, this.rposition + amountToRead)
   );
   this.rposition += amountToRead;
   return arr;


### PR DESCRIPTION
When using `PDFRStreamForBuffer` for using buffers that were relatively large (but not really _that_ large), a range error would be thrown. This commit makes it so PDFRStreamForBuffer does not create an array from the entire buffer at once, but only creates array for each slice being read.

Fixes #334