### PR TITLE
Fix JS stream reader buffer overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix DictionaryContext.writeKey() signature to include required key parameter [#479](https://github.com/julianhille/MuhammaraJS/issues/479)
 - Memory leak, by improper addition of document context extender instead of removal
 - Update dependencies
+- Prevent JS stream readers from overflowing native buffers [#518](https://github.com/julianhille/MuhammaraJS/issues/518)
 
 ### Removed
 

--- a/src/ObjectByteReader.cpp
+++ b/src/ObjectByteReader.cpp
@@ -53,8 +53,10 @@ IOBasicTypes::LongBufferSizeType ObjectByteReader::Read(IOBasicTypes::Byte* inBu
         return 0;
     
     IOBasicTypes::LongBufferSizeType bufferLength = result->TO_OBJECT()->Get(GET_CURRENT_CONTEXT, v8::NEW_STRING("length")).ToLocalChecked()->TO_UINT32Value();
+    if(bufferLength > inBufferSize)
+        bufferLength = inBufferSize;
     for(IOBasicTypes::LongBufferSizeType i=0;i < bufferLength;++i)
-        inBuffer[i] = (IOBasicTypes::Byte)(TO_UINT32(value->TO_OBJECT()->Get(GET_CURRENT_CONTEXT, (uint32_t)i).ToLocalChecked())->Value());
+        inBuffer[i] = (IOBasicTypes::Byte)(TO_UINT32(result->TO_OBJECT()->Get(GET_CURRENT_CONTEXT, (uint32_t)i).ToLocalChecked())->Value());
     
     return bufferLength;
 }

--- a/src/ObjectByteReaderWithPosition.cpp
+++ b/src/ObjectByteReaderWithPosition.cpp
@@ -52,6 +52,8 @@ IOBasicTypes::LongBufferSizeType ObjectByteReaderWithPosition::Read(IOBasicTypes
         return 0;
     
     IOBasicTypes::LongBufferSizeType bufferLength = result->TO_OBJECT()->Get(GET_CURRENT_CONTEXT, NEW_STRING("length")).ToLocalChecked()->TO_UINT32Value();
+    if(bufferLength > inBufferSize)
+        bufferLength = inBufferSize;
     for(IOBasicTypes::LongBufferSizeType i=0;i < bufferLength;++i)
         inBuffer[i] = (IOBasicTypes::Byte)(TO_UINT32(result->TO_OBJECT()->Get(GET_CURRENT_CONTEXT, (uint32_t)i).ToLocalChecked())->Value());
     

--- a/tests/security/GH-518.js
+++ b/tests/security/GH-518.js
@@ -1,0 +1,57 @@
+var assert = require("assert");
+var fs = require("fs");
+var muhammara = require("../../lib/muhammara");
+
+function OversizedReadStream(buffer) {
+  this.buffer = buffer;
+  this.position = 0;
+}
+
+OversizedReadStream.prototype.read = function (amount) {
+  var result = Array.from(
+    this.buffer.subarray(this.position, this.position + amount),
+  );
+  this.position += amount;
+  if (result.length === amount) {
+    this.returnedOversizedRead = true;
+  }
+  result.push(0x41);
+  return result;
+};
+
+OversizedReadStream.prototype.notEnded = function () {
+  return this.position < this.buffer.length;
+};
+
+OversizedReadStream.prototype.setPosition = function (position) {
+  this.position = position;
+};
+
+OversizedReadStream.prototype.setPositionFromEnd = function (position) {
+  this.position = position;
+};
+
+OversizedReadStream.prototype.skip = function (amount) {
+  this.position += amount;
+};
+
+OversizedReadStream.prototype.getCurrentPosition = function () {
+  return this.position;
+};
+
+OversizedReadStream.prototype.moveStartPosition = function (position) {
+  this.position = position;
+};
+
+describe("GH-518", function () {
+  it("does not write past the native buffer for oversized stream reads", function () {
+    var source = fs.readFileSync(
+      __dirname + "/../TestMaterials/XObjectContent.PDF",
+    );
+    var stream = new OversizedReadStream(source);
+    assert.throws(function () {
+      muhammara.createReader(stream);
+    }, /Unable to start parsing PDF file/);
+    assert.strictEqual(stream.returnedOversizedRead, true);
+  });
+});


### PR DESCRIPTION
## Summary

- bound JS stream reads to the capacity of native buffers
- correct the legacy byte reader to consume the returned array
- add regression coverage for oversized read responses

## Testing

- npm test
- npm run test:codestyle

Fixes #518