### PR TITLE
Release 6.0.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.node_version }}
-      - run: npm install prettier@^3.3.3
+      - run: npm ci --ignore-scripts
       - run: npm run test:codestyle
   build-musl-arm:
     needs: [lint]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update brace-expansion to 2.1.4 for security vulnerability fixes.
 - Update diff to 5.2.2 for security vulnerability fixes.
 - Update js-yaml to 4.3.1 for security vulnerability fixes.
+- Update linkify-it to 5.0.2 for security vulnerability fixes.
 
 ## [6.0.5] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update lodash to 4.18.1 for security vulnerability fixes.
 - Update markdown-it to 14.3.0 for security vulnerability fixes.
 - Update picomatch to 2.3.2 for security vulnerability fixes.
+- Update underscore to 1.13.8 for security vulnerability fixes.
 
 ## [6.0.5] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use the lockfile's Prettier version in the CI lint job.
 - Update brace-expansion to 2.1.4 for security vulnerability fixes.
 - Update diff to 5.2.2 for security vulnerability fixes.
+- Update js-yaml to 4.3.1 for security vulnerability fixes.
 
 ## [6.0.5] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update js-yaml to 4.3.1 for security vulnerability fixes.
 - Update linkify-it to 5.0.2 for security vulnerability fixes.
 - Update lodash to 4.18.1 for security vulnerability fixes.
+- Update markdown-it to 14.3.0 for security vulnerability fixes.
 
 ## [6.0.5] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update markdown-it to 14.3.0 for security vulnerability fixes.
 - Update picomatch to 2.3.2 for security vulnerability fixes.
 - Update underscore to 1.13.8 for security vulnerability fixes.
+- Default missing Crypt filter parameters to Identity to fix GHSA-ch7g-v45m-q27g and GHSA-7xrh-8x56-r797.
 
 ## [6.0.5] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update the tar override to 7.5.22 for security vulnerability fixes.
 - Use the lockfile's Prettier version in the CI lint job.
 - Update brace-expansion to 2.1.4 for security vulnerability fixes.
+- Update diff to 5.2.2 for security vulnerability fixes.
 
 ## [6.0.5] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update diff to 5.2.2 for security vulnerability fixes.
 - Update js-yaml to 4.3.1 for security vulnerability fixes.
 - Update linkify-it to 5.0.2 for security vulnerability fixes.
+- Update lodash to 4.18.1 for security vulnerability fixes.
 
 ## [6.0.5] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update linkify-it to 5.0.2 for security vulnerability fixes.
 - Update lodash to 4.18.1 for security vulnerability fixes.
 - Update markdown-it to 14.3.0 for security vulnerability fixes.
+- Update picomatch to 2.3.2 for security vulnerability fixes.
 
 ## [6.0.5] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Update the tar override to 7.5.22 for security vulnerability fixes.
 - Use the lockfile's Prettier version in the CI lint job.
+- Update brace-expansion to 2.1.4 for security vulnerability fixes.
 
 ## [6.0.5] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [6.0.4] - 2026-02-25
-
-### Fixed
-
-- Raise node-tar override to 7.5.9 for the recurring security vulnerability fix.
-
-## [6.0.4] - 2026-05-21
+## [6.0.5] - 2026-05-21
 
 ### Fixed
 
@@ -21,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update node-tar to 7.5.15 to address cve issue
 - Update minimatch to 9.0.9 to address cve issue
 - Fix GHSA-fhp4-pr5j-46m5 DOS issue in PDF Writer
+
+## [6.0.4] - 2026-02-25
+
+### Fixed
+
+- Raise node-tar override to 7.5.9 for the recurring security vulnerability fix.
 
 ## [6.0.3] - 2026-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.0.6] - 2026-08-22
+
+### Fixed
+
+- Update the tar override to 7.5.22 for security vulnerability fixes.
+- Use the lockfile's Prettier version in the CI lint job.
+
 ## [6.0.5] - 2026-05-21
 
 ### Fixed
@@ -545,7 +552,8 @@ with the following changes.
 
 - Initial release
 
