### PR TITLE
conf: drop later defines close overriding the former, and causing ZIP_SUPPORT=1 to be ignored

### DIFF
--- a/src/deps/LibTiff/binding.gyp
+++ b/src/deps/LibTiff/binding.gyp
@@ -50,9 +50,6 @@
             'include_dirs': [
               '<(module_root_dir)/src/deps/Zlib',
             ],
-            'defines': [
-                'USE_BUNDLED=TRUE'
-            ],
            'sources': [
                 'tif_aux.c',
                 'tif_close.c',


### PR DESCRIPTION
tiff images tests fail.
placing logs on the failures i saw that deflate wasn't configured. AKA zip. which is weird cause there's this ZIP_SUPPORT=1 set up on defines. only problem is its being ignored because the later "defines" statement overrides all the earlier definitions. removing the later defines compiles and the tests succeed.