### PR TITLE
Add Turbopack N-API metadata workaround

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  verify-napi-metadata:
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [24.0.0, 24.1.0]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci --ignore-scripts
+      - run: node scripts/patch-node-pre-gyp.js
+      - run: node scripts/verify-node-pre-gyp-napi-metadata.js
   lint:
     runs-on: ubuntu-22.04
     env:
@@ -24,7 +38,7 @@ jobs:
       - run: npm ci --ignore-scripts
       - run: npm run test:codestyle
   build-musl-arm:
-    needs: [lint]
+    needs: [lint, verify-napi-metadata]
     strategy:
       fail-fast: false
       matrix:
@@ -66,6 +80,7 @@ jobs:
           CPPFLAGS: ${{ env.CPPFLAGS }} ${{ matrix.extra_compile_flags }}
           EXTRA_NODE_PRE_GYP_FLAGS: --target_libc=musl
           npm_config_unsafe_perm: true
+      - run: node scripts/verify-node-pre-gyp-napi-metadata.js
       # - run: npm run test, this is not an arm64 machine so we can not test.
       - run: ./node_modules/.bin/node-pre-gyp package --target_libc=musl  --target_arch=${{ matrix.target_architecture }}
       - uses: actions/upload-artifact@v6
@@ -74,7 +89,7 @@ jobs:
           name: bindings-node-musl-arm-${{ matrix.node }}
           if-no-files-found: error
   build-musl:
-    needs: [lint]
+    needs: [lint, verify-napi-metadata]
     strategy:
       fail-fast: false
       matrix:
@@ -105,6 +120,7 @@ jobs:
         env:
           EXTRA_NODE_PRE_GYP_FLAGS: --target_libc=musl
           npm_config_unsafe_perm: true
+      - run: node scripts/verify-node-pre-gyp-napi-metadata.js
       - run: npm run test
       - run: ./node_modules/.bin/node-pre-gyp package testpackage --target_libc=musl
       - uses: actions/upload-artifact@v6
@@ -113,7 +129,7 @@ jobs:
           name: bindings-node-musl-${{ matrix.node }}
           if-no-files-found: error
   build-electron:
-    needs: [lint]
+    needs: [lint, verify-napi-metadata]
     strategy:
       fail-fast: false
       matrix:
@@ -263,6 +279,7 @@ jobs:
           npm_config_python: python${{ matrix.python_version }}
           CFLAGS: ${{ matrix.extra_compile_flags }}
           CPPFLAGS: ${{ env.CPPFLAGS }} ${{ matrix.extra_compile_flags }}
+      - run: node scripts/verify-node-pre-gyp-napi-metadata.js
       - name: Bundle OpenSSL DLLs (Windows)
         if: ${{ matrix.os == 'windows-2022' }}
         shell: pwsh
@@ -307,7 +324,7 @@ jobs:
           if-no-files-found: error
 
   build-node-linux:
-    needs: [lint]
+    needs: [lint, verify-napi-metadata]
     strategy:
       fail-fast: false
       matrix:
@@ -351,6 +368,7 @@ jobs:
           npm_config_target_arch: ${{ matrix.target_architecture }}
           CFLAGS: ${{ matrix.extra_compile_flags }}
           CPPFLAGS: ${{ env.CPPFLAGS }} ${{ matrix.extra_compile_flags }}
+      - run: node scripts/verify-node-pre-gyp-napi-metadata.js
       - run: ./node_modules/.bin/node-pre-gyp package testpackage
       - uses: actions/upload-artifact@v6
         with:
@@ -358,7 +376,7 @@ jobs:
           name: bindings-electron-${{ matrix.os }}-${{ matrix.target_architecture }}-${{matrix.node}}
           if-no-files-found: error
   build-node:
-    needs: [lint]
+    needs: [lint, verify-napi-metadata]
     strategy:
       fail-fast: false
       matrix:
@@ -436,6 +454,7 @@ jobs:
           npm_config_msbuild_path: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe'
           CFLAGS: ${{ matrix.extra_compile_flags }}
           CPPFLAGS: ${{ env.CPPFLAGS }} ${{ matrix.extra_compile_flags }}