-:[unreleased]: https://github.com/julianhille/MuhammaraJS/compare/6.0.5...HEAD
+[unreleased]: https://github.com/julianhille/MuhammaraJS/compare/6.0.6...HEAD
+[6.0.6]: https://github.com/julianhille/MuhammaraJS/compare/6.0.5...6.0.6
 [6.0.5]: https://github.com/julianhille/MuhammaraJS/compare/6.0.4...6.0.5
 [6.0.4]: https://github.com/julianhille/MuhammaraJS/compare/6.0.3...6.0.4
 [6.0.3]: https://github.com/julianhille/MuhammaraJS/compare/6.0.2...6.0.3

--- a/lib/recipe/vector-polygon.js
+++ b/lib/recipe/vector-polygon.js
@@ -101,7 +101,7 @@ exports.polygon = function polygon(coordinates = [], options = {}) {
       height,
       pathOptions,
       (ctx, xObject) => {
-        (ctx.gs(xObject.getGsName(pathOptions.fillGsId)), setPathOptions(ctx));
+        ctx.gs(xObject.getGsName(pathOptions.fillGsId)), setPathOptions(ctx);
         xObject.fill(colorModel);
         drawPolygon(ctx, coordinates);
         ctx.f();

--- a/package-lock.json
+++ b/package-lock.json
@@ -889,10 +889,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -985,10 +985,20 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1622,9 +1622,9 @@
       "license": "MIT"
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -299,9 +299,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1021,9 +1021,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muhammara",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muhammara",
-      "version": "6.0.5",
+      "version": "6.0.6",
       "bundleDependencies": [
         "@mapbox/node-pre-gyp"
       ],
@@ -1522,9 +1522,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1351,9 +1351,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1055,16 +1055,26 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muhammara",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "Create, read and modify PDF files and streams. A drop in replacement for hummusjs PDF library",
   "homepage": "https://github.com/julianhille/Muhammarajs",
   "license": "Apache-2.0",
@@ -52,7 +52,7 @@
     "jsdoc": "^4.0.3"
   },
   "overrides": {
-    "tar": ">=7.5.14"
+    "tar": "7.5.22"
   },
   "binary": {
     "module_name": "muhammara",

--- a/src/deps/PDFWriter/PDFParser.cpp
+++ b/src/deps/PDFWriter/PDFParser.cpp
@@ -2137,9 +2137,15 @@ EStatusCodeAndIByteReader PDFParser::CreateFilterForStream(IByteReader* inStream
 #endif
 		else if (inFilterName->GetValue() == "Crypt")
 		{
-			PDFObjectCastPtr<PDFName> cryptFilterName(QueryDictionaryObject(inDecodeParams, "Name"));
+			std::string cryptFilterName = "Identity";
+			if (inDecodeParams)
+			{
+				PDFObjectCastPtr<PDFName> cryptFilterNameObject(QueryDictionaryObject(inDecodeParams, "Name"));
+				if (cryptFilterNameObject.GetPtr())
+					cryptFilterName = cryptFilterNameObject->GetValue();
+			}
 
-			result = mDecryptionHelper.CreateDecryptionFilterForStream(inPDFStream, inStream, cryptFilterName->GetValue());
+			result = mDecryptionHelper.CreateDecryptionFilterForStream(inPDFStream, inStream, cryptFilterName);
 		}
 		else if(mParserExtender)
 		{
@@ -2306,7 +2312,6 @@ IByteReaderWithPosition* PDFParser::GetParserStream()
 {
     return &mStream;
 }
-
 
 
 

--- a/tests/security/GHSA-7xrh-8x56-r797.js
+++ b/tests/security/GHSA-7xrh-8x56-r797.js
@@ -1,0 +1,65 @@
+var assert = require("assert");
+var fs = require("fs");
+var muhammara = require("../../lib/muhammara");
+
+function buildCryptPDF() {
+  var payload = Buffer.from([0]);
+  var header = "%PDF-1.4\n";
+  var objects = [
+    "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+    "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+    "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>\nendobj\n",
+  ];
+  var streamHeader = `4 0 obj\n<< /Filter /Crypt /DecodeParms << >> /Length ${payload.length} >>\nstream\n`;
+  var streamTail = "\nendstream\nendobj\n";
+  var offsets = [];
+  var position = header.length;
+
+  objects.forEach(function (object) {
+    offsets.push(position);
+    position += object.length;
+  });
+  offsets.push(position);
+
+  var xrefPosition =
+    position + streamHeader.length + payload.length + streamTail.length;
+  var formatOffset = function (offset) {
+    return String(offset).padStart(10, "0");
+  };
+  var xref =
+    "xref\n0 5\n0000000000 65535 f \n" +
+    `${formatOffset(offsets[0])} 00000 n \n` +
+    `${formatOffset(offsets[1])} 00000 n \n` +
+    `${formatOffset(offsets[2])} 00000 n \n` +
+    `${formatOffset(offsets[3])} 00000 n \n`;
+  var trailer = `trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n${xrefPosition}\n%%EOF`;
+
+  return Buffer.concat([
+    Buffer.from(header),
+    ...objects.map(function (object) {
+      return Buffer.from(object);
+    }),
+    Buffer.from(streamHeader),
+    payload,
+    Buffer.from(streamTail),
+    Buffer.from(xref),
+    Buffer.from(trailer),
+  ]);
+}
+
+describe("GHSA-7xrh-8x56-r797", function () {
+  it("does not crash for a Crypt stream without a Name parameter", function () {
+    var target = __dirname + "/../output/ghsa-7xrh-8x56-r797.pdf";
+    fs.writeFileSync(target, buildCryptPDF());
+
+    try {
+      var reader = muhammara.createReader(target);
+      var stream = reader.parseNewObject(4);
+      assert.doesNotThrow(function () {
+        reader.startReadingFromStream(stream);
+      });
+    } finally {
+      fs.unlinkSync(target);
+    }
+  });
+});

--- a/tests/security/GHSA-ch7g-v45m-q27g.js
+++ b/tests/security/GHSA-ch7g-v45m-q27g.js
@@ -1,0 +1,65 @@
+var assert = require("assert");
+var fs = require("fs");
+var muhammara = require("../../lib/muhammara");
+
+function buildCryptPDF() {
+  var payload = Buffer.from([0]);
+  var header = "%PDF-1.4\n";
+  var objects = [
+    "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+    "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+    "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>\nendobj\n",
+  ];
+  var streamHeader = `4 0 obj\n<< /Filter /Crypt /Length ${payload.length} >>\nstream\n`;
+  var streamTail = "\nendstream\nendobj\n";
+  var offsets = [];
+  var position = header.length;
+
+  objects.forEach(function (object) {
+    offsets.push(position);
+    position += object.length;
+  });
+  offsets.push(position);
+
+  var xrefPosition =
+    position + streamHeader.length + payload.length + streamTail.length;
+  var formatOffset = function (offset) {
+    return String(offset).padStart(10, "0");
+  };
+  var xref =
+    "xref\n0 5\n0000000000 65535 f \n" +
+    `${formatOffset(offsets[0])} 00000 n \n` +
+    `${formatOffset(offsets[1])} 00000 n \n` +
+    `${formatOffset(offsets[2])} 00000 n \n` +
+    `${formatOffset(offsets[3])} 00000 n \n`;
+  var trailer = `trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n${xrefPosition}\n%%EOF`;
+
+  return Buffer.concat([
+    Buffer.from(header),
+    ...objects.map(function (object) {
+      return Buffer.from(object);
+    }),
+    Buffer.from(streamHeader),
+    payload,
+    Buffer.from(streamTail),
+    Buffer.from(xref),
+    Buffer.from(trailer),
+  ]);
+}
+
+describe("GHSA-ch7g-v45m-q27g", function () {
+  it("does not crash for a Crypt stream without DecodeParms", function () {
+    var target = __dirname + "/../output/ghsa-ch7g-v45m-q27g.pdf";
+    fs.writeFileSync(target, buildCryptPDF());
+
+    try {
+      var reader = muhammara.createReader(target);
+      var stream = reader.parseNewObject(4);
+      assert.doesNotThrow(function () {
+        reader.startReadingFromStream(stream);
+      });
+    } finally {
+      fs.unlinkSync(target);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- update the tar override to 7.5.22
- correct release changelog entries and add 6.0.6 release information
- use the lockfile's Prettier version in the lint job

## Verification
- npm test
- npm run test:codestyle

Closes #520