### PR TITLE
Add PDFWriter.reset() to release internal resources

### DIFF
--- a/muhammara.d.ts
+++ b/muhammara.d.ts
@@ -709,6 +709,12 @@ declare module "muhammara" {
 
   export interface PDFWriter {
     end(): PDFWriter;
+    /**
+     * Explicitly releases all internal resources held by the PDFWriter.
+     * Call this after end() to immediately free memory without waiting for garbage collection.
+     * Useful in high-throughput scenarios where many PDFs are processed in a loop.
+     */
+    reset(): PDFWriter;
     createPage(x: PosX, y: PosY, width: Width, height: Height): PDFPage;
     createPage(): PDFPage;
     writePage(page: PDFPage): this;

--- a/src/PDFWriterDriver.cpp
+++ b/src/PDFWriterDriver.cpp
@@ -105,6 +105,7 @@ DEF_SUBORDINATE_INIT(PDFWriterDriver::Init)
 	SET_PROTOTYPE_METHOD(t, "getOutputFile", GetOutputFile);
 	SET_PROTOTYPE_METHOD(t, "registerAnnotationReferenceForNextPageWrite", RegisterAnnotationReferenceForNextPageWrite);
     SET_PROTOTYPE_METHOD(t, "requireCatalogUpdate", RequireCatalogUpdate);
+    SET_PROTOTYPE_METHOD(t, "reset", Reset);
     SET_CONSTRUCTOR_EXPORT("PDFWriter", t);
 
     // save in factory
@@ -141,7 +142,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::End(const ARGS_TYPE& args)
         status = pdfWriter->mPDFWriter.EndPDF();
 
     // now remove event listener
-    pdfWriter->mPDFWriter.GetDocumentContext().AddDocumentContextExtender(pdfWriter);
+    pdfWriter->mPDFWriter.GetDocumentContext().RemoveDocumentContextExtender(pdfWriter);
 
 
     if(status != PDFHummus::eSuccess)
@@ -1697,4 +1698,37 @@ PDFHummus::EStatusCode PDFWriterDriver::setupListenerIfOK(PDFHummus::EStatusCode
     if(inCode == PDFHummus::eSuccess)
         mPDFWriter.GetDocumentContext().AddDocumentContextExtender(this);
     return inCode;
+}
+
+METHOD_RETURN_TYPE PDFWriterDriver::Reset(const ARGS_TYPE& args)
+{
+    CREATE_ISOLATE_CONTEXT;
+    CREATE_ESCAPABLE_SCOPE;
+
+    PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
+
+    // Remove event listener if registered
+    pdfWriter->mPDFWriter.GetDocumentContext().RemoveDocumentContextExtender(pdfWriter);
+
+    // Call Reset on the underlying PDFWriter to release all internal resources
+    pdfWriter->mPDFWriter.Reset();
+
+    // Clean up stream proxies
+    if(pdfWriter->mWriteStreamProxy)
+    {
+        delete pdfWriter->mWriteStreamProxy;
+        pdfWriter->mWriteStreamProxy = NULL;
+    }
+
+    if(pdfWriter->mReadStreamProxy)
+    {
+        delete pdfWriter->mReadStreamProxy;
+        pdfWriter->mReadStreamProxy = NULL;
+    }
+
+    // Reset state flags
+    pdfWriter->mStartedWithStream = false;
+    pdfWriter->mIsCatalogUpdateRequired = false;
+
+    SET_FUNCTION_RETURN_VALUE(args.This())
 }

--- a/src/PDFWriterDriver.h
+++ b/src/PDFWriterDriver.h
@@ -219,6 +219,7 @@ private:
     static METHOD_RETURN_TYPE GetDocumentContext(const ARGS_TYPE& args);
     static METHOD_RETURN_TYPE RegisterAnnotationReferenceForNextPageWrite(const ARGS_TYPE& args);
 	static METHOD_RETURN_TYPE RequireCatalogUpdate(const ARGS_TYPE& args);
+    static METHOD_RETURN_TYPE Reset(const ARGS_TYPE& args);
     
     static CMYKRGBColor colorFromArray(v8::Local<v8::Value> inArray);
     static PDFPageRange ObjectToPageRange(v8::Local<v8::Object> inObject);


### PR DESCRIPTION
Introduces a reset() method to the PDFWriter interface and implementation, allowing explicit release of internal resources and memory after PDF processing. This is useful for high-throughput scenarios to avoid waiting for garbage collection. Also fixes event listener removal in End(). (featured in https://github.com/julianhille/MuhammaraJS/pull/473)

In the current implementation of MuhammaraJS, regular usage of the PDF writer for different files or threads ends up with persistent memory usage/leak. A reset flag would be useful to indicate a direct release of the object in memory.
This pull request adds a new `reset` method to the `PDFWriterDriver` class and ensures proper cleanup of resources and event listeners, improving the reliability and usability of the PDF writer interface. The most important changes are grouped below:

### API Additions (Copilot)

* Added a new `reset` method to the `PDFWriterDriver` class, exposing it to the API and registering it with the prototype so it can be called from JavaScript. This method allows users to reset the PDF writer and release resources. [[1]](diffhunk://#diff-20b9e8211c134bdba0fbe3d9fbc489cb8b081c1286a2079bbc2d90e85ae9f953R108) [[2]](diffhunk://#diff-83f299dba0ae27d4e1cc49633c189c9b7b943c44c353bd7a5d2977c8972263baR222)
* Implemented the `Reset` method in `PDFWriterDriver.cpp`, which removes the document context extender, calls `Reset` on the underlying `PDFWriter`, cleans up stream proxies, and resets internal state flags.

### Resource and Event Listener Management

* Fixed a bug in the `End` method by removing the document context extender when ending a PDF document, instead of incorrectly adding it. This prevents resource leaks and ensures listeners are properly managed.