### PR TITLE
fix: Add missing type definitions and fix incorrect signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Set version of setup-node action to v6
 - Set version of checkout action to v6
 - Set versoin of cache action to v5
+- Add missing type definitions for PDFReader methods and PDFObjectParser interface [#479](https://github.com/julianhille/MuhammaraJS/issues/479)
 
 ### Fixed
 
 - Update macOS runner from macos-13 to macos-14
+- Fix DictionaryContext.writeKey() signature to include required key parameter [#479](https://github.com/julianhille/MuhammaraJS/issues/479)
 - Memory leak, by improper addition of document context extender instead of removal
 
 ### Removed

--- a/muhammara.d.ts
+++ b/muhammara.d.ts
@@ -441,7 +441,16 @@ declare module "muhammara" {
     getXrefSize(): number;
     getXrefPosition(objectId: number): number;
     startReadingFromStream(inputStream: PDFStreamInput): ByteReader;
+    startReadingFromStreamForPlainCopying(
+      inputStream: PDFStreamInput,
+    ): ByteReader;
+    startReadingObjectsFromStream(stream: PDFStreamInput): PDFObjectParser;
+    startReadingObjectsFromStreams(streams: PDFArray): PDFObjectParser;
     getParserStream(): ByteReaderWithPosition;
+  }
+
+  export interface PDFObjectParser {
+    parseNewObject(): PDFObject | undefined;
   }
 
   export interface PDFStream {

--- a/muhammara.d.ts
+++ b/muhammara.d.ts
@@ -576,7 +576,7 @@ declare module "muhammara" {
   }
 
   export interface DictionaryContext {
-    writeKey(): DictionaryContext;
+    writeKey(key: string): DictionaryContext;
     writeNameValue(nameValue: string): this;
     writeRectangleValue(values: Array<number>): this;
     writeRectangleValue(a: number, b: number, c: number, d: number): this;


### PR DESCRIPTION
fixes: #479

- Add missing `PDFObjectParser` interface with `parseNewObject()` method
- Add missing `PDFReader` methods:
  - `startReadingFromStreamForPlainCopying()`
  - `startReadingObjectsFromStream()`
  - `startReadingObjectsFromStreams()`
- Fix `DictionaryContext.writeKey()` signature to include required `key: string` parameter