### PR TITLE
fix: ensure bindings get copied

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lib",
     "fonts",
     "binding.gyp",
+    "binding",
     "muhammara.d.ts"
   ],
   "dependencies": {


### PR DESCRIPTION
As far as I understand, this ensures that installed bindings get copied along with the package code when running `pnpm deploy`.

It's hard to test this due to the nature of the install. I'm copying the file manually now.