### PR TITLE
Use `Buffer.from` instead of `new Buffer`

### DIFF
--- a/lib/PDFRStreamForFile.js
+++ b/lib/PDFRStreamForFile.js
@@ -12,7 +12,7 @@ function PDFRStreamForFile(inPath) {
 }
 
 PDFRStreamForFile.prototype.read = function (inAmount) {
-  var buffer = Buffer.from(inAmount * 2);
+  var buffer = Buffer.alloc(inAmount * 2);
   var bytesRead = fs.readSync(this.rs, buffer, 0, inAmount, this.rposition);
   var arr = [];
 

--- a/lib/PDFRStreamForFile.js
+++ b/lib/PDFRStreamForFile.js
@@ -12,7 +12,7 @@ function PDFRStreamForFile(inPath) {
 }
 
 PDFRStreamForFile.prototype.read = function (inAmount) {
-  var buffer = new Buffer(inAmount * 2);
+  var buffer = Buffer.from(inAmount * 2);
   var bytesRead = fs.readSync(this.rs, buffer, 0, inAmount, this.rposition);
   var arr = [];
 

--- a/lib/PDFStreamForResponse.js
+++ b/lib/PDFStreamForResponse.js
@@ -9,7 +9,7 @@ function PDFStreamForResponse(inResponse) {
 
 PDFStreamForResponse.prototype.write = function (inBytesArray) {
   if (inBytesArray.length > 0) {
-    this.response.write(new Buffer(inBytesArray));
+    this.response.write(Buffer.from(inBytesArray));
     this.position += inBytesArray.length;
     return inBytesArray.length;
   } else return 0;

--- a/lib/PDFWStreamForFile.js
+++ b/lib/PDFWStreamForFile.js
@@ -12,7 +12,7 @@ function PDFWStreamForFile(inPath) {
 
 PDFWStreamForFile.prototype.write = function (inBytesArray) {
   if (inBytesArray.length > 0) {
-    this.ws.write(new Buffer(inBytesArray));
+    this.ws.write(Buffer.from(inBytesArray));
     this.position += inBytesArray.length;
     return inBytesArray.length;
   } else return 0;

--- a/tests/BufferReadTest.js
+++ b/tests/BufferReadTest.js
@@ -5,7 +5,7 @@ var assert = require("chai").assert;
 describe("BufferRead", function () {
   it("should read buffer correctly", function () {
     var originalString = "hello world";
-    var buffer = new Buffer(originalString);
+    var buffer = Buffer.from(originalString);
     var stream = new muhammara.PDFRStreamForBuffer(buffer);
     assert.equal(
       stream.read(originalString.length * 10).length,


### PR DESCRIPTION
The `Buffer` constructor [is deprecated](https://nodejs.org/api/buffer.html#new-bufferarray), so we should use the recommended `Buffer.from` instead.

Fixes #338 