### PR TITLE
Add readme note regarding installing on pnpm 10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ npm install muhammara
 
 ```
 
+> Note: If you are using pnpm 10 or above, lifecycle scripts of dependencies are not
+> executed during installation by default. This means that MuhammaraJS will be unable to
+> build its native code modules. To fix this, you must add `muhammara` to
+> `pnpm.onlyBuiltDependencies` in the `package.json`, or use `pnpm approve-builds` and
+> select `muhammara` as a dependency approved to run lifecycle scripts.
+
 # Replace hummusJS with MuhammaraJS for hummus
 
 Replace:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npm install muhammara
 ```
 
 > Note: If you are using pnpm 10 or above, lifecycle scripts of dependencies are not
-> executed during installation by default. This means that MuhammaraJS will be unable to
+> executed during installation by default (see the [pnpm 10 discussion post](https://github.com/orgs/pnpm/discussions/8945#discussion-7793415)). This means that MuhammaraJS will be unable to
 > build its native code modules. To fix this, you must add `muhammara` to
 > `pnpm.onlyBuiltDependencies` in the `package.json`, or use `pnpm approve-builds` and
 > select `muhammara` as a dependency approved to run lifecycle scripts.


### PR DESCRIPTION
Closes  #448.

From pnpm 10 and onward, lifecycle scripts are no longer run by default. MuhammaraJS uses these scripts to build native dependencies, so an extra step must be taken to install `muhammara` on pnpm 10+. This commit clarifies that in the readme, in the installation section.