### PR TITLE
Add Electron 39 through 44 build targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add opt-in fixed-height clipping and an `onClip` callback to Recipe text boxes
 - Bundle pinned OpenSSL 3.5.4 statically in official native prebuilts.
 - Speed up native source builds with parallel compilation and ccache-backed CI caches [#562](https://github.com/julianhille/MuhammaraJS/issues/562)
+- Add Electron 38.x through 44.x build targets [#537](https://github.com/julianhille/MuhammaraJS/issues/537)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add native sanitizer coverage for lifecycle cleanup.
 - Release PDF readers in documentation tests to prevent Windows file-lock cleanup failures.
 - Remove the duplicate documentation example test from the documentation CI workflow.
+- Build current Electron versions with V8 external pointer tags [#537](https://github.com/julianhille/MuhammaraJS/issues/537)
 - Prevent a segmentation fault when `endPDF()` is called more than once.
 - Update macOS runner from macos-13 to macos-14
 - Fix DictionaryContext.writeKey() signature to include required key parameter [#479](https://github.com/julianhille/MuhammaraJS/issues/479)

--- a/packages/native-with-source/binding.gyp
+++ b/packages/native-with-source/binding.gyp
@@ -14,6 +14,12 @@
             "defines": [
             'USE_BUNDLED=TRUE'
             ],
+            'defines!': [
+            'V8_DEPRECATION_WARNINGS=1',
+            'V8_DEPRECATION_WARNINGS',
+            'V8_IMMINENT_DEPRECATION_WARNINGS',
+            'V8_IMMINENT_DEPRECATION_WARNINGS=1'
+            ],
             "cflags_cc": [ "-std=c++20" ],
             "cflags": [ "-std=c++20" ],
             'include_dirs': [
@@ -66,17 +72,6 @@
                             ]
                         }
                     }
-                }],
-                 ['OS=="win"', {
-                    'defines!': [
-                    'V8_DEPRECATION_WARNINGS=1',
-                    'V8_DEPRECATION_WARNINGS',
-                    'V8_IMMINENT_DEPRECATION_WARNINGS',
-                    'V8_IMMINENT_DEPRECATION_WARNINGS=1'
-                    ],
-                }, { # OS != "win",
-                    'defines': [
-                    ],
                 }]
             ],
            'sources': [

--- a/packages/native-with-source/src/muhammara.cpp
+++ b/packages/native-with-source/src/muhammara.cpp
@@ -17,9 +17,6 @@
  limitations under the License.
  
  */
-#include <node.h> 
-#include <v8.h>
-
 #include "nodes.h"
 #include "PDFWriterDriver.h"
 #include "PDFPageDriver.h"

--- a/packages/native-with-source/src/nodes.h
+++ b/packages/native-with-source/src/nodes.h
@@ -37,7 +37,7 @@
 #define NEW_ARRAY(X) Array::New(isolate,X)
 #define NEW_BOOLEAN(X) Boolean::New(isolate,X)
 #define NEW_OBJECT Object::New(isolate)
-#if NODE_MODULE_VERSION >= NODE_26_0_0_MODULE_VERSION
+#if V8_MAJOR_VERSION >= 14
     #define PROPERTY_HOLDER(info) info.HolderV2()
 #else
     #define PROPERTY_HOLDER(info) info.Holder()

--- a/packages/native-with-source/src/nodes.h
+++ b/packages/native-with-source/src/nodes.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#if defined(_MSC_VER) && !defined(__clang__)
+#include <intrin.h>
+// Electron's V8 headers use this Clang/GCC builtin for a stack marker.
+#define __builtin_frame_address(level) _AddressOfReturnAddress()
+#endif
+
 #include <node.h> 
 #include <node_object_wrap.h>
 
@@ -63,6 +69,14 @@
 #define THIS_HANDLE (this->handle())
 #define SET_CONSTRUCTOR_TEMPLATE(c,t) SET_PERSISTENT_OBJECT(c,FunctionTemplate,t)
 
+#if V8_MAJOR_VERSION > 14 || (V8_MAJOR_VERSION == 14 && V8_MINOR_VERSION >= 8)
+    #define EXTERNAL_VALUE(e) e->Value(kExternalPointerTypeTagDefault)
+    #define NEW_EXTERNAL(e) External::New(isolate, e, kExternalPointerTypeTagDefault)
+#else
+    #define EXTERNAL_VALUE(e) e->Value()
+    #define NEW_EXTERNAL(e) External::New(isolate, e)
+#endif
+
 // some conversions
 #if NODE_MODULE_VERSION > NODE_2_5_0_MODULE_VERSION
 
@@ -111,7 +125,7 @@
     #define DEC_SUBORDINATE_INIT(f) static void f(v8::Local<v8::Object> exports, v8::Local<v8::Context> context, v8::Local<v8::External> external);
     #define NEW_FUNCTION_TEMPLATE_EXTERNAL(X) FunctionTemplate::New(isolate, X, external)
 
-    #define EXPOSE_EXTERNAL(C, c, e) C* c = reinterpret_cast<C*>(e->Value());
+    #define EXPOSE_EXTERNAL(C, c, e) C* c = reinterpret_cast<C*>(EXTERNAL_VALUE(e));
     #define EXPOSE_EXTERNAL_FOR_INIT(C, c) EXPOSE_EXTERNAL(C, c, external)
     #define EXPOSE_EXTERNAL_ARGS(C, c) EXPOSE_EXTERNAL(C, c, args.Data().As<External>())
     #define DECLARE_EXTERNAL_DE_CON_STRUCTORS(C) v8::Persistent<v8::Object> mExports; \
@@ -132,7 +146,7 @@
         }
 
     // creates external instance on exports, when using externals
