### PR TITLE
Fix improper addition of document context extender instead of removal

### DIFF
--- a/src/PDFWriterDriver.cpp
+++ b/src/PDFWriterDriver.cpp
@@ -141,7 +141,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::End(const ARGS_TYPE& args)
         status = pdfWriter->mPDFWriter.EndPDF();
 
     // now remove event listener
-    pdfWriter->mPDFWriter.GetDocumentContext().AddDocumentContextExtender(pdfWriter);
+    pdfWriter->mPDFWriter.GetDocumentContext().RemoveDocumentContextExtender(pdfWriter);
 
 
     if(status != PDFHummus::eSuccess)


### PR DESCRIPTION
Changed `PDFWriterDriver::End` in `src/PDFWriterDriver.cpp` to remove the document context extender during cleanup instead of incorrectly adding it.