### PR TITLE
Add page text extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add context opacity support for transparent text [#496](https://github.com/julianhille/MuhammaraJS/issues/496)
 - New version of PDF Writer 4.8.1
 - New version of PDF Writer 4.9.0 [#534](https://github.com/julianhille/MuhammaraJS/issues/534)
+- Add `PDFReader.extractPageText()` for enumerating page content-stream text operations.
 
 ### Fixed
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -120,6 +120,7 @@
                 './src/ObjectByteWriter.cpp',
                 './src/ObjectByteWriterWithPosition.cpp',
                 './src/PDFObjectParserDriver.cpp',
+                './src/text-extraction/PDFTextExtractor.cpp',
                 './src/muhammara.cpp'
             ]
 

--- a/muhammara.d.ts
+++ b/muhammara.d.ts
@@ -388,6 +388,17 @@ declare module "muhammara" {
     height: number;
   }
 
+  /** A text-showing operation in a page content stream. */
+  export interface PDFTextElement {
+    /** Raw character codes from the content stream. Unicode decoding requires a font ToUnicode CMap. */
+    content: string;
+    /** The page resource name selected by the most recent Tf operation. */
+    fontResource: string;
+    fontSize: number;
+    /** The active PDF text matrix: [a, b, c, d, e, f]. */
+    textMatrix: [number, number, number, number, number, number];
+  }
+
   export interface RectangleDimension {
     width: Width;
     height: Height;
@@ -432,6 +443,13 @@ declare module "muhammara" {
     getPageObjectID(objectId: number): number;
     parsePageDictionary(objectId: number): PDFDictionary;
     parsePage(page: number): PDFPageInput;
+    /**
+     * Returns text-showing operations in PDF content-stream drawing order.
+     * Does not decode font character maps or calculate glyph bounds. For safety,
+     * extraction rejects pages with more than 1,000,000 content objects, 100,000 text
+     * operations, or 16 MiB of text.
+     */
+    extractPageText(pageIndex: number): PDFTextElement[];
     getObjectsCount(): number;
     isEncrypted(): boolean;
     getXrefSize(): number;

--- a/src/PDFReaderDriver.cpp
+++ b/src/PDFReaderDriver.cpp
@@ -32,6 +32,7 @@
 #include "ByteReaderWithPositionDriver.h"
 #include "ObjectByteReaderWithPosition.h"
 #include "ConstructorsHolder.h"
+#include "text-extraction/PDFTextExtractor.h"
 
 using namespace v8;
 
@@ -71,6 +72,7 @@ DEF_SUBORDINATE_INIT(PDFReaderDriver::Init)
 	SET_PROTOTYPE_METHOD(t, "getPageObjectID", GetPageObjectID);
 	SET_PROTOTYPE_METHOD(t, "parsePageDictionary", ParsePageDictionary);
 	SET_PROTOTYPE_METHOD(t, "parsePage", ParsePage);
+	SET_PROTOTYPE_METHOD(t, "extractPageText", ExtractPageText);
 	SET_PROTOTYPE_METHOD(t, "getObjectsCount", GetObjectsCount);
 	SET_PROTOTYPE_METHOD(t, "isEncrypted", IsEncrypted);
 	SET_PROTOTYPE_METHOD(t, "getXrefSize", GetXrefSize);
@@ -357,6 +359,47 @@ METHOD_RETURN_TYPE PDFReaderDriver::ParsePage(const ARGS_TYPE& args)
         ObjectWrap::Unwrap<PDFPageInputDriver>(newInstance->TO_OBJECT())->PageInputDictionary = newObject.GetPtr();
         SET_FUNCTION_RETURN_VALUE(newInstance)
     }
+}
+
+METHOD_RETURN_TYPE PDFReaderDriver::ExtractPageText(const ARGS_TYPE& args)
+{
+    CREATE_ISOLATE_CONTEXT;
+    CREATE_ESCAPABLE_SCOPE;
+
+    if(args.Length() != 1 || !args[0]->IsNumber())
+    {
+        THROW_EXCEPTION("Wrong arguments. Provide a page index");
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+
+    PDFReaderDriver* reader = ObjectWrap::Unwrap<PDFReaderDriver>(args.This());
+    RefCountPtr<PDFDictionary> page(reader->mPDFReader->ParsePage(TO_UINT32(args[0])->Value()));
+    if(!page)
+    {
+        THROW_EXCEPTION("Unable to read page, page index is wrong or page is null");
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+
+    std::vector<PDFTextElement> elements;
+    if(!PDFTextExtractor().Extract(reader->mPDFReader, page.GetPtr(), elements))
+    {
+        THROW_EXCEPTION("Page content exceeds text extraction limits");
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+    Local<Array> result = NEW_ARRAY(elements.size());
+    for(size_t i = 0; i < elements.size(); ++i)
+    {
+        Local<Object> element = NEW_OBJECT;
+        element->Set(GET_CURRENT_CONTEXT, NEW_STRING("content"), String::NewFromOneByte(isolate, reinterpret_cast<const uint8_t*>(elements[i].content.data()), v8::NewStringType::kNormal, static_cast<int>(elements[i].content.size())).ToLocalChecked());
+        element->Set(GET_CURRENT_CONTEXT, NEW_STRING("fontResource"), NEW_STRING(elements[i].fontResource.c_str()));
+        element->Set(GET_CURRENT_CONTEXT, NEW_STRING("fontSize"), NEW_NUMBER(elements[i].fontSize));
+        Local<Array> textMatrix = NEW_ARRAY(6);
+        for(size_t j = 0; j < 6; ++j)
+            textMatrix->Set(GET_CURRENT_CONTEXT, NEW_NUMBER(j), NEW_NUMBER(elements[i].textMatrix[j]));
+        element->Set(GET_CURRENT_CONTEXT, NEW_STRING("textMatrix"), textMatrix);
+        result->Set(GET_CURRENT_CONTEXT, NEW_NUMBER(i), element);
+    }
+    SET_FUNCTION_RETURN_VALUE(result)
 }
 
 METHOD_RETURN_TYPE PDFReaderDriver::GetObjectsCount(const ARGS_TYPE& args)

--- a/src/PDFReaderDriver.h
+++ b/src/PDFReaderDriver.h
@@ -59,6 +59,7 @@ private:
 	static METHOD_RETURN_TYPE GetPageObjectID(const ARGS_TYPE& args);
 	static METHOD_RETURN_TYPE ParsePageDictionary(const ARGS_TYPE& args);
 	static METHOD_RETURN_TYPE ParsePage(const ARGS_TYPE& args);
+	static METHOD_RETURN_TYPE ExtractPageText(const ARGS_TYPE& args);
 	static METHOD_RETURN_TYPE GetObjectsCount(const ARGS_TYPE& args);
 	static METHOD_RETURN_TYPE IsEncrypted(const ARGS_TYPE& args);
 	static METHOD_RETURN_TYPE GetXrefSize(const ARGS_TYPE& args);

--- a/src/text-extraction/PDFTextExtractor.cpp
+++ b/src/text-extraction/PDFTextExtractor.cpp
@@ -1,0 +1,158 @@
+#include "PDFTextExtractor.h"
+
+#include "PDFArray.h"
+#include "PDFHexString.h"
+#include "PDFInteger.h"
+#include "PDFLiteralString.h"
+#include "PDFName.h"
+#include "PDFObject.h"
+#include "PDFObjectParser.h"
+#include "PDFParser.h"
+#include "PDFReal.h"
+#include "PDFStreamInput.h"
+#include "PDFSymbol.h"
+#include "RefCountPtr.h"
+
+namespace
+{
+const size_t kMaxExtractedElements = 100000;
+const size_t kMaxOperands = 1024;
+const size_t kMaxExtractedTextBytes = 16 * 1024 * 1024;
+const size_t kMaxParsedObjects = 1000000;
+
+double GetNumber(PDFObject* inObject)
+{
+  if (inObject->GetType() == PDFObject::ePDFObjectInteger)
+    return static_cast<double>(static_cast<PDFInteger*>(inObject)->GetValue());
+  if (inObject->GetType() == PDFObject::ePDFObjectReal)
+    return static_cast<PDFReal*>(inObject)->GetValue();
+  return 0;
+}
+
+bool IsTextString(PDFObject* inObject)
+{
+  return inObject &&
+         (inObject->GetType() == PDFObject::ePDFObjectLiteralString ||
+          inObject->GetType() == PDFObject::ePDFObjectHexString);
+}
+
+std::string GetTextString(PDFObject* inObject)
+{
+  if (inObject->GetType() == PDFObject::ePDFObjectLiteralString)
+    return static_cast<PDFLiteralString*>(inObject)->GetValue();
+  return static_cast<PDFHexString*>(inObject)->GetValue();
+}
+
+std::string GetTextArray(PDFArray* inArray)
+{
+  std::string result;
+  for (unsigned long i = 0; i < inArray->GetLength(); ++i)
+  {
+    RefCountPtr<PDFObject> item(inArray->QueryObject(i));
+    if (IsTextString(item.GetPtr()))
+      result += GetTextString(item.GetPtr());
+  }
+  return result;
+}
+
+void SetMatrix(double outMatrix[6], const std::vector<RefCountPtr<PDFObject> >& inOperands)
+{
+  if (inOperands.size() != 6)
+    return;
+  for (size_t i = 0; i < 6; ++i)
+    outMatrix[i] = GetNumber(inOperands[i].GetPtr());
+}
+}
+
+bool PDFTextExtractor::Extract(
+  PDFParser* inParser,
+  PDFDictionary* inPage,
+  std::vector<PDFTextElement>& outElements
+)
+{
+  RefCountPtr<PDFObject> contents(inParser->QueryDictionaryObject(inPage, "Contents"));
+  if (!contents)
+    return true;
+
+  PDFObjectParser* objectParser = NULL;
+  if (contents->GetType() == PDFObject::ePDFObjectStream)
+    objectParser = inParser->StartReadingObjectsFromStream(static_cast<PDFStreamInput*>(contents.GetPtr()));
+  else if (contents->GetType() == PDFObject::ePDFObjectArray)
+    objectParser = inParser->StartReadingObjectsFromStreams(static_cast<PDFArray*>(contents.GetPtr()));
+  if (!objectParser)
+    return true;
+
+  bool inTextObject = false;
+  std::string fontResource;
+  double fontSize = 0;
+  double textMatrix[] = {1, 0, 0, 1, 0, 0};
+  std::vector<RefCountPtr<PDFObject> > operands;
+  PDFObject* object = NULL;
+  size_t extractedTextBytes = 0;
+  size_t parsedObjects = 0;
+  bool withinLimits = true;
+
+  while (withinLimits && (object = objectParser->ParseNewObject()) != NULL)
+  {
+    RefCountPtr<PDFObject> objectHolder(object);
+    if (++parsedObjects > kMaxParsedObjects)
+    {
+      withinLimits = false;
+      break;
+    }
+    if (object->GetType() != PDFObject::ePDFObjectSymbol)
+    {
+      if (operands.size() == kMaxOperands)
+      {
+        withinLimits = false;
+        break;
+      }
+      operands.push_back(objectHolder);
+      continue;
+    }
+
+    std::string operation = static_cast<PDFSymbol*>(object)->GetValue();
+    if (operation == "BT")
+      inTextObject = true;
+    else if (operation == "ET")
+      inTextObject = false;
+    else if (operation == "Tf" && operands.size() == 2)
+    {
+      if (operands[0]->GetType() == PDFObject::ePDFObjectName)
+        fontResource = static_cast<PDFName*>(operands[0].GetPtr())->GetValue();
+      fontSize = GetNumber(operands[1].GetPtr());
+    }
+    else if (operation == "Tm")
+      SetMatrix(textMatrix, operands);
+    else if (inTextObject && (operation == "Tj" || operation == "'" || operation == "\"" || operation == "TJ"))
+    {
+      std::string content;
+      if (operation == "TJ" && operands.size() == 1 && operands[0]->GetType() == PDFObject::ePDFObjectArray)
+        content = GetTextArray(static_cast<PDFArray*>(operands[0].GetPtr()));
+      else if (!operands.empty() && IsTextString(operands.back().GetPtr()))
+        content = GetTextString(operands.back().GetPtr());
+
+      if (!content.empty())
+      {
+        if (outElements.size() == kMaxExtractedElements ||
+            content.size() > kMaxExtractedTextBytes - extractedTextBytes)
+        {
+          withinLimits = false;
+          break;
+        }
+        PDFTextElement element;
+        element.content = content;
+        element.fontResource = fontResource;
+        element.fontSize = fontSize;
+        for (size_t i = 0; i < 6; ++i)
+          element.textMatrix[i] = textMatrix[i];
+        outElements.push_back(element);
+        extractedTextBytes += content.size();
+      }
+    }
+    operands.clear();
+  }
+
+  delete objectParser;
+  return withinLimits;
+}

--- a/src/text-extraction/PDFTextExtractor.h
+++ b/src/text-extraction/PDFTextExtractor.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+class PDFParser;
+class PDFDictionary;
+
+struct PDFTextElement
+{
+  std::string content;
+  std::string fontResource;
+  double fontSize;
+  double textMatrix[6];
+};
+
+class PDFTextExtractor
+{
+public:
+  bool Extract(
+    PDFParser* inParser,
+    PDFDictionary* inPage,
+    std::vector<PDFTextElement>& outElements
+  );
+};

--- a/tests/PDFTextExtractionTest.js
+++ b/tests/PDFTextExtractionTest.js
@@ -1,0 +1,37 @@
+var muhammara = require("../lib/muhammara");
+var assert = require("chai").assert;
+
+describe("PDFTextExtraction", function () {
+  it("returns text operations and their active text state", function () {
+    var output = __dirname + "/output/PDFTextExtraction.pdf";
+    var writer = muhammara.createWriter(output);
+    var page = writer.createPage(0, 0, 200, 200);
+    var font = writer.getFontForFile(
+      __dirname + "/TestMaterials/fonts/arial.ttf",
+    );
+    var context = writer.startPageContentContext(page);
+    context
+      .BT()
+      .Tf(font, 12)
+      .Tm(1, 0, 0, 1, 25, 50)
+      .Tj("first")
+      .Tm(1, 0, 0, 1, 25, 75)
+      .Tj("second")
+      .ET();
+    writer.writePage(page).end();
+
+    var reader = muhammara.createReader(output);
+    var elements = reader.extractPageText(0);
+    reader.end();
+
+    assert.deepEqual(
+      elements.map(function (element) {
+        return element.content;
+      }),
+      ["first", "second"],
+    );
+    assert.equal(elements[0].fontSize, 12);
+    assert.deepEqual(elements[0].textMatrix, [1, 0, 0, 1, 25, 50]);
+    assert.deepEqual(elements[1].textMatrix, [1, 0, 0, 1, 25, 75]);
+  });
+});


### PR DESCRIPTION
## Summary
- add PDFReader.extractPageText() for text-showing page content operations
- expose content, font resource, font size, and text matrix through TypeScript definitions
- bound extraction work and output to protect against malformed content streams

## Testing
- npx node-pre-gyp rebuild
- npx mocha tests/PDFTextExtractionTest.js --timeout 15000
- npm run test:codestyle
- npm test