### PR TITLE
Allow the setting of a default font

### DIFF
--- a/lib/Recipe.js
+++ b/lib/Recipe.js
@@ -15,15 +15,15 @@ const streams = require("memory-streams");
  * @param {string} [options.author] - The author
  * @param {string} [options.title] - The title
  * @param {string} [options.subject] - The subject
- * @param {string} [options.colorspace] - The default colorspace: rgb, cmyk, gray
+ * @param {string} [options.colorspace] - The default colorspace: rgb, cmyk, gray, separation
  * @param {string} [options.defaultFontSize=14] - The default font size
  * @param {string} [options.defaultFontFamily=helvetica] - The default font: 'arial', 'courier new', 'georgia', 'helvetica', 'roboto'
+ * @param {string|string[]} [options.fontSrcPath] - directory location(s) of additional fonts
  * @param {string[]} [options.keywords] - The array of keywords
  * @param {string} [options.password] - permission password
  * @param {string} [options.userPassword] - this 'view' password also enables encryption
  * @param {string} [options.ownerPassword] - this allows owner to 'edit' file
  * @param {string} [options.userProtectionFlag] - encryption security level (see permissions)
- * @param {string|string[]} [options.fontSrcPath] - directory location(s) of additional fonts
  */
 class Recipe {
   constructor(src, output, options = {}) {

--- a/lib/Recipe.js
+++ b/lib/Recipe.js
@@ -16,6 +16,8 @@ const streams = require("memory-streams");
  * @param {string} [options.title] - The title
  * @param {string} [options.subject] - The subject
  * @param {string} [options.colorspace] - The default colorspace: rgb, cmyk, gray
+ * @param {string} [options.defaultFontSize=14] - The default font size
+ * @param {string} [options.defaultFontFamily=helvetica] - The default font: 'arial', 'courier new', 'georgia', 'helvetica', 'roboto'
  * @param {string[]} [options.keywords] - The array of keywords
  * @param {string} [options.password] - permission password
  * @param {string} [options.userPassword] - this 'view' password also enables encryption
@@ -34,7 +36,9 @@ class Recipe {
     this.encryptOptions = this._getEncryptOptions(options, this.isNewPDF);
     this.options = Object.assign({}, options, this.encryptOptions);
     this.current = {};
-    this.current.defaultFontSize = 14;
+    this.current.defaultFontSize = options.defaultFontSize ?? 14;
+    this.current.defaultFontFamily =
+      options.defaultFontFamily?.toLowerCase() ?? "helvetica";
 
     if (this.isBufferSrc) {
       this.outStream = new streams.WritableStream();
@@ -69,9 +73,14 @@ class Recipe {
 
     this._loadFonts(path.join(__dirname, "../fonts"));
 
-    if (options.fontSrcPath) {
-      this._loadFonts(options.fontSrcPath);
+    if (options.fontSrcPath) this._loadFonts(options.fontSrcPath);
+
+    if (!(this.current.defaultFontFamily in this.fonts)) {
+      throw `Cannot find font family '${this.current.defaultFontFamily}'`;
+    } else if (!this.fonts[this.current.defaultFontFamily]["r"]) {
+      throw `Default family '${this.current.defaultFontFamily}' must have a regular type, only found '${Object.keys(this.fonts[this.current.defaultFontFamily])}'`;
     }
+
     this._createWriter();
   }
 

--- a/lib/recipe/font.js
+++ b/lib/recipe/font.js
@@ -22,32 +22,38 @@ exports._loadFonts = function _loadFonts(fontSrcPath) {
   const fontPaths =
     typeof fontSrcPath === "string" ? [fontSrcPath] : fontSrcPath;
 
+  const registerFontFile = (file) => {
+    let fontName = path.basename(file, path.extname(file)).toLowerCase();
+    // simple heuristics to make sure library fonts behave as expected
+    const hasBold = fontName.indexOf("bold") !== -1;
+    const hasItalic = fontName.indexOf("italic") !== -1;
+    let type = "r";
+    if (hasBold && hasItalic) {
+      fontName = fontName.replace(/-*bold/, "");
+      fontName = fontName.replace(/-*italic/, "");
+      type = "bi";
+    } else if (hasBold) {
+      fontName = fontName.replace(/-*bold/, "");
+      type = "b";
+    } else if (hasItalic) {
+      fontName = fontName.replace(/-*italic/, "");
+      type = "i";
+    }
+    return this._registerFont(fontName, file, type);
+  };
+
   for (let fpath of fontPaths) {
-    if (fs.existsSync(fpath)) {
-      // only process when directory exists
+    if (!fs.existsSync(fpath)) throw `Cannot load font file '${fpath}'`;
+    if (fs.statSync(fpath).isFile()) {
+      if (!fontTypes.includes(path.extname(fpath).toLowerCase())) {
+        throw `Invalid font file '${fpath}', allowed extensions ${fontTypes}`;
+      }
+      registerFontFile(fpath);
+    } else {
       fs.readdirSync(fpath)
-        .filter((file) => {
-          return fontTypes.includes(path.extname(file).toLowerCase());
-        })
-        .forEach((file) => {
-          let fontName = path.basename(file, path.extname(file)).toLowerCase();
-          // simple heuristics to make sure library fonts behave as expected
-          const hasBold = fontName.indexOf("bold") !== -1;
-          const hasItalic = fontName.indexOf("italic") !== -1;
-          let type = "r";
-          if (hasBold && hasItalic) {
-            fontName = fontName.replace(/-*bold/, "");
-            fontName = fontName.replace(/-*italic/, "");
-            type = "bi";
-          } else if (hasBold) {
-            fontName = fontName.replace(/-*bold/, "");
-            type = "b";
-          } else if (hasItalic) {
-            fontName = fontName.replace(/-*italic/, "");
-            type = "i";
-          }
-          return this._registerFont(fontName, path.join(fpath, file), type);
-        });
+        .filter((file) => fontTypes.includes(path.extname(file).toLowerCase()))
+        .map((file) => path.join(fpath, file))
+        .forEach(registerFontFile);
     }
   }
 };
@@ -60,6 +66,10 @@ exports._registerFont = function _registerFont(
   this.fonts = this.fonts || {};
   let family = fontName.toLowerCase();
   let font = this.fonts[family] || {};
+
+  if (!fs.existsSync(fontSrcPath)) {
+    throw `Cannot load font file '${fontSrcPath}'`;
+  }
 
   switch (type) {
     default:
@@ -84,7 +94,8 @@ exports._registerFont = function _registerFont(
 };
 
 function _getFontFile(self, options = {}) {
-  let fontFile;
+  const font = options.font?.toLowerCase() ?? self.current.defaultFontFamily;
+
   // Need to choose appropriate file based on bold/italic considerations
   // Note, if this is not done explicitly, the font dimensions will be incorrect.
   let type =
@@ -96,22 +107,14 @@ function _getFontFile(self, options = {}) {
           ? "b"
           : "r";
 
-  if (options.font) {
-    const fontFamily = self.fonts[options.font.toLowerCase()];
-    if (fontFamily) {
-      fontFile = fontFamily[type];
-    }
-  }
-
-  // when file inaccessible ...
-  if (!fontFile || !fs.existsSync(fontFile)) {
-    fontFile = self.fonts["helvetica"][type]; // use default font when otherwise unavailable.
-  }
+  const fontFile =
+    self.fonts[font]?.[type] ??
+    self.fonts[self.current.defaultFontFamily][type] ??
+    self.fonts[self.current.defaultFontFamily]["r"];
 
   if (!fontFile) {
-    fontFile = self.fonts["helvetica"]["r"]; // use default font when otherwise unavailable.
+    throw `Unknown font-type pair '${font ?? self.current.defaultFontFamily}', '${type}'`;
   }
-
   return fontFile;
 }
 

--- a/lib/recipe/page.js
+++ b/lib/recipe/page.js
@@ -127,7 +127,7 @@ exports.editPage = function editPage(pageNumber) {
     const startX = mediaBox[0];
     const startY = mediaBox[1];
     const textOptions = {
-      font: this.writer.getFontForFile(this.fonts["helvetica-bold"]),
+      font: this._getFont({ bold: true }),
       size: 50,
       colorspace: "gray",
       color: 0x00,

--- a/muhammara.d.ts
+++ b/muhammara.d.ts
@@ -876,9 +876,15 @@ declare module "muhammara" {
       author?: string;
       title?: string;
       subject?: string;
-      colorspace?: 'rbg' | 'cmyk' | 'gray' | 'separation';
+      colorspace?: "rbg" | "cmyk" | "gray" | "separation";
       defaultFontSize?: number;
-      defaultFontFamily?: 'arial' | 'courier new' | 'georgia' | 'helvetica' | 'roboto' | string;
+      defaultFontFamily?:
+        | "arial"
+        | "courier new"
+        | "georgia"
+        | "helvetica"
+        | "roboto"
+        | string;
       fontSrcPath?: string;
       keywords?: string[];
     }

--- a/muhammara.d.ts
+++ b/muhammara.d.ts
@@ -336,14 +336,16 @@ declare module "muhammara" {
   export const eRangeTypeSpecific = 1;
   export type eRangeType = 0 | 1;
 
-  export interface PDFWriterOptions {
-    version?: EPDFVersion;
-    log?: string;
-    compress?: boolean;
-
+  export interface EncryptionOptions {
     userPassword?: string;
     ownerPassword?: string;
     userProtectionFlag?: number;
+  }
+
+  export interface PDFWriterOptions extends EncryptionOptions {
+    version?: EPDFVersion;
+    log?: string;
+    compress?: boolean;
   }
 
   type FormXObjectId = number;
@@ -869,11 +871,15 @@ declare module "muhammara" {
       | "Paragraph"
       | "Insert";
 
-    interface RecipeOptions {
+    interface RecipeOptions extends EncryptionOptions {
       version?: number;
       author?: string;
       title?: string;
       subject?: string;
+      colorspace?: 'rbg' | 'cmyk' | 'gray' | 'separation';
+      defaultFontSize?: number;
+      defaultFontFamily?: 'arial' | 'courier new' | 'georgia' | 'helvetica' | 'roboto' | string;
+      fontSrcPath?: string;
       keywords?: string[];
     }
 
@@ -1117,8 +1123,8 @@ declare module "muhammara" {
 
     text(
       text: string,
-      x: number,
-      y: number,
+      x?: number,
+      y?: number,
       options?: Recipe.TextOptions,
     ): Recipe;
 

--- a/tests/recipe/font.js
+++ b/tests/recipe/font.js
@@ -36,4 +36,20 @@ describe("Font", () => {
       .endPage()
       .endPDF(done);
   });
+
+  it("Override the default font family", (done) => {
+    const output = path.join(
+        __dirname,
+        "../output/Override the default font family.pdf",
+    );
+    const recipe = new HummusRecipe("new", output, {
+      defaultFontFamily: 'arial',
+      defaultFontSize: 20,
+    });
+    recipe
+        .createPage("letter")
+        .text("This is Arial", 0, 0)
+        .endPage()
+        .endPDF(done);
+  });
 });

--- a/tests/recipe/font.js
+++ b/tests/recipe/font.js
@@ -39,17 +39,17 @@ describe("Font", () => {
 
   it("Override the default font family", (done) => {
     const output = path.join(
-        __dirname,
-        "../output/Override the default font family.pdf",
+      __dirname,
+      "../output/Override the default font family.pdf",
     );
     const recipe = new HummusRecipe("new", output, {
-      defaultFontFamily: 'arial',
+      defaultFontFamily: "arial",
       defaultFontSize: 20,
     });
     recipe
-        .createPage("letter")
-        .text("This is Arial", 0, 0)
-        .endPage()
-        .endPDF(done);
+      .createPage("letter")
+      .text("This is Arial", 0, 0)
+      .endPage()
+      .endPDF(done);
   });
 });


### PR DESCRIPTION
Allow a user to override to default font family and font size.

- Validations are in place to ensure that the files exist and at most the font family supports at least the regular font type.

- Updates to the font loader to allow loading of a single file rather than a directory