+      - run: node scripts/verify-node-pre-gyp-napi-metadata.js
       - name: Bundle OpenSSL DLLs (Windows)
         if: ${{ matrix.os == 'windows-2022' }}
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add context opacity support for transparent text [#496](https://github.com/julianhille/MuhammaraJS/issues/496)
 - New version of PDF Writer 4.8.1
 - New version of PDF Writer 4.9.0 [#534](https://github.com/julianhille/MuhammaraJS/issues/534)
+- Add Node-API metadata for Turbopack compatibility while retaining Node-ABI builds [#504](https://github.com/julianhille/MuhammaraJS/issues/504)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,11 @@
     "module_path": "./binding",
     "remote_path": "julianhille/MuhammaraJS/releases/download/{version}",
     "host": "https://github.com",
-    "package_name": "{node_abi}-{platform}-{arch}-{libc}.tar.gz"
+    "package_name": "{node_abi}-{platform}-{arch}-{libc}.tar.gz",
+    "napi_versions": [
+      9,
+      10
+    ]
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/scripts/patch-node-pre-gyp.js
+++ b/scripts/patch-node-pre-gyp.js
@@ -20,6 +20,16 @@ var replacements = [
     "new URL(opts.package_name, opts.hosted_path).href",
   ],
 ];
+var napiPath = require.resolve("@mapbox/node-pre-gyp/lib/util/napi");
+var napiSource = fs.readFileSync(napiPath, "utf8");
+var napiBuildVersionsReplacement = [
+  "module.exports.get_napi_build_versions = function(package_json, opts, warnings) { // opts may be undefined\n",
+  'module.exports.get_napi_build_versions = function(package_json, opts, warnings) { // opts may be undefined\n  if (package_json.name === "muhammara" && package_json.binary.module_name === "muhammara") {\n    return undefined;\n  }\n',
+];
+var napiValidationReplacement = [
+  "module.exports.validate_package_json = function(package_json, opts) { // throws Error\n",
+  'module.exports.validate_package_json = function(package_json, opts) { // throws Error\n  if (package_json.name === "muhammara" && package_json.binary.module_name === "muhammara") {\n    return;\n  }\n',
+];
 
 replacements.forEach(function (replacement) {
   if (source.includes(replacement[1])) {
@@ -34,3 +44,21 @@ replacements.forEach(function (replacement) {
 });
 
 fs.writeFileSync(versioningPath, source);
+
+// The published N-API metadata is for Turbopack's package parser. Muhammara
+// remains a V8 addon, so node-pre-gyp must continue resolving Node-ABI builds.
+[napiBuildVersionsReplacement, napiValidationReplacement].forEach(
+  function (replacement) {
+    if (napiSource.includes(replacement[1])) {
+      return;
+    }
+    if (!napiSource.includes(replacement[0])) {
+      throw new Error(
+        "Unsupported @mapbox/node-pre-gyp version: expected N-API function was not found",
+      );
+    }
+    napiSource = napiSource.replace(replacement[0], replacement[1]);
+  },
+);
+
+fs.writeFileSync(napiPath, napiSource);

--- a/scripts/verify-node-pre-gyp-napi-metadata.js
+++ b/scripts/verify-node-pre-gyp-napi-metadata.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var assert = require("assert");
+var packageJson = require("../package.json");
+var versioning = require("@mapbox/node-pre-gyp/lib/util/versioning");
+
+var napiVersion = Number(process.versions.napi);
+assert(
+  packageJson.binary.napi_versions.includes(napiVersion),
+  `Node-API ${napiVersion} is missing from binary.napi_versions`,
+);
+
+var options = versioning.evaluate(packageJson, {});
+assert(
+  options.package_name.startsWith(`node-v${process.versions.modules}-`),
+  `Expected a Node-ABI package name, received ${options.package_name}`,
+);
+assert(
+  !options.package_name.includes("napi-v"),
+  `Expected N-API metadata to be ignored by node-pre-gyp, received ${options.package_name}`,
+);
+
+console.log(
+  `Node ${process.version}: N-API ${napiVersion}, Node ABI ${process.versions.modules}`,
+);


### PR DESCRIPTION
## Summary

- publish Node-API 9 and 10 metadata required by Turbopack
- retain ABI-specific native artifacts by patching `node-pre-gyp` only for Muhammara
- verify every build family continues resolving `node-v{abi}` artifacts
- add a Node 24.0.0/24.1.0 check; both report N-API 10 and ABI 137

This does not claim that the V8 addon is Node-API compatible. The metadata is consumed by Turbopack while `node-pre-gyp` continues using existing Node-ABI artifacts.

Closes #504.

## Validation

- `npm run test:codestyle`
- `npm test`
- `npm pack --dry-run`
- Node 24.0.0 and 24.1.0 metadata-resolution checks