### PR TITLE
Expose PDF 2.0 writer support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add context opacity support for transparent text [#496](https://github.com/julianhille/MuhammaraJS/issues/496)
 - New version of PDF Writer 4.8.1
 - New version of PDF Writer 4.9.0 [#534](https://github.com/julianhille/MuhammaraJS/issues/534)
+- Expose PDF 2.0 writer support [#551](https://github.com/julianhille/MuhammaraJS/issues/551)
 
 ### Fixed
 

--- a/docs/Basic-pdf-creation.md
+++ b/docs/Basic-pdf-creation.md
@@ -21,7 +21,7 @@ You can alternatively pass a stream object, which is simply an object implementi
 
 The second, optional, object provide options for the PDF file creation. It may have the following members:
 
-- `version` - a number value stating the version of the desired PDF. default is 13 (PDF 1.3). Any number between 10 and 17 works. You can use `hummus. ePDFVersion10` to `hummus.ePDFVersion13` if you prefer nice symbols.
+- `version` - a number value stating the version of the desired PDF. Default is 13 (PDF 1.3). Supported values are 10 through 17 and 20 (PDF 2.0). Use `hummus.ePDFVersion10` through `hummus.ePDFVersion17`, or `hummus.ePDFVersion20`, if you prefer named constants.
 - `compress` - the PDF streams are normally compressed using flate compression. If you want to cancel this (maybe for debugging, or whatnot), set this member value to false.
 - `log` - For debugging purposes, if something goes wrong, use this option to allow the internal library to provide some log notes. log parameter should be set to a file path where the end result log should reside in.Note! when using the log the module/library is no longer thread safe. So unless for debugging, avoid.
 

--- a/muhammara.d.ts
+++ b/muhammara.d.ts
@@ -310,7 +310,8 @@ declare module "muhammara" {
   export const ePDFVersion15 = 15;
   export const ePDFVersion16 = 16;
   export const ePDFVersion17 = 17;
-  export type EPDFVersion = 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17;
+  export const ePDFVersion20 = 20;
+  export type EPDFVersion = 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 20;
 
   export const ePDFObjectBoolean = 0;
   export const ePDFObjectLiteralString = 1;

--- a/src/muhammara.cpp
+++ b/src/muhammara.cpp
@@ -593,6 +593,7 @@ DEF_INIT(MuhammaraInit) {
     EXPORTS_SET(exports,NEW_SYMBOL("ePDFVersion15"),NEW_NUMBER(ePDFVersion15))
     EXPORTS_SET(exports,NEW_SYMBOL("ePDFVersion16"),NEW_NUMBER(ePDFVersion16))
     EXPORTS_SET(exports,NEW_SYMBOL("ePDFVersion17"),NEW_NUMBER(ePDFVersion17))
+    EXPORTS_SET(exports,NEW_SYMBOL("ePDFVersion20"),NEW_NUMBER(ePDFVersion20))
     EXPORTS_SET(exports,NEW_SYMBOL("ePDFVersionUndefined"),NEW_NUMBER(ePDFVersionUndefined))
     
     // procsets for resource inclusion

--- a/tests/PDFVersionTest.js
+++ b/tests/PDFVersionTest.js
@@ -1,0 +1,31 @@
+var assert = require("chai").assert;
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+var muhammara = require("../lib/muhammara");
+
+describe("PDF versions", function () {
+  var outputDirectory;
+
+  beforeEach(function () {
+    outputDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), "muhammara-version-"),
+    );
+  });
+
+  afterEach(function () {
+    fs.rmSync(outputDirectory, { recursive: true, force: true });
+  });
+
+  it("creates a PDF 2.0 document", function () {
+    var outputPath = path.join(outputDirectory, "version-20.pdf");
+    var writer = muhammara.createWriter(outputPath, {
+      version: muhammara.ePDFVersion20,
+    });
+
+    writer.writePage(writer.createPage(0, 0, 100, 100));
+    writer.end();
+
+    assert.match(fs.readFileSync(outputPath, "latin1"), /^%PDF-2\.0/);
+  });
+});


### PR DESCRIPTION
## Summary

- export the existing native `ePDFVersion20` constant
- add PDF 2.0 to TypeScript declarations and creation documentation
- add a regression test that verifies a PDF 2.0 header

Closes #551.

## Testing

- `npm test`
- `npx prettier --check CHANGELOG.md muhammara.d.ts docs/Basic-pdf-creation.md tests/PDFVersionTest.js`
- `git diff --check`