### PR TITLE
Add bounded Recipe text clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New version of PDF Writer 4.8.1
 - New version of PDF Writer 4.9.0 [#534](https://github.com/julianhille/MuhammaraJS/issues/534)
 - Add `PDFReader.extractPageText()` for enumerating page content-stream text operations.
+- Add opt-in fixed-height clipping and an `onClip` callback to Recipe text boxes
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,27 @@ pdfDoc
   });
 ```
 
+#### Clip text to a fixed-height box
+
+Set `clipIfExceedsBox` to render only complete lines that fit in a text box.
+`onClip` receives the remaining text and the active recipe for writing it elsewhere.
+Do not call `endPage()` or `endPDF()` from `onClip`; finish the page after `text()` returns.
+
+```javascript
+pdfDoc.text(longText, 50, 50, {
+  textBox: {
+    width: 240,
+    height: 100,
+    clipIfExceedsBox: true,
+    onClip(recipe, result) {
+      recipe.text(result.remainder, 320, 50, {
+        textBox: { width: 240, height: 100, clipIfExceedsBox: true },
+      });
+    },
+  },
+});
+```
+
 #### Create a new PDF as a Buffer
 
 ```javascript

--- a/lib/recipe/text.js
+++ b/lib/recipe/text.js
@@ -180,6 +180,8 @@ exports._makeTextBox = function _makeTextBox(options) {
         minHeight: options.textBox.minHeight || 0,
         style: options.textBox.style,
         textAlign: options.textBox.textAlign,
+        clipIfExceedsBox: options.textBox.clipIfExceedsBox,
+        onClip: options.textBox.onClip,
         wrap:
           options.textBox.wrap !== undefined ? options.textBox.wrap : "auto",
       };
