### PR TITLE
Add content context opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Set version of checkout action to v6
 - Set versoin of cache action to v5
 - Add missing type definitions for PDFReader methods and PDFObjectParser interface [#479](https://github.com/julianhille/MuhammaraJS/issues/479)
+- Add context opacity support for transparent text [#496](https://github.com/julianhille/MuhammaraJS/issues/496)
 
 ### Fixed
 

--- a/docs/Show-text.md
+++ b/docs/Show-text.md
@@ -35,6 +35,16 @@ var textOptions = {
 cxt.writeText("Paths", 75, 805, textOptions);
 ```
 
+## Transparency
+
+Use `setOpacity` to apply fill and stroke opacity to the current graphics state. Opacity is a value from `0` (fully transparent) to `1` (fully opaque). Save and restore the graphics state with `q` and `Q` to limit the effect to a specific text operation:
+
+```javascript
+cxt.q().setOpacity(0.5).writeText("Watermark", 100, 500, textOptions).Q();
+```
+
+Opacity is not part of the `color` value. The color value contains only RGB, CMYK, or gray components.
+
 `getFontForFile` simply receives a path to a file for a font. Hummus supports ttf,otf,pfb/pfm,dfont and ttc.
 for type 1 (pfb/pfm), pass two paths. first the pfb, then the other one (pfm, normally).
 dfont and ttc are font collections, so you can pass a 2nd parameter that will be the font index (if not, it'll take the first font in the colletion).

--- a/muhammara.d.ts
+++ b/muhammara.d.ts
@@ -181,6 +181,7 @@ declare module "muhammara" {
     ri(renderingIntentName: string): this;
     i(flatness: number): this;
     gs(graphicStateName: string): this;
+    setOpacity(opacity: number): this;
     CS(colorSpaceName: string): this;
     cs(colorSpaceName: string): this;
     SC(...colorComponents: number[]): this;

--- a/src/AbstractContentContextDriver.cpp
+++ b/src/AbstractContentContextDriver.cpp
@@ -123,6 +123,7 @@ void AbstractContentContextDriver::Init(Local<FunctionTemplate>& ioDriverTemplat
 	SET_PROTOTYPE_METHOD(ioDriverTemplate, "ri", ri);
 	SET_PROTOTYPE_METHOD(ioDriverTemplate, "i", i);
 	SET_PROTOTYPE_METHOD(ioDriverTemplate, "gs", gs);
+	SET_PROTOTYPE_METHOD(ioDriverTemplate, "setOpacity", SetOpacity);
 	SET_PROTOTYPE_METHOD(ioDriverTemplate, "CS", CS);
 	SET_PROTOTYPE_METHOD(ioDriverTemplate, "cs", cs);
 	SET_PROTOTYPE_METHOD(ioDriverTemplate, "SC", SC);
@@ -726,6 +727,30 @@ METHOD_RETURN_TYPE AbstractContentContextDriver::gs(const ARGS_TYPE& args)
     
     contentContext->GetContext()->gs(*UTF_8_VALUE(args[0]->TO_STRING()));
     
+    SET_FUNCTION_RETURN_VALUE(args.This())
+}
+
+METHOD_RETURN_TYPE AbstractContentContextDriver::SetOpacity(const ARGS_TYPE& args)
+{
+	CREATE_ISOLATE_CONTEXT;
+	CREATE_ESCAPABLE_SCOPE;
+
+    AbstractContentContextDriver* contentContext = ObjectWrap::Unwrap<AbstractContentContextDriver>(args.This());
+    if(!contentContext->GetContext())
+    {
+        THROW_EXCEPTION("Null content context. Please create a context using pdfWriter.startPageContentContext(page)");
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+
+    double opacity = args.Length() == 1 && args[0]->IsNumber() ? TO_NUMBER(args[0])->Value() : -1;
+    if(opacity < 0 || opacity > 1 || opacity != opacity)
+    {
+        THROW_EXCEPTION("Wrong Argument, please provide 1 opacity value between 0 and 1");
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+
+    contentContext->GetContext()->SetOpacity(opacity);
+
     SET_FUNCTION_RETURN_VALUE(args.This())
 }
 

--- a/src/AbstractContentContextDriver.h
+++ b/src/AbstractContentContextDriver.h
@@ -111,6 +111,7 @@ private:
     static METHOD_RETURN_TYPE ri(const ARGS_TYPE& args);
     static METHOD_RETURN_TYPE i(const ARGS_TYPE& args);
     static METHOD_RETURN_TYPE gs(const ARGS_TYPE& args);
+    static METHOD_RETURN_TYPE SetOpacity(const ARGS_TYPE& args);
 
     // color operators
     static METHOD_RETURN_TYPE CS(const ARGS_TYPE& args);

--- a/tests/HighLevelContentContext.js
+++ b/tests/HighLevelContentContext.js
@@ -1,8 +1,12 @@
 describe("HighLevelContentContext", function () {
+  var expect = require("chai").expect;
+  var fs = require("fs");
+  var os = require("os");
+  var path = require("path");
+  var outputPath = __dirname + "/output/HighLevelContentContext.pdf";
+
   it("should complete without error", function () {
-    var pdfWriter = require("../lib/muhammara").createWriter(
-      __dirname + "/output/HighLevelContentContext.pdf",
-    );
+    var pdfWriter = require("../lib/muhammara").createWriter(outputPath);
     var page = pdfWriter.createPage(0, 0, 595, 842);
     var cxt = pdfWriter.startPageContentContext(page);
 
@@ -69,7 +73,52 @@ describe("HighLevelContentContext", function () {
       .writeText("Rectangles", 375, 400, textOptions)
       .writeText("Circles", 75, 400, textOptions);
 
+    cxt
+      .q()
+      .setOpacity(0.5)
+      .writeText("Transparent", 75, 370, textOptions)
+      .Q()
+      .writeText("Opaque", 75, 350, textOptions);
+
     pdfWriter.writePage(page);
     pdfWriter.end();
+
+    var pdf = fs.readFileSync(outputPath, "latin1");
+    expect(pdf).to.contain("/ca 0.5");
+    expect(pdf).to.contain("/CA 0.5");
+  });
+
+  it("should reject invalid opacity values", function () {
+    var tempDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), "muhammara-opacity-"),
+    );
+    var pdfWriter = require("../lib/muhammara").createWriter(
+      path.join(tempDirectory, "invalid-opacity.pdf"),
+    );
+    var page = pdfWriter.createPage(0, 0, 595, 842);
+    var cxt = pdfWriter.startPageContentContext(page);
+
+    try {
+      expect(function () {
+        cxt.setOpacity();
+      }).to.throw("opacity value between 0 and 1");
+      expect(function () {
+        cxt.setOpacity("0.5");
+      }).to.throw("opacity value between 0 and 1");
+      expect(function () {
+        cxt.setOpacity(NaN);
+      }).to.throw("opacity value between 0 and 1");
+      expect(function () {
+        cxt.setOpacity(-0.1);
+      }).to.throw("opacity value between 0 and 1");
+      expect(function () {
+        cxt.setOpacity(1.1);
+      }).to.throw("opacity value between 0 and 1");
+
+      pdfWriter.writePage(page);
+      pdfWriter.end();
+    } finally {
+      fs.rmSync(tempDirectory, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Add `setOpacity(opacity)` to page and form content contexts for PDF fill and stroke transparency.
- Validate opacity values from 0 through 1 and document context-scoped usage.
- Add regression coverage for generated ExtGState opacity and invalid inputs.

Closes #496

## Validation
- `npx mocha tests/HighLevelContentContext.js --timeout 15000`
- `npm test`
- `npm run test:codestyle`