### PR TITLE
Update appendPage pages arg type declaration to support page ranges

### DIFF
--- a/muhammara.d.ts
+++ b/muhammara.d.ts
@@ -1066,7 +1066,10 @@ declare module "muhammara" {
       options?: Recipe.AnnotOptions
     ): Recipe;
 
-    appendPage(pdfSrc: string, pages?: number | number[]): Recipe;
+    appendPage(
+      pdfSrc: string,
+      pages?: number | (number | [number, number])[]
+    ): Recipe;
 
     encrypt(options: Recipe.EncryptOptions): Recipe;
 


### PR DESCRIPTION
According to the docs, page ranges can be provided to the `appendPage` method as shown the [example](https://github.com/julianhille/MuhammaraJS?tab=readme-ov-file#append-pdf).

e.g. 
```
pdfDoc.appendPage(longPDF, [
    [1, 3],
    [6, 20],
  ])
```

The current type declaration for `pages` only supports pages value to be `[1, 3, 4]` or simply `1`. This PR updates this type declaration to support the ranges shown in the example.