### PR TITLE
Feature/410 update pdfwriter

### DIFF
--- a/src/deps/FreeType/binding.gyp
+++ b/src/deps/FreeType/binding.gyp
@@ -5,19 +5,15 @@
             'type': 'static_library',
             'defines': [
                 'FT2_BUILD_LIBRARY=1',
-                'USE_BUNDLED=TRUE'
-            ],
-            'dependencies': [
-                '<(module_root_dir)/src/deps/Zlib/binding.gyp:zlib'
+                'FT_CONFIG_OPTION_SYSTEM_ZLIB=1'
             ],
             'include_dirs': [
              './include',
-             './include',
+             './include/freetype',
              './include/freetype/config',
              './include/src',
              './include/freetype/internal',
              './include/freetype/internal/services'
-             '<(module_root_dir)/src/deps/Zlib',
             ],
            'msvs_settings':
 			{

--- a/src/deps/LibTiff/binding.gyp
+++ b/src/deps/LibTiff/binding.gyp
@@ -30,6 +30,11 @@
                     "defines": [
                         'HAVE_UNISTD_H=1'
                     ]
+                }],
+                ['target_arch == "ia32"', {
+                    "defines": [
+                        'SIZEOF_SIZE_T=4'
+                    ]
                 }]
             ],
            'msvs_settings':

--- a/src/deps/LibTiff/tif_config.h
+++ b/src/deps/LibTiff/tif_config.h
@@ -45,8 +45,10 @@
 /* Define to the home page for this package. */
 #define PACKAGE_URL ""
 
-/* Size of size_t */
+/* Size of size_t, allowing external override */
+#ifndef SIZEOF_SIZE_T
 #define SIZEOF_SIZE_T 8
+#endif
 
 
 /** Maximum number of TIFF IFDs that libtiff can iterate through in a file. */

--- a/src/deps/PDFWriter/DecryptionHelper.cpp
+++ b/src/deps/PDFWriter/DecryptionHelper.cpp
@@ -38,6 +38,7 @@ limitations under the License.
 #include "Trace.h"
 #include "Deletable.h"
 #include <memory>
+#include <algorithm>
 
 using namespace std;
 using namespace PDFHummus;


### PR DESCRIPTION
reckon this should fix the problems in upgrading:
- freetype configuration to allow other zlib symbols. this should get building working.
- libtiff in ia32 needs to be told that size of size t is 4 and not 8. this should fix TiffImageTest,js otherwise failing on embedding a few tiff images.
- [when building locally i got errors on decryptionhelper with std::max not available. to fix this adding <algorithm> include. not sure this comes up in building via cicd, but corrected anyways]