### PR TITLE
Support Node 26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20.9.0, 22.0.0, 24.0.0, 25.0.0]
+        node: [20.9.0, 22.0.0, 24.0.0, 25.0.0, 26.7.0]
         include:
           - architecture: arm64
             architecture_node: x64
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20.9.0, 22.0.0, 24.0.0, 25.0.0]
+        node: [20.9.0, 22.0.0, 24.0.0, 25.0.0, 26.7.0]
         include:
           - python_version: 3
     runs-on: ubuntu-latest
@@ -312,7 +312,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm]
-        node: [20.9.0, 22.9.0, 24.0.0, 25.2.0]
+        node: [20.9.0, 22.9.0, 24.0.0, 25.2.0, 26.7.0]
         include:
           - os: ubuntu-22.04
             architecture: x64
@@ -363,7 +363,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15, windows-2022]
-        node: [20.9.0, 22.9.0, 24.0.0, 25.2.0]
+        node: [20.9.0, 22.9.0, 24.0.0, 25.2.0, 26.7.0]
         architecture: [x64, arm64]
         include:
           - python_version: "3.10"

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 10
+          node-version: 22
       - run: npm install
       - run: npm test
       - uses: JS-DevTools/npm-publish@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Set versoin of cache action to v5
 - Add missing type definitions for PDFReader methods and PDFObjectParser interface [#479](https://github.com/julianhille/MuhammaraJS/issues/479)
 - node version 25
+- Add Node.js 26 support [#516](https://github.com/julianhille/MuhammaraJS/issues/516)
 - Add context opacity support for transparent text [#496](https://github.com/julianhille/MuhammaraJS/issues/496)
 - New version of PDF Writer 4.8.1
 - New version of PDF Writer 4.9.0 [#534](https://github.com/julianhille/MuhammaraJS/issues/534)

--- a/src/FormXObjectDriver.cpp
+++ b/src/FormXObjectDriver.cpp
@@ -77,7 +77,7 @@ METHOD_RETURN_TYPE FormXObjectDriver::GetID(SET_ACCESSOR_METHOD_NAME_TYPE proper
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    FormXObjectDriver* form = ObjectWrap::Unwrap<FormXObjectDriver>(info.Holder());
+    FormXObjectDriver* form = ObjectWrap::Unwrap<FormXObjectDriver>(PROPERTY_HOLDER(info));
     
     if(!form->FormXObject)
     {

--- a/src/ImageXObjectDriver.cpp
+++ b/src/ImageXObjectDriver.cpp
@@ -66,7 +66,7 @@ METHOD_RETURN_TYPE ImageXObjectDriver::GetID(SET_ACCESSOR_METHOD_NAME_TYPE prope
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    ImageXObjectDriver* image = ObjectWrap::Unwrap<ImageXObjectDriver>(info.Holder());
+    ImageXObjectDriver* image = ObjectWrap::Unwrap<ImageXObjectDriver>(PROPERTY_HOLDER(info));
     
     if(!image->ImageXObject)
     {

--- a/src/InfoDictionaryDriver.cpp
+++ b/src/InfoDictionaryDriver.cpp
@@ -77,7 +77,7 @@ METHOD_RETURN_TYPE InfoDictionaryDriver::GetTitle(SET_ACCESSOR_METHOD_NAME_TYPE 
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(info.Holder());
+    InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(PROPERTY_HOLDER(info));
     
     if(!infoDictionaryDriver->InfoDictionaryInstance)
     {
@@ -92,7 +92,7 @@ void InfoDictionaryDriver::SetTitle(SET_ACCESSOR_METHOD_NAME_TYPE property, Loca
 {
 	CREATE_ISOLATE_CONTEXT;
 	
-	InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(info.Holder());
+	InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(PROPERTY_HOLDER(info));
     
     if(!infoDictionaryDriver->InfoDictionaryInstance)
 		THROW_EXCEPTION("info dictionary driver not initialized. use the document context object to get a valid info dictionary");
@@ -105,7 +105,7 @@ METHOD_RETURN_TYPE InfoDictionaryDriver::GetAuthor(SET_ACCESSOR_METHOD_NAME_TYPE
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(info.Holder());
+    InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(PROPERTY_HOLDER(info));
     
     if(!infoDictionaryDriver->InfoDictionaryInstance)
     {
@@ -120,7 +120,7 @@ void InfoDictionaryDriver::SetAuthor(SET_ACCESSOR_METHOD_NAME_TYPE property, Loc
 {
 	CREATE_ISOLATE_CONTEXT;
 	
-	InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(info.Holder());
+	InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(PROPERTY_HOLDER(info));
     
     if(!infoDictionaryDriver->InfoDictionaryInstance)
 		THROW_EXCEPTION("info dictionary driver not initialized. use the document context object to get a valid info dictionary");
@@ -133,7 +133,7 @@ METHOD_RETURN_TYPE InfoDictionaryDriver::GetSubject(SET_ACCESSOR_METHOD_NAME_TYP
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(info.Holder());
+    InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(PROPERTY_HOLDER(info));
     
     if(!infoDictionaryDriver->InfoDictionaryInstance)
     {
@@ -147,7 +147,7 @@ METHOD_RETURN_TYPE InfoDictionaryDriver::GetSubject(SET_ACCESSOR_METHOD_NAME_TYP
 void InfoDictionaryDriver::SetSubject(SET_ACCESSOR_METHOD_NAME_TYPE property, Local<Value> value, const PROPERTY_SETTER_TYPE &info)
 {
 	CREATE_ISOLATE_CONTEXT;
-	InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(info.Holder());
+	InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(PROPERTY_HOLDER(info));
     
     if(!infoDictionaryDriver->InfoDictionaryInstance)
 		THROW_EXCEPTION("info dictionary driver not initialized. use the document context object to get a valid info dictionary");
@@ -160,7 +160,7 @@ METHOD_RETURN_TYPE InfoDictionaryDriver::GetKeywords(SET_ACCESSOR_METHOD_NAME_TY
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(info.Holder());
+    InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(PROPERTY_HOLDER(info));
     
     if(!infoDictionaryDriver->InfoDictionaryInstance)
     {
@@ -174,7 +174,7 @@ METHOD_RETURN_TYPE InfoDictionaryDriver::GetKeywords(SET_ACCESSOR_METHOD_NAME_TY
 void InfoDictionaryDriver::SetKeywords(SET_ACCESSOR_METHOD_NAME_TYPE property, Local<Value> value, const PROPERTY_SETTER_TYPE &info)
 {
 	CREATE_ISOLATE_CONTEXT;
-	InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(info.Holder());
+	InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(PROPERTY_HOLDER(info));
     
     if(!infoDictionaryDriver->InfoDictionaryInstance)
 		THROW_EXCEPTION("info dictionary driver not initialized. use the document context object to get a valid info dictionary");
@@ -187,7 +187,7 @@ METHOD_RETURN_TYPE InfoDictionaryDriver::GetCreator(SET_ACCESSOR_METHOD_NAME_TYP
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(info.Holder());
+    InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(PROPERTY_HOLDER(info));
     
     if(!infoDictionaryDriver->InfoDictionaryInstance)
     {
@@ -201,7 +201,7 @@ METHOD_RETURN_TYPE InfoDictionaryDriver::GetCreator(SET_ACCESSOR_METHOD_NAME_TYP
 void InfoDictionaryDriver::SetCreator(SET_ACCESSOR_METHOD_NAME_TYPE property, Local<Value> value, const PROPERTY_SETTER_TYPE &info)
 {
 	CREATE_ISOLATE_CONTEXT;
-	InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(info.Holder());
+	InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(PROPERTY_HOLDER(info));
     
     if(!infoDictionaryDriver->InfoDictionaryInstance)
 		THROW_EXCEPTION("info dictionary driver not initialized. use the document context object to get a valid info dictionary");
@@ -214,7 +214,7 @@ METHOD_RETURN_TYPE InfoDictionaryDriver::GetProducer(SET_ACCESSOR_METHOD_NAME_TY
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
    
-    InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(info.Holder());
+    InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(PROPERTY_HOLDER(info));
     
     if(!infoDictionaryDriver->InfoDictionaryInstance)
     {
@@ -228,7 +228,7 @@ METHOD_RETURN_TYPE InfoDictionaryDriver::GetProducer(SET_ACCESSOR_METHOD_NAME_TY
 void InfoDictionaryDriver::SetProducer(SET_ACCESSOR_METHOD_NAME_TYPE property, Local<Value> value, const PROPERTY_SETTER_TYPE &info)
 {
 	CREATE_ISOLATE_CONTEXT;
-	InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(info.Holder());
+	InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(PROPERTY_HOLDER(info));
     
     if(!infoDictionaryDriver->InfoDictionaryInstance)
 		THROW_EXCEPTION("info dictionary driver not initialized. use the document context object to get a valid info dictionary");
@@ -241,7 +241,7 @@ METHOD_RETURN_TYPE InfoDictionaryDriver::GetTrapped(SET_ACCESSOR_METHOD_NAME_TYP
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(info.Holder());
+    InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(PROPERTY_HOLDER(info));
     
     if(!infoDictionaryDriver->InfoDictionaryInstance)
     {
@@ -255,7 +255,7 @@ METHOD_RETURN_TYPE InfoDictionaryDriver::GetTrapped(SET_ACCESSOR_METHOD_NAME_TYP
 void InfoDictionaryDriver::SetTrapped(SET_ACCESSOR_METHOD_NAME_TYPE property, Local<Value> value, const PROPERTY_SETTER_TYPE &info)
 {
 	CREATE_ISOLATE_CONTEXT;
-	InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(info.Holder());
+	InfoDictionaryDriver* infoDictionaryDriver = ObjectWrap::Unwrap<InfoDictionaryDriver>(PROPERTY_HOLDER(info));
     
     if(!infoDictionaryDriver->InfoDictionaryInstance)
 		THROW_EXCEPTION("info dictionary driver not initialized. use the document context object to get a valid info dictionary");

--- a/src/PDFBooleanDriver.cpp
+++ b/src/PDFBooleanDriver.cpp
@@ -65,7 +65,7 @@ METHOD_RETURN_TYPE PDFBooleanDriver::GetValue(SET_ACCESSOR_METHOD_NAME_TYPE prop
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    Local<Boolean> result = NEW_BOOLEAN(ObjectWrap::Unwrap<PDFBooleanDriver>(info.Holder())->TheObject->GetValue());
+    Local<Boolean> result = NEW_BOOLEAN(ObjectWrap::Unwrap<PDFBooleanDriver>(PROPERTY_HOLDER(info))->TheObject->GetValue());
 
     
     SET_ACCESSOR_RETURN_VALUE(result)

--- a/src/PDFHexStringDriver.cpp
+++ b/src/PDFHexStringDriver.cpp
@@ -68,7 +68,7 @@ METHOD_RETURN_TYPE PDFHexStringDriver::GetValue(SET_ACCESSOR_METHOD_NAME_TYPE pr
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    Local<String> result = NEW_STRING(ObjectWrap::Unwrap<PDFHexStringDriver>(info.Holder())->TheObject->GetValue().c_str());
+    Local<String> result = NEW_STRING(ObjectWrap::Unwrap<PDFHexStringDriver>(PROPERTY_HOLDER(info))->TheObject->GetValue().c_str());
     SET_ACCESSOR_RETURN_VALUE(result)
 }
 

--- a/src/PDFIntegerDriver.cpp
+++ b/src/PDFIntegerDriver.cpp
@@ -62,7 +62,7 @@ METHOD_RETURN_TYPE PDFIntegerDriver::GetValue(SET_ACCESSOR_METHOD_NAME_TYPE prop
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    Local<Number> result = NEW_NUMBER(ObjectWrap::Unwrap<PDFIntegerDriver>(info.Holder())->TheObject->GetValue());
+    Local<Number> result = NEW_NUMBER(ObjectWrap::Unwrap<PDFIntegerDriver>(PROPERTY_HOLDER(info))->TheObject->GetValue());
     SET_ACCESSOR_RETURN_VALUE(result)
 }
 

--- a/src/PDFLiteralStringDriver.cpp
+++ b/src/PDFLiteralStringDriver.cpp
@@ -70,7 +70,7 @@ METHOD_RETURN_TYPE PDFLiteralStringDriver::GetValue(SET_ACCESSOR_METHOD_NAME_TYP
 	CREATE_ESCAPABLE_SCOPE;
     
     
-    Local<String> result = NEW_STRING(ObjectWrap::Unwrap<PDFLiteralStringDriver>(info.Holder())->TheObject->GetValue().c_str());
+    Local<String> result = NEW_STRING(ObjectWrap::Unwrap<PDFLiteralStringDriver>(PROPERTY_HOLDER(info))->TheObject->GetValue().c_str());
     SET_ACCESSOR_RETURN_VALUE(result)
 }
 

--- a/src/PDFNameDriver.cpp
+++ b/src/PDFNameDriver.cpp
@@ -64,7 +64,7 @@ METHOD_RETURN_TYPE PDFNameDriver::GetValue(SET_ACCESSOR_METHOD_NAME_TYPE propert
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    Local<String> result = NEW_STRING(ObjectWrap::Unwrap<PDFNameDriver>(info.Holder())->TheObject->GetValue().c_str());
+    Local<String> result = NEW_STRING(ObjectWrap::Unwrap<PDFNameDriver>(PROPERTY_HOLDER(info))->TheObject->GetValue().c_str());
     SET_ACCESSOR_RETURN_VALUE(result)
 }
 

--- a/src/PDFPageDriver.cpp
+++ b/src/PDFPageDriver.cpp
@@ -96,7 +96,7 @@ METHOD_RETURN_TYPE PDFPageDriver::GetMediaBox(SET_ACCESSOR_METHOD_NAME_TYPE prop
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
 
-    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(info.Holder());
+    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(PROPERTY_HOLDER(info));
     
     Local<Array> mediaBox = NEW_ARRAY(4);
     
@@ -113,7 +113,7 @@ METHOD_RETURN_TYPE PDFPageDriver::GetCropBox(SET_ACCESSOR_METHOD_NAME_TYPE prope
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
 
-    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(info.Holder());
+    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(PROPERTY_HOLDER(info));
     
     BoolAndPDFRectangle cropBox = pageDriver->mPDFPage->GetCropBox();
     
@@ -139,7 +139,7 @@ METHOD_RETURN_TYPE PDFPageDriver::GetBleedBox(SET_ACCESSOR_METHOD_NAME_TYPE prop
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
 
-    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(info.Holder());
+    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(PROPERTY_HOLDER(info));
     
     BoolAndPDFRectangle bleedBox = pageDriver->mPDFPage->GetBleedBox();
     
@@ -165,7 +165,7 @@ METHOD_RETURN_TYPE PDFPageDriver::GetTrimBox(SET_ACCESSOR_METHOD_NAME_TYPE prope
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
 
-    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(info.Holder());
+    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(PROPERTY_HOLDER(info));
     
     BoolAndPDFRectangle trimBox = pageDriver->mPDFPage->GetTrimBox();
     
@@ -191,7 +191,7 @@ METHOD_RETURN_TYPE PDFPageDriver::GetArtBox(SET_ACCESSOR_METHOD_NAME_TYPE proper
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
 
-    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(info.Holder());
+    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(PROPERTY_HOLDER(info));
     
     BoolAndPDFRectangle artBox = pageDriver->mPDFPage->GetArtBox();
     
@@ -217,7 +217,7 @@ void PDFPageDriver::SetMediaBox(SET_ACCESSOR_METHOD_NAME_TYPE property, Local<Va
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(info.Holder());
+    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(PROPERTY_HOLDER(info));
 
     if(!value->IsArray())
         THROW_EXCEPTION("Media box is set to a value which is not a 4 numbers array");
@@ -237,7 +237,7 @@ METHOD_RETURN_TYPE PDFPageDriver::GetRotate(SET_ACCESSOR_METHOD_NAME_TYPE proper
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
 
-    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(info.Holder());
+    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(PROPERTY_HOLDER(info));
     
     BoolAndInt rotate = pageDriver->mPDFPage->GetRotate();
     
@@ -257,7 +257,7 @@ void PDFPageDriver::SetRotate(SET_ACCESSOR_METHOD_NAME_TYPE property, Local<Valu
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(info.Holder());
+    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(PROPERTY_HOLDER(info));
 
     if(!value->IsNumber())
         THROW_EXCEPTION("Rotation is not set to a number");
@@ -272,7 +272,7 @@ void PDFPageDriver::SetCropBox(SET_ACCESSOR_METHOD_NAME_TYPE property, Local<Val
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(info.Holder());
+    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(PROPERTY_HOLDER(info));
 
     if(!value->IsArray())
         THROW_EXCEPTION("Crop box is set to a value which is not a 4 numbers array");
@@ -292,7 +292,7 @@ void PDFPageDriver::SetBleedBox(SET_ACCESSOR_METHOD_NAME_TYPE property, Local<Va
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(info.Holder());
+    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(PROPERTY_HOLDER(info));
 
     if(!value->IsArray())
         THROW_EXCEPTION("Bleed box is set to a value which is not a 4 numbers array");
@@ -312,7 +312,7 @@ void PDFPageDriver::SetTrimBox(SET_ACCESSOR_METHOD_NAME_TYPE property, Local<Val
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(info.Holder());
+    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(PROPERTY_HOLDER(info));
 
     if(!value->IsArray())
         THROW_EXCEPTION("Trim box is set to a value which is not a 4 numbers array");
@@ -332,7 +332,7 @@ void PDFPageDriver::SetArtBox(SET_ACCESSOR_METHOD_NAME_TYPE property, Local<Valu
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(info.Holder());
+    PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(PROPERTY_HOLDER(info));
 
     if(!value->IsArray())
         THROW_EXCEPTION("Art box is set to a value which is not a 4 numbers array");

--- a/src/PDFRealDriver.cpp
+++ b/src/PDFRealDriver.cpp
@@ -63,7 +63,6 @@ METHOD_RETURN_TYPE PDFRealDriver::GetValue(SET_ACCESSOR_METHOD_NAME_TYPE propert
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-	SET_ACCESSOR_RETURN_VALUE(NEW_NUMBER(ObjectWrap::Unwrap<PDFRealDriver>(info.Holder())->TheObject->GetValue()))
+	SET_ACCESSOR_RETURN_VALUE(NEW_NUMBER(ObjectWrap::Unwrap<PDFRealDriver>(PROPERTY_HOLDER(info))->TheObject->GetValue()))
 }
-
 

--- a/src/PDFSymbolDriver.cpp
+++ b/src/PDFSymbolDriver.cpp
@@ -64,8 +64,7 @@ METHOD_RETURN_TYPE PDFSymbolDriver::GetValue(SET_ACCESSOR_METHOD_NAME_TYPE prope
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    Local<String> result = NEW_STRING(ObjectWrap::Unwrap<PDFSymbolDriver>(info.Holder())->TheObject->GetValue().c_str());
+    Local<String> result = NEW_STRING(ObjectWrap::Unwrap<PDFSymbolDriver>(PROPERTY_HOLDER(info))->TheObject->GetValue().c_str());
     SET_ACCESSOR_RETURN_VALUE(result)
 }
-
 

--- a/src/nodes.h
+++ b/src/nodes.h
@@ -8,6 +8,7 @@
 #define NODE_10_0_0_MODULE_VERSION 64
 #define NODE_11_0_0_MODULE_VERSION 67
 #define NODE_21_0_0_MODULE_VERSION  120
+#define NODE_26_0_0_MODULE_VERSION 147
 #define NODE_CONTEXT_AWARE_VERSION NODE_10_0_0_MODULE_VERSION
 #define IS_CONTEXT_AWARE NODE_MODULE_VERSION >= NODE_CONTEXT_AWARE_VERSION
 #ifdef NODE_MODULE_INIT
@@ -30,6 +31,11 @@
 #define NEW_ARRAY(X) Array::New(isolate,X)
 #define NEW_BOOLEAN(X) Boolean::New(isolate,X)
 #define NEW_OBJECT Object::New(isolate)
+#if NODE_MODULE_VERSION >= NODE_26_0_0_MODULE_VERSION
+    #define PROPERTY_HOLDER(info) info.HolderV2()
+#else
+    #define PROPERTY_HOLDER(info) info.Holder()
+#endif
 #if NODE_MODULE_VERSION < NODE_21_0_0_MODULE_VERSION
     #define SET_ACCESSOR_METHOD(t,s,f) t->InstanceTemplate()->SetAccessor(NEW_STRING(s), f);
     #define SET_ACCESSOR_METHODS(t,s,f,g) t->InstanceTemplate()->SetAccessor(NEW_STRING(s), f, g);


### PR DESCRIPTION
## Summary
- add Node 26.7.0 CI builds and prebuild artifacts while retaining Node 20/25 coverage
- update the native V8 property-holder compatibility layer for Node 26
- update the manual publish runtime and changelog

## Testing
- npm run test:codestyle
- clean node:26.7.0-alpine source install and npm test (177 passing)