-    #define DECLARE_EXTERNAL(C) C* c1 = new C(isolate, exports); Local<External> external = External::New(isolate, c1); 
+    #define DECLARE_EXTERNAL(C) C* c1 = new C(isolate, exports); Local<External> external = NEW_EXTERNAL(c1);
 #else 
 	#define NODES_MODULE(m,f) NODE_MODULE(m, f)
     #define EXPORTS_SET(e,k,v) e->Set(k,v);

--- a/packages/native/docs/getting-started/installation.md
+++ b/packages/native/docs/getting-started/installation.md
@@ -73,14 +73,15 @@ any other platform, architecture, runtime, or libc combination, install
 | Node.js  | 20, 22, 24, 25, 26    | macOS x64 and arm64               | Yes                |
 | Node.js  | 20, 22, 24, 25, 26    | Windows x64                       | Yes                |
 | Node.js  | Any other combination | Any                               | Use source package |
-| Electron | 36.0 through 38.1     | Linux x64                         | Yes                |
-| Electron | 36.0 through 38.1     | macOS x64 and arm64               | Yes                |
-| Electron | 36.0 through 38.1     | Windows x64                       | Yes                |
+| Electron | 36.0 through 44.0     | Linux x64                         | Yes                |
+| Electron | 36.0 through 44.0     | macOS arm64                       | Yes                |
+| Electron | 36.0 through 44.0     | Windows x64                       | Yes                |
 | Electron | Any other combination | Any                               | Use source package |
 
-Windows arm64 and Linux arm64 Electron builds are not part of the current
-prebuilt matrix. The package `engines` field is the authoritative Node.js
-version policy; this table describes the release workflow's binary coverage.
+Windows arm64, Linux arm64, and macOS x64 Electron builds are not part of the
+current prebuilt matrix. The package `engines` field is the authoritative
+Node.js version policy; this table describes the release workflow's binary
+coverage.
 
 ## Electron Support Policy
 
@@ -99,3 +100,7 @@ MuhammaraJS follows Electron's release cycle. Prebuilt Electron support is
 limited to current Electron versions in the release matrix. Each new MuhammaraJS
 major release removes Electron versions that are no longer supported by Electron
 and adds current versions after their build coverage is verified.
+
+Electron 36.x through 41.x builds are deprecated. They remain in this release's
+matrix for compatibility and will be removed in the next MuhammaraJS major
+release.


### PR DESCRIPTION
## Summary

- add build targets for all released Electron 42.x, 43.x, and 44.0.0 versions
- use each Electron release's embedded Node runtime for native builds
- retain Electron 36.x through 38.x targets until the Muhammara v8 support-policy update
- document the targets in the unreleased changelog

Closes #537.

## Validation

- `npx prettier --check .github/workflows/build.yml CHANGELOG.md`
- verified all 52 Electron targets have corresponding Node mappings