@@ -232,6 +234,9 @@ exports._makeTextBox = function _makeTextBox(options) {
  *  how the text which does not fit on a line is to be truncated. True is equivalent to 'auto'. False is equivalent to 'ellipsis'.
  * @param {string} [options.textBox.textAlign='left top'] - Alignment inside text box, specified as 'horizontal vertical',
  * where horizontal is one of: 'left', 'center', 'right', 'justify' and veritical is one of: 'top', 'center', 'bottom'.
+ * @param {boolean} [options.textBox.clipIfExceedsBox=false] - Render only complete lines that fit within the text box height.
+ * @param {function} [options.textBox.onClip] - Called as onClip(recipe, result) when clipping leaves text unrendered.
+ * Do not call endPage() or endPDF() in this callback because the text operation is still active.
  * @param {Object} [options.textBox.style] - Text Box styles
  * @param {number} [options.textBox.style.lineWidth=2] - Text Box border width
  * @param {string|number[]} [options.textBox.style.stroke] - Text Box border color  (HexColor, PercentColor or DecimalColor)
@@ -279,6 +284,12 @@ exports.text = function text(text = "", x, y, options = {}) {
     : this._makeTextObject(text, pathOptions.size, options);
   const textBox = this._makeTextBox(options);
 
+  if (textBox.onClip && !textBox.clipIfExceedsBox) {
+    console.warn(
+      "textBox.onClip will not be called unless textBox.clipIfExceedsBox is true.",
+    );
+  }
+
   let { toWriteTextObjects } = this._layoutText(
     textObjects,
     textBox,
@@ -296,6 +307,31 @@ exports.text = function text(text = "", x, y, options = {}) {
     this._previousTextObjects = [...toWriteTextObjects];
   } else {
     textBox.textHeight = getTextBoxHeight(toWriteTextObjects);
+
+    let clipResult;
+    if (textBox.clipIfExceedsBox && textBox.height !== undefined) {
+      const clippedText = clipTextToBox(
+        toWriteTextObjects,
+        textBox.height - textBox.paddingTop - textBox.paddingBottom,
+      );
+      toWriteTextObjects = clippedText.textObjects;
+      textBox.textHeight = getTextBoxHeight(toWriteTextObjects);
+
+      if (clippedText.remainder.length) {
+        clipResult = {
+          remainder: clippedText.remainder,
+          linesWritten: clippedText.linesWritten,
+          clipped: true,
+          bounds: {
+            x: this.x,
+            y: this.y,
+            width: textBox.width,
+            height: textBox.height,
+          },
+        };
+      }
+    }
+
     let [nx, ny] = getTextBoxPosition(this, textBox, pathOptions);
     let textYpos = ny;
 
@@ -316,7 +352,11 @@ exports.text = function text(text = "", x, y, options = {}) {
     }
 
     // Determine vertical starting position of text within textBox
-    switch (toWriteTextObjects[0].writeOptions.alignVertical) {
+    switch (
+      toWriteTextObjects.length
+        ? toWriteTextObjects[0].writeOptions.alignVertical
+        : undefined
+    ) {
       case "center":
         textYpos -=
           (textBox.height - textBox.textHeight) / 2 - textBox.paddingTop;
@@ -708,6 +748,11 @@ exports.text = function text(text = "", x, y, options = {}) {
         }
       }
     });
+
+    if (clipResult && typeof textBox.onClip === "function") {
+      // The active text operation owns the page context until it returns.
+      textBox.onClip(this, clipResult);
+    }
   }
 
   return this;
@@ -867,6 +912,49 @@ function getTextBoxHeight(textObjs) {
   }
 
   return height;
+}
+
+function clipTextToBox(textObjs, availableHeight) {
+  const lines = [];
+  let line = [];
+  let lineID;
+
+  textObjs.forEach((textObj) => {
+    if (line.length && lineID !== textObj.lineID) {
+      lines.push(line);
+      line = [];
+    }
+    lineID = textObj.lineID;
+    line.push(textObj);
+  });
+
+  if (line.length) {
+    lines.push(line);
+  }
+
+  let usedHeight = 0;
+  let linesWritten = 0;
+  const visibleLines = [];
+  for (const currentLine of lines) {
+    const lastSegment = currentLine[currentLine.length - 1];
+    const lineHeight = lastSegment.lineHeight * lastSegment.lineOffset;
+    if (usedHeight + lineHeight > availableHeight) {
+      break;
+    }
+    visibleLines.push(currentLine);
+    usedHeight += lineHeight;
+    linesWritten++;
+  }
+
+  const remainderLines = lines.slice(linesWritten);
+  return {
+    textObjects: visibleLines.flat(),
+    linesWritten,
+    // Preserve line boundaries so a remainder can be written into another box.
+    remainder: remainderLines
+      .map((currentLine) => currentLine.map((textObj) => textObj.text).join(""))
+      .join("\n"),
+  };
 }
 
 function getTextBoxPosition(self, textBox, pathOptions) {

--- a/muhammara.d.ts
+++ b/muhammara.d.ts
@@ -978,6 +978,18 @@ declare module "muhammara" {
       opacity?: number;
     }
 
+    interface TextBoxClipResult {
+      remainder: string;
+      linesWritten: number;
+      clipped: true;
+      bounds: {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+      };
+    }
+
     interface TextBox {
       width?: number;
       height?: number;
@@ -985,6 +997,8 @@ declare module "muhammara" {
       padding?: number | number[];
       lineHeight?: number;
       textAlign?: string;
+      clipIfExceedsBox?: boolean;
+      onClip?: (recipe: Recipe, result: TextBoxClipResult) => void;
       style?: TextBoxStyle;
     }
 

--- a/tests/recipe/text-clip.js
+++ b/tests/recipe/text-clip.js
@@ -1,0 +1,71 @@
+const assert = require("assert");
+const path = require("path");
+const Recipe = require("../../lib").Recipe;
+
+describe("Text box clipping", () => {
+  it("clips complete lines and reports the remainder", (done) => {
+    const output = path.join(__dirname, "../output/text-box-clipping.pdf");
+    const recipe = new Recipe("new", output);
+    let callbackRecipe;
+    let clipResult;
+
+    recipe
+      .createPage("letter")
+      .text(
+        "First line of text that fits. Second line of text that must be clipped.",
+        50,
+        50,
+        {
+          size: 12,
+          textBox: {
+            width: 200,
+            height: 15,
+            clipIfExceedsBox: true,
+            onClip: (currentRecipe, result) => {
+              callbackRecipe = currentRecipe;
+              clipResult = result;
+            },
+          },
+        },
+      )
+      .endPage()
+      .endPDF(() => {
+        assert.strictEqual(callbackRecipe, recipe);
+        assert.strictEqual(clipResult.clipped, true);
+        assert.strictEqual(clipResult.linesWritten, 1);
+        assert.ok(clipResult.remainder.length > 0);
+        assert.deepStrictEqual(clipResult.bounds, {
+          x: 50,
+          y: 50,
+          width: 200,
+          height: 15,
+        });
+        done();
+      });
+  });
+
+  it("warns when onClip is configured without clipping", (done) => {
+    const output = path.join(__dirname, "../output/text-box-clip-warning.pdf");
+    const recipe = new Recipe("new", output);
+    const originalWarn = console.warn;
+    let warning;
+    console.warn = (message) => {
+      warning = message;
+    };
+
+    recipe
+      .createPage("letter")
+      .text("Text", 50, 50, {
+        textBox: { width: 100, height: 20, onClip: () => {} },
+      })
+      .endPage()
+      .endPDF(() => {
+        console.warn = originalWarn;
+        assert.strictEqual(
+          warning,
+          "textBox.onClip will not be called unless textBox.clipIfExceedsBox is true.",
+        );
+        done();
+      });
+  });
+});


### PR DESCRIPTION
## Summary

- add opt-in fixed-height text-box clipping and an onClip callback with the remaining text
- warn when onClip is configured without clipping
- document and type the new options and add regression coverage

## Testing

- npm test
- npx prettier --check "README.md" "CHANGELOG.md" "lib/recipe/text.js" "muhammara.d.ts" "tests/recipe/text-clip.js"