### PR TITLE
ci: add support for linux arm64 glibc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-13, windows-2019]
+        os: [ubuntu-22.04, macos-13, windows-2022]
         architecture: [x64, ia32, arm64]
         electron:
           - 33.3.0
@@ -210,11 +210,11 @@ jobs:
         exclude:
           - os: macos-13
             architecture: ia32
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             architecture: arm64
-          - os: windows-2019
+          - os: windows-2022
             architecture: arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             architecture: ia32
     runs-on: ${{ matrix.os }}
     steps:
@@ -223,7 +223,7 @@ jobs:
         with:
           version: 11
           platform: ${{matrix.architecture}}
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
@@ -245,7 +245,7 @@ jobs:
       - run: npm install --build-from-source
         env:
           npm_config_arch: ${{ matrix.architecture }}
-          npm_config_msbuild_path: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe'
+          npm_config_msbuild_path: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe'
           npm_config_target_arch: ${{ matrix.target_architecture }}
           npm_config_target: ${{ matrix.electron }}
           npm_config_disturl: https://artifacts.electronjs.org/headers/dist
@@ -283,7 +283,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-13, windows-2019]
+        os: [ubuntu-22.04, macos-13, windows-2022]
         architecture: [x64, ia32, arm64]
         electron:
           - 28.0.0
@@ -405,11 +405,11 @@ jobs:
         exclude:
           - os: macos-13
             architecture: ia32
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             architecture: arm64
-          - os: windows-2019
+          - os: windows-2022
             architecture: arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             architecture: ia32
     runs-on: ${{ matrix.os }}
     steps:
@@ -419,7 +419,7 @@ jobs:
         with:
           version: 11
           platform: ${{matrix.architecture}}
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
@@ -440,7 +440,7 @@ jobs:
       - run: npm install --build-from-source
         env:
           npm_config_arch: ${{ matrix.architecture }}
-          npm_config_msbuild_path: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe'
+          npm_config_msbuild_path: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe'
           npm_config_target_arch: ${{ matrix.target_architecture }}
           npm_config_target: ${{ matrix.electron }}
           npm_config_disturl: https://artifacts.electronjs.org/headers/dist
@@ -475,7 +475,7 @@ jobs:
           if-no-files-found: error
   build-node-linux:
     needs: [lint]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: gcc:11-bullseye
       credentials:
@@ -514,7 +514,7 @@ jobs:
           npm_config_arch: ${{ matrix.architecture }}
           npm_config_target_arch: ${{ matrix.target_architecture }}
           npm_config_python: python${{ matrix.python_version }}
-          npm_config_msbuild_path: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe'
+          npm_config_msbuild_path: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe'
           CFLAGS: ${{ matrix.extra_compile_flags }}
           CPPFLAGS: ${{ matrix.extra_compile_flags }}
       - run: ./node_modules/.bin/node-pre-gyp package testpackage
@@ -528,7 +528,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, windows-2019]
+        os: [macos-13, windows-2022]
         node: [17.6.0, 18.8.0, 19.0.0, 20.0.0, 21.7.3, 22.9.0, 23.0.0]
         architecture: [x64, ia32, arm64]
         include:
@@ -545,11 +545,11 @@ jobs:
             extra_compile_flags: -arch arm64
             EXTRA_NODE_PRE_GYP_FLAGS: --target_arch=arm64
         exclude:
-          - os: windows-2019
+          - os: windows-2022
             architecture: arm64
           - os: macos-13
             architecture: ia32
-          - os: windows-2019
+          - os: windows-2022
             architecture: ia32
             node: 23.0.0
     runs-on: ${{ matrix.os }}
@@ -577,7 +577,7 @@ jobs:
           npm_config_arch: ${{ matrix.architecture }}
           npm_config_target_arch: ${{ matrix.target_architecture }}
           npm_config_python: python${{ matrix.python_version }}
-          npm_config_msbuild_path: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe'
+          npm_config_msbuild_path: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe'
           CFLAGS: ${{ matrix.extra_compile_flags }}
           CPPFLAGS: ${{ matrix.extra_compile_flags }}
       - run: ./node_modules/.bin/node-pre-gyp package testpackage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -514,7 +514,6 @@ jobs:
           npm_config_arch: ${{ matrix.architecture }}
           npm_config_target_arch: ${{ matrix.target_architecture }}
           npm_config_python: python${{ matrix.python_version }}
-          npm_config_msbuild_path: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe'
           CFLAGS: ${{ matrix.extra_compile_flags }}
           CPPFLAGS: ${{ matrix.extra_compile_flags }}
       - run: ./node_modules/.bin/node-pre-gyp package testpackage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -487,14 +487,10 @@ jobs:
         node: [17.6.0, 18.8.0, 19.0.0, 20.0.0, 21.7.3, 22.9.0, 23.0.0]
         include:
           - architecture: x64
-            python_version: "3.10"
             architecture_node: x64
             target_architecture: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python_version }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
@@ -513,7 +509,6 @@ jobs:
         env:
           npm_config_arch: ${{ matrix.architecture }}
           npm_config_target_arch: ${{ matrix.target_architecture }}
-          npm_config_python: python${{ matrix.python_version }}
           CFLAGS: ${{ matrix.extra_compile_flags }}
           CPPFLAGS: ${{ matrix.extra_compile_flags }}
       - run: ./node_modules/.bin/node-pre-gyp package testpackage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -475,20 +475,27 @@ jobs:
           if-no-files-found: error
   build-node-linux:
     needs: [lint]
-    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
+        node: [17.6.0, 18.8.0, 19.0.0, 20.0.0, 21.7.3, 22.9.0, 23.0.0]
+        include:
+          - os: ubuntu-22.04
+            architecture: x64
+            architecture_node: x64
+            target_architecture: x64
+          - os: ubuntu-22.04-arm
+            architecture: arm64
+            architecture_node: arm64
+            target_architecture: arm64
+            extra_compile_flags: -march=armv8-a
+    runs-on: ${{ matrix.os }}
     container:
       image: gcc:11-bullseye
       credentials:
         username: "${{ secrets.DOCKER_USERNAME }}"
         password: "${{ secrets.DOCKER_PASSWORD }}"
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [17.6.0, 18.8.0, 19.0.0, 20.0.0, 21.7.3, 22.9.0, 23.0.0]
-        include:
-          - architecture: x64
-            architecture_node: x64
-            target_architecture: x64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/lib/recipe/vector-polygon.js
+++ b/lib/recipe/vector-polygon.js
@@ -101,7 +101,7 @@ exports.polygon = function polygon(coordinates = [], options = {}) {
       height,
       pathOptions,
       (ctx, xObject) => {
-        ctx.gs(xObject.getGsName(pathOptions.fillGsId)), setPathOptions(ctx);
+        (ctx.gs(xObject.getGsName(pathOptions.fillGsId)), setPathOptions(ctx));
         xObject.fill(colorModel);
         drawPolygon(ctx, coordinates);
         ctx.f();


### PR DESCRIPTION
- Updated windows and ubuntu runners to oldest supported versions (`windows-2022` & `ubuntu-22.04`)
- Fix linux ci by using builtin python version
- Compile for linux arm64 with glibc using `ubuntu-22.04-arm`

Fixes #453