### PR TITLE
Release the source PDF file handle Recipe holds (#381)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Release the source PDF file handle that `Recipe` holds, so the source,
+  appended, and overlaid files can be deleted right after `endPDF()` instead of
+  failing with `EBUSY` on Windows [#381](https://github.com/julianhille/MuhammaraJS/issues/381)
+
 ### Changed
 
 - Build Linux prebuilds against the Debian archive now that Debian 11

--- a/packages/native-core/lib/Recipe.js
+++ b/packages/native-core/lib/Recipe.js
@@ -149,12 +149,14 @@ class Recipe {
    */
   read(inSrc) {
     const isForExternal = inSrc ? true : false;
+    let pdfReader = null;
+    let isAdopted = false;
     try {
       let src = isForExternal ? inSrc : this.src;
       if (this.isBufferSrc) {
         src = new muhammara.PDFRStreamForBuffer(this.src);
       }
-      const pdfReader = muhammara.createReader(src, this.encryptOptions);
+      pdfReader = muhammara.createReader(src, this.encryptOptions);
       const pages = pdfReader.getPagesCount();
       if (pages == 0) {
         // broken or modify password protected
@@ -206,13 +208,50 @@ class Recipe {
         metadata[page.pageNumber] = page;
       }
       if (!isForExternal) {
+        this._releaseReader();
         this.pdfReader = pdfReader;
         this.metadata = metadata;
+        isAdopted = true;
       }
       return metadata;
     } catch (err) {
       throw new Error(err);
+    } finally {
+      // Only the recipe source reader outlives read(); anything else would keep
+      // the file open until the process exits.
+      if (pdfReader && !isAdopted) {
+        pdfReader.end();
+      }
     }
+  }
+
+  /**
+   * Release the source reader and the file handle it holds.
+   * @private
+   * @returns {void}
+   */
+  _releaseReader() {
+    const pdfReader = this.pdfReader;
+    if (!pdfReader) {
+      return;
+    }
+    this.pdfReader = null;
+    pdfReader.end();
+  }
+
+  /**
+   * Get the source reader, which endPDF() releases.
+   * @private
+   * @returns {Object} The source PDF reader.
+   * @throws {Error} If the reader was already released by endPDF().
+   */
+  _getReader() {
+    if (!this.pdfReader) {
+      throw new Error(
+        "The source PDF reader has been released by endPDF(). Read the source before ending the document.",
+      );
+    }
+    return this.pdfReader;
   }
 
   /**
@@ -256,6 +295,12 @@ class Recipe {
       this._writeInfo();
       this.writer.end();
     }
+
+    // Every step above may still read the source; _insertPages() and _encrypt()
+    // below rename the output, which is the source itself when no separate
+    // output was given, and Windows refuses that while the reader holds it.
+    this._releaseReader();
+
     if (this.needToInsertPages) {
       if (this.isBufferSrc) {
         // eslint-disable-next-line no-console

--- a/packages/native-core/lib/recipe/info.js
+++ b/packages/native-core/lib/recipe/info.js
@@ -33,60 +33,63 @@ exports._readInfo = function _readInfo() {
       ? new muhammara.PDFRStreamForBuffer(this.src)
       : this.src;
     const copyCtx = this.writer.createPDFCopyingContext(copyFrom);
-    const infoDict = copyCtx
-      .getSourceDocumentParser()
-      .queryDictionaryObject(
-        copyCtx.getSourceDocumentParser().getTrailer(),
-        "Info",
-      );
+    try {
+      const infoDict = copyCtx
+        .getSourceDocumentParser()
+        .queryDictionaryObject(
+          copyCtx.getSourceDocumentParser().getTrailer(),
+          "Info",
+        );
 
-    const oldInfo =
-      infoDict && infoDict.toJSObject ? infoDict.toJSObject() : null;
+      const oldInfo =
+        infoDict && infoDict.toJSObject ? infoDict.toJSObject() : null;
 
-    if (oldInfo) {
-      this.infoDictionary = {};
-      Object.getOwnPropertyNames(oldInfo).forEach((key) => {
-        if (!oldInfo[key]) {
-          return;
-        }
-        const oldInforSrc = this._parseObjectByType(oldInfo[key]);
-        if (!oldInforSrc) {
-          return;
-        }
-        switch (key) {
-          case "Trapped":
-            if (oldInforSrc && oldInforSrc.value) {
-              this.infoDictionary.trapped = oldInforSrc.value;
-            }
-            break;
-          case "CreationDate":
-            if (oldInforSrc && oldInforSrc.value) {
-              this.infoDictionary.creationDate = oldInforSrc.value;
-            }
-            break;
-          case "ModDate":
-            if (oldInforSrc && oldInforSrc.value) {
-              this.infoDictionary.modDate = oldInforSrc.value;
-            }
-            break;
-          case "Creator":
-            if (oldInforSrc && oldInforSrc.toText) {
-              this.infoDictionary.creator = oldInforSrc.toText();
-            }
-            break;
-          case "Producer":
-            if (oldInforSrc && oldInforSrc.toText) {
-              this.infoDictionary.producer = oldInforSrc.toText();
-            }
-            break;
-          default:
-            if (oldInforSrc && oldInforSrc.toText) {
-              this.infoDictionary[key.toLowerCase()] = oldInforSrc.toText();
-            }
-        }
-      });
+      if (oldInfo) {
+        this.infoDictionary = {};
+        Object.getOwnPropertyNames(oldInfo).forEach((key) => {
+          if (!oldInfo[key]) {
+            return;
+          }
+          const oldInforSrc = this._parseObjectByType(oldInfo[key]);
+          if (!oldInforSrc) {
+            return;
+          }
+          switch (key) {
+            case "Trapped":
+              if (oldInforSrc && oldInforSrc.value) {
+                this.infoDictionary.trapped = oldInforSrc.value;
+              }
+              break;
+            case "CreationDate":
+              if (oldInforSrc && oldInforSrc.value) {
+                this.infoDictionary.creationDate = oldInforSrc.value;
+              }
+              break;
+            case "ModDate":
+              if (oldInforSrc && oldInforSrc.value) {
+                this.infoDictionary.modDate = oldInforSrc.value;
+              }
+              break;
+            case "Creator":
+              if (oldInforSrc && oldInforSrc.toText) {
+                this.infoDictionary.creator = oldInforSrc.toText();
+              }
+              break;
+            case "Producer":
+              if (oldInforSrc && oldInforSrc.toText) {
+                this.infoDictionary.producer = oldInforSrc.toText();
+              }
+              break;
+            default:
+              if (oldInforSrc && oldInforSrc.toText) {
+                this.infoDictionary[key.toLowerCase()] = oldInforSrc.toText();
+              }
+          }
+        });
+      }
+    } finally {
+      copyCtx.end();
     }
-    copyCtx.end();
   }
 
   return this.infoDictionary;
@@ -225,7 +228,7 @@ exports.structure = function structure(output) {
   // const outputFileType = path.extname(output);
   const outputFile = fs.openSync(output, "w");
   const muhammara = this.muhammara;
-  const pdfReader = this.pdfReader;
+  const pdfReader = this._getReader();
 
   const tabWidth = "  ";
   const structures = [
@@ -331,7 +334,7 @@ exports._parseObjectByType = function _parseObjectByType(inObject) {
     return;
   }
   const muhammara = this.muhammara;
-  const pdfReader = this.pdfReader;
+  const pdfReader = this._getReader();
   const type = inObject.getType();
   const label = muhammara.getTypeLabel(type);
   const saveToObject = this.pdfStructure || {};

--- a/packages/native-core/lib/recipe/split.js
+++ b/packages/native-core/lib/recipe/split.js
@@ -18,7 +18,7 @@ exports.split = function split(outputDir = "", prefix) {
     const pdfWriter = muhammara.createWriter(newPdf);
     hummusUtils.appendPDFPageFromPDFWithAnnotations(
       pdfWriter,
-      this.pdfReader,
+      this._getReader(),
       i,
     );
     pdfWriter.end();

--- a/packages/native-with-source/tests/recipe/appendPages.js
+++ b/packages/native-with-source/tests/recipe/appendPages.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const fs = require("fs");
 const HummusRecipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Append Pages", () => {
@@ -20,5 +21,23 @@ describe("Append Pages", () => {
       ])
       .appendPage(longPDF)
       .endPDF(done);
+  });
+
+  it("releases the input files once the PDF is written", () => {
+    const source = path.join(__dirname, "../output/appendPages-source.pdf");
+    const appended = path.join(__dirname, "../output/appendPages-appended.pdf");
+    const output = path.join(__dirname, "../output/appendPages-handles.pdf");
+    const material = path.join(__dirname, "../TestMaterials/recipe/test.pdf");
+    fs.copyFileSync(material, source);
+    fs.copyFileSync(material, appended);
+
+    new HummusRecipe(source, output).appendPage(appended).endPDF();
+
+    // Windows refuses the unlink with EBUSY while a reader still holds the
+    // file, which is what https://github.com/julianhille/MuhammaraJS/issues/381
+    // reported.
+    fs.unlinkSync(source);
+    fs.unlinkSync(appended);
+    fs.rmSync(output, { force: true });
   });
 });

--- a/packages/native-with-source/tests/recipe/overlay.js
+++ b/packages/native-with-source/tests/recipe/overlay.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const fs = require("fs");
 const HummusRecipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Modify", () => {
@@ -250,5 +251,25 @@ describe("Modify", () => {
       page: 2,
     };
     recipe.editPage(1).overlay(overlayPDF, options).endPage().endPDF(done);
+  });
+
+  it("releases the overlaid file once the PDF is written", () => {
+    const material = path.join(__dirname, "../TestMaterials/recipe/test.pdf");
+    const source = path.join(__dirname, "../output/overlay-source.pdf");
+    const overlaid = path.join(__dirname, "../output/overlay-overlaid.pdf");
+    const output = path.join(__dirname, "../output/overlay-handles.pdf");
+    fs.copyFileSync(material, source);
+    fs.copyFileSync(material, overlaid);
+
+    new HummusRecipe(source, output)
+      .editPage(1)
+      .overlay(overlaid)
+      .endPage()
+      .endPDF();
+
+    // Both files stay locked on Windows while a reader still holds them: #381.
+    fs.unlinkSync(source);
+    fs.unlinkSync(overlaid);
+    fs.rmSync(output, { force: true });
   });
 });

--- a/packages/native/docs/api/reader-and-objects.md
+++ b/packages/native/docs/api/reader-and-objects.md
@@ -20,10 +20,15 @@ and `toJSObject`; an array provides `getLength`, `queryObject`, and `toJSArray`.
 Use reader query helpers when an entry may be an indirect reference and must be
 resolved.
 
+`end()` releases the reader and the file handle behind it. Call it once every
+parsed object and stream has been consumed; until then the input file stays
+open, and Windows refuses to rename or delete it.
+
 ```javascript
 var reader = muhammara.createReader("input.pdf");
 var pageCount = reader.getPagesCount();
 var firstPage = reader.parsePage(0);
+reader.end();
 ```
 
 [`tests/PDFParser.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/PDFParser.js) covers reader creation, page inspection, trailer traversal,

--- a/packages/native/docs/low-level/read-pdfs.md
+++ b/packages/native/docs/low-level/read-pdfs.md
@@ -8,7 +8,14 @@ var muhammara = require("@muhammara/native");
 var reader = muhammara.createReader("input.pdf");
 
 console.log(reader.getPagesCount());
+
+reader.end();
 ```
+
+Call `end()` when the reader is no longer needed, after every object and stream
+parsed from it has been consumed. It closes the underlying file handle; skipping
+it leaves `input.pdf` locked on Windows, where the file then cannot be deleted
+or renamed.
 
 Readers provide page counts, PDF level, trailers, page dictionaries, and
 low-level PDF objects. `parsePage(index)` exposes page boxes and rotation;

--- a/packages/native/docs/low-level/read-pdfs.md
+++ b/packages/native/docs/low-level/read-pdfs.md
@@ -15,7 +15,7 @@ reader.end();
 Call `end()` when the reader is no longer needed, after every object and stream
 parsed from it has been consumed. It closes the underlying file handle; skipping
 it leaves `input.pdf` locked on Windows, where the file then cannot be deleted
-or renamed.
+or renamed. `Recipe` releases the readers it opens itself, in `endPDF()`.
 
 Readers provide page counts, PDF level, trailers, page dictionaries, and
 low-level PDF objects. `parsePage(index)` exposes page boxes and rotation;

--- a/tests/AppendPagesTest.js
+++ b/tests/AppendPagesTest.js
@@ -1,5 +1,7 @@
 const muhammara = require("../lib/muhammara");
+const Recipe = require("../lib/Recipe");
 const expect = require("chai").expect;
+const fs = require("fs");
 
 describe("AppendPagesTest", function () {
   it("should complete without error", function () {
@@ -25,5 +27,20 @@ describe("AppendPagesTest", function () {
         __dirname + "/TestMaterials/appendbreaks.pdf",
       ),
     ).to.throw("unable to append");
+  });
+
+  it("should free the file handle", () => {
+    const testFile1 = __dirname + "/output/test1.pdf";
+    const testFile2 = __dirname + "/output/test2.pdf";
+    const resultFile = __dirname + "/output/result.pdf";
+    fs.copyFileSync(__dirname + "/TestMaterials/Original.pdf", testFile1);
+    fs.copyFileSync(__dirname + "/TestMaterials/Original.pdf", testFile2);
+
+    const pdfDoc = new Recipe(testFile1, resultFile);
+    pdfDoc.appendPage(testFile2).endPDF();
+
+    // error here: Error: EBUSY: resource busy or locked, unlink
+    fs.unlinkSync(testFile1);
+    fs.unlinkSync(testFile2);
   });
 });


### PR DESCRIPTION
Fixes [#381](https://github.com/julianhille/MuhammaraJS/issues/381), reopened because `4862c99` only closed half of it.

Two commits: the regression test first, then the fix, so the test is verifiably red before it is green.

### The leak

`4862c99` released the reader `appendPage()` opens for the *appended* file. But `Recipe.read()` opens a second reader for the **source** and stores it as `this.pdfReader` (`Recipe.js:157`, `Recipe.js:209`) and nothing ever ends it. `endPDF()` ends `this.writer`, never `this.pdfReader`, so the handle survives until the process exits — which is why the reporters saw the lock outlive both `setTimeout` and the `endPDF()` callback.

Measured on Linux by counting `/proc/self/fd` entries still pointing at each input after `endPDF()`:

| scenario | before (source, other) | after |
| --- | --- | --- |
| `appendPage()` | **1**, 0 | 0, 0 |
| `overlay()` | **1**, **1** | 0, 0 |
| in-place (`new Recipe(src)`) | **1** | 0 |

`overlay()` leaks twice over: `Recipe.read(inSrc)` takes an `isForExternal` path where the reader is neither stored nor ended.

### Where the handle is released

`endPDF()`, positioned deliberately:

- **after** `_writeInfo()` and the annotation-rewrite block — both reach the reader through `_readInfo()` → `_parseObjectByType()`;
- **before** `_insertPages()` and `_encrypt()` — both `fs.renameSync(this.output, …)`, and `this.output` *is* the source when no separate output was given, so on Windows Recipe was tripping over its own handle.

`read()` now ends any reader the instance does not adopt, in a `finally`, which covers the `overlay()` path and the error paths in one place. `_readInfo()` ends its copying context through a `finally` as well — that context holds the source open too, and `PDFWriter::EndPDF()` only calls `ReleaseDocumentContextReference()` on registered copying contexts, which nulls a back-pointer without closing the file.

`split()` and the info helpers take the reader through a `_getReader()` accessor that throws a descriptive error instead of dereferencing null, should anything reach for it after `endPDF()`. Both are used before `endPDF()` everywhere in the suite and docs.

### Tests

`tests/recipe/appendPages.js` — the original reproduction, and `tests/recipe/overlay.js` — the second leak. Both unlink their inputs immediately after `endPDF()`. They assert nothing on POSIX, which unlinks open files happily; the Windows leg is what enforces them, and it is where the first commit fails.

Full native suite: 194/194.

Native-only. The Wasm `appendPage`/`overlay` read through the Emscripten in-memory FS, where there is no OS file handle to leak.