### PR TITLE
Fix: support negative rotation in Recipe page changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - definitions: appendPage optionnal parameter
 - Build musl/musl-arm with node 20
+- Support negative rotation in recipe page changes
 
 ## [4.0.0] - 2023-07-14
 

--- a/lib/recipe/page.js
+++ b/lib/recipe/page.js
@@ -184,12 +184,15 @@ exports._resumePageRotation = function _resumePageRotation(
 
   switch (rotate) {
     case 90:
+    case -270:
       context.cm(0, 1, -1, 0, height - startX, startY);
       break;
     case 180:
+    case -180:
       context.cm(-1, 0, 0, -1, width, height);
       break;
     case 270:
+    case -90:
       context.cm(0, -1, 1, 0, startX, width - startY);
       break;
 


### PR DESCRIPTION
Minor change to handle PDF pages with negative rotation (-90, -180, -270) when modifying an existing PDF. This is unusual but it happens occasionally. In a recent customer PDF, the file shows a setting of /Rotate -180/ and MuhammaraJS reports the same. 

Looking at the Adobe PDF spec v1.7, it just says "The number of degrees by which the page should
be rotated clockwise when displayed or printed. The value must be a multiple of 90. Default value: 0."... so I guess some PDF writers have taken that to mean negative is okay. Thanks 