### PR TITLE
fix: prevent crash when endPDF is called twice

### DIFF
--- a/lib/Recipe.js
+++ b/lib/Recipe.js
@@ -65,6 +65,8 @@ class Recipe {
 
     this.needToInsertPages = false;
 
+    this._pdfEnded = false;
+
     this._setParameters(options);
 
     this._loadFonts(path.join(__dirname, "../fonts"));
@@ -216,6 +218,10 @@ class Recipe {
    * @param {function} callback - The callback function.
    */
   endPDF(callback) {
+    if (this._pdfEnded) {
+      throw new Error("endPDF has already been called");
+    }
+    this._pdfEnded = true;
     this._writeInfo();
     this.writer.end();
     // This is a temporary work around for copying context will overwrite the current one

--- a/tests/recipe/endPDF-twice.js
+++ b/tests/recipe/endPDF-twice.js
@@ -1,0 +1,18 @@
+const path = require("path");
+const { expect } = require("chai");
+const HummusRecipe = require("../../lib").Recipe;
+
+describe("endPDF called twice", () => {
+  it("should fail when endPDF is called twice", (done) => {
+    const output = path.join(__dirname, "../output/endPDF-twice.pdf");
+    const recipe = new HummusRecipe("new", output);
+
+    recipe.createPage("letter").endPage().endPDF();
+
+    expect(() => {
+      recipe.endPDF();
+    }).to.throw();
+
+    done();
+  });
+});


### PR DESCRIPTION
## Summary
- Add guard to prevent calling `endPDF()` multiple times on a Recipe instance
- Throws a descriptive error instead of causing a segmentation fault
- Add test to verify the behavior

## Test plan
- [x] Run `npm test` - all 172 tests pass
- [x] New test `tests/recipe/endPDF-twice.js` verifies error is thrown on second call