### PR TITLE
Add low-level page object replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bundle pinned OpenSSL 3.5.4 statically in official native prebuilts.
 - Speed up native source builds with parallel compilation and ccache-backed CI caches [#562](https://github.com/julianhille/MuhammaraJS/issues/562)
 - Add `PDFWriter.replaceObject()` for page-scoped indirect object replacement, with optional global scope [#315](https://github.com/julianhille/MuhammaraJS/issues/315)
+- Add `Recipe.replaceText()` for replacing literal text in a page content stream [#315](https://github.com/julianhille/MuhammaraJS/issues/315)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add opt-in fixed-height clipping and an `onClip` callback to Recipe text boxes
 - Bundle pinned OpenSSL 3.5.4 statically in official native prebuilts.
 - Speed up native source builds with parallel compilation and ccache-backed CI caches [#562](https://github.com/julianhille/MuhammaraJS/issues/562)
-- Add `PDFWriter.replaceObject()` for page-scoped indirect object replacement [#315](https://github.com/julianhille/MuhammaraJS/issues/315)
+- Add `PDFWriter.replaceObject()` for page-scoped indirect object replacement, with optional global scope [#315](https://github.com/julianhille/MuhammaraJS/issues/315)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add `PDFWriter.replaceObject()` for page-scoped indirect object replacement, with optional global scope [#315](https://github.com/julianhille/MuhammaraJS/issues/315)
+- Add `Recipe.replaceText()` for replacing literal text in a page content stream [#315](https://github.com/julianhille/MuhammaraJS/issues/315)
+
 ### Fixed
 
 - Generate native API reference pages during Read the Docs builds and cache the
@@ -51,8 +56,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add opt-in fixed-height clipping and an `onClip` callback to Recipe text boxes
 - Bundle pinned OpenSSL 3.5.4 statically in official native prebuilts.
 - Speed up native source builds with parallel compilation and ccache-backed CI caches [#562](https://github.com/julianhille/MuhammaraJS/issues/562)
-- Add `PDFWriter.replaceObject()` for page-scoped indirect object replacement, with optional global scope [#315](https://github.com/julianhille/MuhammaraJS/issues/315)
-- Add `Recipe.replaceText()` for replacing literal text in a page content stream [#315](https://github.com/julianhille/MuhammaraJS/issues/315)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add opt-in fixed-height clipping and an `onClip` callback to Recipe text boxes
 - Bundle pinned OpenSSL 3.5.4 statically in official native prebuilts.
 - Speed up native source builds with parallel compilation and ccache-backed CI caches [#562](https://github.com/julianhille/MuhammaraJS/issues/562)
+- Add `PDFWriter.replaceObject()` for page-scoped indirect object replacement [#315](https://github.com/julianhille/MuhammaraJS/issues/315)
 
 ### Fixed
 

--- a/packages/native-core/index.js
+++ b/packages/native-core/index.js
@@ -23,6 +23,39 @@ exports.createMuhammara = function createMuhammara(muhammara) {
     eventParams.writer = this;
     this.getEvents().emit(eventName, eventParams);
   };
+  muhammara.PDFWriter.prototype.replaceObject = function (
+    pageIndex,
+    sourceObjectId,
+    replacementObjectId,
+  ) {
+    var copyingContext = this.createPDFCopyingContextForModifiedFile();
+    var parser = copyingContext.getSourceDocumentParser();
+    var pageObjectId = parser.getPageObjectID(pageIndex);
+    var pageObject = parser.parsePage(pageIndex).getDictionary().toJSObject();
+    var objectsContext = this.getObjectsContext();
+    var pageDictionary;
+
+    objectsContext.startModifiedIndirectObject(pageObjectId);
+    pageDictionary = objectsContext.startDictionary();
+
+    Object.getOwnPropertyNames(pageObject).forEach(function (key) {
+      var value = pageObject[key];
+
+      pageDictionary.writeKey(key);
+      if (
+        value.getType() === muhammara.ePDFObjectIndirectObjectReference &&
+        value.toPDFIndirectObjectReference().getObjectID() === sourceObjectId
+      ) {
+        pageDictionary.writeObjectReferenceValue(replacementObjectId);
+      } else {
+        copyingContext.copyDirectObjectAsIs(value);
+      }
+    });
+
+    objectsContext.endDictionary(pageDictionary).endIndirectObject();
+    copyingContext.end();
+    return this;
+  };
   muhammara.PDFStreamForResponse = require("./lib/PDFStreamForResponse");
   muhammara.PDFWStreamForFile = require("./lib/PDFWStreamForFile");
   muhammara.PDFRStreamForFile = require("./lib/PDFRStreamForFile");

--- a/packages/native-core/index.js
+++ b/packages/native-core/index.js
@@ -27,7 +27,19 @@ exports.createMuhammara = function createMuhammara(muhammara) {
     pageIndex,
     sourceObjectId,
     replacementObjectId,
+    options,
   ) {
+    if (options && options.scope === "global") {
+      var copyingContext = this.createPDFCopyingContextForModifiedFile();
+      var pageCount = copyingContext.getSourceDocumentParser().getPagesCount();
+
+      copyingContext.end();
+      for (var index = 0; index < pageCount; ++index) {
+        this.replaceObject(index, sourceObjectId, replacementObjectId);
+      }
+      return this;
+    }
+
     var copyingContext = this.createPDFCopyingContextForModifiedFile();
     var parser = copyingContext.getSourceDocumentParser();
     var pageObjectId = parser.getPageObjectID(pageIndex);

--- a/packages/native-core/lib/recipe/replaceText.js
+++ b/packages/native-core/lib/recipe/replaceText.js
@@ -7,7 +7,7 @@ function escapePDFLiteralString(value) {
  *
  * @name replaceText
  * @function
- * @memberof Recipe
+ * @memberof Recipe#
  * @param {string} text Text to replace.
  * @param {string} replacement Replacement text.
  * @param {number} [pageNumber=1] One-based page number.

--- a/packages/native-core/lib/recipe/replaceText.js
+++ b/packages/native-core/lib/recipe/replaceText.js
@@ -1,0 +1,64 @@
+function escapePDFLiteralString(value) {
+  return value.replace(/([\\()])/g, "\\$1");
+}
+
+/**
+ * Replace literal text-showing operands in a page's single content stream.
+ *
+ * @name replaceText
+ * @function
+ * @memberof Recipe
+ * @param {string} text Text to replace.
+ * @param {string} replacement Replacement text.
+ * @param {number} [pageNumber=1] One-based page number.
+ */
+exports.replaceText = function replaceText(text, replacement, pageNumber) {
+  pageNumber = pageNumber || 1;
+
+  if (typeof text !== "string" || typeof replacement !== "string") {
+    throw new TypeError("replaceText expects text and replacement strings");
+  }
+
+  var pageIndex = pageNumber - 1;
+  var page = this.pdfReader.parsePage(pageIndex).getDictionary();
+  var contents = page.queryObject("Contents");
+
+  if (
+    !contents ||
+    contents.getType() !== this.muhammara.ePDFObjectIndirectObjectReference
+  ) {
+    throw new Error("replaceText supports pages with one content stream");
+  }
+
+  var contentsObjectId = contents.toPDFIndirectObjectReference().getObjectID();
+  var stream = this.pdfReader.parseNewObject(contentsObjectId).toPDFStream();
+  var streamReader = this.pdfReader.startReadingFromStream(stream);
+  var chunks = [];
+
+  while (streamReader.notEnded()) {
+    chunks.push(Buffer.from(streamReader.read(65536)));
+  }
+
+  var source = Buffer.concat(chunks).toString("latin1");
+  var textPattern = new RegExp(
+    "\\(" + escapePDFLiteralString(text) + "\\)(\\s+Tj\\b)",
+    "g",
+  );
+  var replaced = source.replace(
+    textPattern,
+    "(" + escapePDFLiteralString(replacement) + ")$1",
+  );
+
+  if (replaced === source) {
+    return this;
+  }
+
+  var objectsContext = this.writer.getObjectsContext();
+  var replacementObjectId = objectsContext.startNewIndirectObject();
+  var replacementStream = objectsContext.startUnfilteredPDFStream();
+
+  replacementStream.getWriteStream().write(Array.from(Buffer.from(replaced)));
+  objectsContext.endPDFStream(replacementStream).endIndirectObject();
+  this.writer.replaceObject(pageIndex, contentsObjectId, replacementObjectId);
+  return this;
+};

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -755,6 +755,7 @@ declare namespace muhammara {
       pageIndex: number,
       sourceObjectId: number,
       replacementObjectId: number,
+      options?: ObjectReplacementOptions,
     ): this;
     end(): PDFWriter;
     createPage(x: PosX, y: PosY, width: Width, height: Height): PDFPage;
@@ -852,6 +853,10 @@ declare namespace muhammara {
       eventName: string | symbol,
       eventParams: any,
     ): void;
+  }
+
+  export interface ObjectReplacementOptions {
+    scope?: "global";
   }
 
   namespace Recipe {

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -747,6 +747,15 @@ declare namespace muhammara {
   export type inInterPagesCallback = () => {};
 
   export interface PDFWriter {
+    /**
+     * Replace direct references to an object in a page dictionary.
+     * Available only when modifying an existing PDF.
+     */
+    replaceObject(
+      pageIndex: number,
+      sourceObjectId: number,
+      replacementObjectId: number,
+    ): this;
     end(): PDFWriter;
     createPage(x: PosX, y: PosY, width: Width, height: Height): PDFPage;
     createPage(): PDFPage;

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -1193,6 +1193,8 @@ declare namespace muhammara {
 
     editPage(pageNumber: number): Recipe;
 
+    replaceText(text: string, replacement: string, pageNumber?: number): Recipe;
+
     pageInfo(pageNumber: number): {
       width: number;
       height: number;

--- a/packages/native-with-source/docs/tests/modify-pdfs.js
+++ b/packages/native-with-source/docs/tests/modify-pdfs.js
@@ -1,0 +1,81 @@
+var assert = require("chai").assert;
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+var muhammara = require("@muhammara/native-with-source");
+require.cache[require.resolve("@muhammara/native")] = { exports: muhammara };
+var replacePageObject = require("../../../native/docs/examples/replace-page-object");
+var replaceRecipeText = require("../../../native/docs/examples/replace-recipe-text");
+
+var fontPath = path.join(
+  __dirname,
+  "../../tests/TestMaterials/fonts/arial.ttf",
+);
+
+function getPageContentsId(reader, pageIndex) {
+  return reader
+    .parsePage(pageIndex)
+    .getDictionary()
+    .queryObject("Contents")
+    .toPDFIndirectObjectReference()
+    .getObjectID();
+}
+
+function writeSourcePdf(sourcePath) {
+  var writer = muhammara.createWriter(sourcePath);
+  var page = writer.createPage(0, 0, 200, 200);
+
+  writer
+    .startPageContentContext(page)
+    .BT()
+    .Tf(writer.getFontForFile(fontPath), 12)
+    .Tm(1, 0, 0, 1, 20, 30)
+    .Tj("Before")
+    .ET();
+  writer.writePage(page);
+  writer.end();
+}
+
+describe("Documentation examples", function () {
+  var outputDirectory;
+  var sourcePath;
+
+  beforeEach(function () {
+    outputDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "muhammara-docs-"));
+    sourcePath = path.join(outputDirectory, "source.pdf");
+    writeSourcePdf(sourcePath);
+  });
+
+  afterEach(function () {
+    fs.rmSync(outputDirectory, { recursive: true, force: true });
+  });
+
+  it("replaces a page object", function () {
+    var outputPath = path.join(outputDirectory, "replaced-object.pdf");
+    var sourceReader = muhammara.createReader(sourcePath);
+    var sourceContentsId = getPageContentsId(sourceReader, 0);
+
+    sourceReader.end();
+    replacePageObject(sourcePath, outputPath);
+
+    var reader = muhammara.createReader(outputPath);
+
+    assert.notStrictEqual(getPageContentsId(reader, 0), sourceContentsId);
+    assert.deepStrictEqual(reader.extractPageText(0), []);
+    reader.end();
+  });
+
+  it("replaces literal Recipe text", function () {
+    var outputPath = path.join(outputDirectory, "replaced-text.pdf");
+
+    replaceRecipeText(sourcePath, outputPath);
+
+    var reader = muhammara.createReader(outputPath);
+    var text = reader.extractPageText(0);
+
+    assert.strictEqual(text.length, 1);
+    assert.strictEqual(text[0].content, "After");
+    assert.deepStrictEqual(text[0].textMatrix, [1, 0, 0, 1, 20, 30]);
+    reader.end();
+  });
+});

--- a/packages/native-with-source/tests/ObjectReplacementTest.js
+++ b/packages/native-with-source/tests/ObjectReplacementTest.js
@@ -1,0 +1,60 @@
+var expect = require("chai").expect;
+var muhammara = require("..");
+
+function getPageContentsID(reader, pageIndex) {
+  return reader
+    .parsePage(pageIndex)
+    .getDictionary()
+    .queryObject("Contents")
+    .toPDFIndirectObjectReference()
+    .getObjectID();
+}
+
+describe("ObjectReplacement", function () {
+  it("replaces a direct object reference on only the specified page", function () {
+    var sourcePath = __dirname + "/output/ObjectReplacementSource.PDF";
+    var outputPath = __dirname + "/output/ObjectReplacementOutput.PDF";
+    var sourceWriter = muhammara.createWriter(sourcePath);
+    var firstPage = sourceWriter.createPage(0, 0, 200, 200);
+    var secondPage = sourceWriter.createPage(0, 0, 200, 200);
+
+    sourceWriter
+      .startPageContentContext(firstPage)
+      .q()
+      .k(100, 0, 0, 0)
+      .re(10, 10, 100, 100)
+      .f()
+      .Q();
+    sourceWriter.writePage(firstPage);
+    sourceWriter
+      .startPageContentContext(secondPage)
+      .q()
+      .k(0, 100, 0, 0)
+      .re(20, 20, 100, 100)
+      .f()
+      .Q();
+    sourceWriter.writePage(secondPage);
+    sourceWriter.end();
+
+    var sourceReader = muhammara.createReader(sourcePath);
+    var firstPageContentsID = getPageContentsID(sourceReader, 0);
+    var secondPageContentsID = getPageContentsID(sourceReader, 1);
+    sourceReader.end();
+
+    var writer = muhammara.createWriterToModify(sourcePath, {
+      modifiedFilePath: outputPath,
+    });
+    var objectsContext = writer.getObjectsContext();
+    var replacementObjectID = objectsContext.startNewIndirectObject();
+    var replacementStream = objectsContext.startPDFStream();
+
+    objectsContext.endPDFStream(replacementStream).endIndirectObject();
+    writer.replaceObject(0, firstPageContentsID, replacementObjectID);
+    writer.end();
+
+    var resultReader = muhammara.createReader(outputPath);
+    expect(getPageContentsID(resultReader, 0)).to.equal(replacementObjectID);
+    expect(getPageContentsID(resultReader, 1)).to.equal(secondPageContentsID);
+    resultReader.end();
+  });
+});

--- a/packages/native-with-source/tests/ObjectReplacementTest.js
+++ b/packages/native-with-source/tests/ObjectReplacementTest.js
@@ -57,4 +57,58 @@ describe("ObjectReplacement", function () {
     expect(getPageContentsID(resultReader, 1)).to.equal(secondPageContentsID);
     resultReader.end();
   });
+
+  it("replaces matching page references globally when requested", function () {
+    var sourcePath = __dirname + "/output/ObjectReplacementGlobalSource.PDF";
+    var sharedPath = __dirname + "/output/ObjectReplacementShared.PDF";
+    var outputPath = __dirname + "/output/ObjectReplacementGlobalOutput.PDF";
+    var sourceWriter = muhammara.createWriter(sourcePath);
+    var firstPage = sourceWriter.createPage(0, 0, 200, 200);
+    var secondPage = sourceWriter.createPage(0, 0, 200, 200);
+
+    sourceWriter
+      .startPageContentContext(firstPage)
+      .q()
+      .re(10, 10, 10, 10)
+      .f()
+      .Q();
+    sourceWriter.writePage(firstPage);
+    sourceWriter
+      .startPageContentContext(secondPage)
+      .q()
+      .re(20, 20, 10, 10)
+      .f()
+      .Q();
+    sourceWriter.writePage(secondPage);
+    sourceWriter.end();
+
+    var sourceReader = muhammara.createReader(sourcePath);
+    var firstPageContentsID = getPageContentsID(sourceReader, 0);
+    var secondPageContentsID = getPageContentsID(sourceReader, 1);
+    sourceReader.end();
+
+    var sharingWriter = muhammara.createWriterToModify(sourcePath, {
+      modifiedFilePath: sharedPath,
+    });
+    sharingWriter.replaceObject(1, secondPageContentsID, firstPageContentsID);
+    sharingWriter.end();
+
+    var writer = muhammara.createWriterToModify(sharedPath, {
+      modifiedFilePath: outputPath,
+    });
+    var objectsContext = writer.getObjectsContext();
+    var replacementObjectID = objectsContext.startNewIndirectObject();
+    var replacementStream = objectsContext.startPDFStream();
+
+    objectsContext.endPDFStream(replacementStream).endIndirectObject();
+    writer.replaceObject(0, firstPageContentsID, replacementObjectID, {
+      scope: "global",
+    });
+    writer.end();
+
+    var resultReader = muhammara.createReader(outputPath);
+    expect(getPageContentsID(resultReader, 0)).to.equal(replacementObjectID);
+    expect(getPageContentsID(resultReader, 1)).to.equal(replacementObjectID);
+    resultReader.end();
+  });
 });

--- a/packages/native-with-source/tests/recipe/replaceText.js
+++ b/packages/native-with-source/tests/recipe/replaceText.js
@@ -1,0 +1,33 @@
+var expect = require("chai").expect;
+var path = require("path");
+var muhammara = require("../..");
+var Recipe = muhammara.Recipe;
+
+describe("Replace text", function () {
+  it("replaces text at its existing position", function () {
+    var source = path.join(__dirname, "../output/Replace text source.pdf");
+    var output = path.join(__dirname, "../output/Replace text output.pdf");
+    var writer = muhammara.createWriter(source);
+    var page = writer.createPage(0, 0, 200, 200);
+
+    writer
+      .startPageContentContext(page)
+      .BT()
+      .Tf(writer.getFontForFile("../TestMaterials/fonts/arial.ttf"), 12)
+      .Tm(1, 0, 0, 1, 20, 30)
+      .Tj("Before")
+      .ET();
+    writer.writePage(page);
+    writer.end();
+
+    new Recipe(source, output).replaceText("Before", "After").endPDF();
+
+    var reader = muhammara.createReader(output);
+    var text = reader.extractPageText(0);
+
+    expect(text).to.have.lengthOf(1);
+    expect(text[0].content).to.equal("After");
+    expect(text[0].textMatrix).to.deep.equal([1, 0, 0, 1, 20, 30]);
+    reader.end();
+  });
+});

--- a/packages/native-with-source/tests/recipe/replaceText.js
+++ b/packages/native-with-source/tests/recipe/replaceText.js
@@ -13,7 +13,12 @@ describe("Replace text", function () {
     writer
       .startPageContentContext(page)
       .BT()
-      .Tf(writer.getFontForFile("../TestMaterials/fonts/arial.ttf"), 12)
+      .Tf(
+        writer.getFontForFile(
+          path.join(__dirname, "../TestMaterials/fonts/arial.ttf"),
+        ),
+        12,
+      )
       .Tm(1, 0, 0, 1, 20, 30)
       .Tj("Before")
       .ET();

--- a/packages/native/docs/examples/replace-page-object.js
+++ b/packages/native/docs/examples/replace-page-object.js
@@ -1,0 +1,27 @@
+var muhammara = require("@muhammara/native");
+
+function replacePageObject(inputPath, outputPath) {
+  var reader = muhammara.createReader(inputPath);
+  var contentsId = reader
+    .parsePage(0)
+    .getDictionary()
+    .queryObject("Contents")
+    .toPDFIndirectObjectReference()
+    .getObjectID();
+
+  reader.end();
+
+  var writer = muhammara.createWriterToModify(inputPath, {
+    modifiedFilePath: outputPath,
+  });
+  var objectsContext = writer.getObjectsContext();
+  var replacementId = objectsContext.startNewIndirectObject();
+  var replacement = objectsContext.startPDFStream();
+
+  replacement.getWriteStream().write(Array.from(Buffer.from("BT ET")));
+  objectsContext.endPDFStream(replacement).endIndirectObject();
+  writer.replaceObject(0, contentsId, replacementId);
+  writer.end();
+}
+
+module.exports = replacePageObject;

--- a/packages/native/docs/examples/replace-recipe-text.js
+++ b/packages/native/docs/examples/replace-recipe-text.js
@@ -1,0 +1,7 @@
+var Recipe = require("@muhammara/native").Recipe;
+
+function replaceRecipeText(inputPath, outputPath) {
+  new Recipe(inputPath, outputPath).replaceText("Before", "After").endPDF();
+}
+
+module.exports = replaceRecipeText;

--- a/packages/native/docs/low-level/modify-pdfs.md
+++ b/packages/native/docs/low-level/modify-pdfs.md
@@ -13,6 +13,47 @@ To add content to an existing page, use `PDFPageModifier`, start its context,
 draw content, end the context, and write the page. Passing `true` as the third
 constructor argument isolates new graphics from the existing graphics state.
 
+## Replace an Indirect Object
+
+`replaceObject(pageIndex, sourceObjectId, replacementObjectId, options)` rewrites
+a page dictionary so every direct reference to `sourceObjectId` points at
+`replacementObjectId` instead. `pageIndex` is zero-based, and the method is
+available only on a writer created with `createWriterToModify`.
+
+```javascript
+var reader = muhammara.createReader("input.pdf");
+var contentsId = reader
+  .parsePage(0)
+  .getDictionary()
+  .queryObject("Contents")
+  .toPDFIndirectObjectReference()
+  .getObjectID();
+
+reader.end();
+
+var writer = muhammara.createWriterToModify("input.pdf", {
+  modifiedFilePath: "output.pdf",
+});
+var objectsContext = writer.getObjectsContext();
+var replacementId = objectsContext.startNewIndirectObject();
+var replacement = objectsContext.startPDFStream();
+
+replacement.getWriteStream().write(Array.from(Buffer.from("BT ET")));
+objectsContext.endPDFStream(replacement).endIndirectObject();
+writer.replaceObject(0, contentsId, replacementId);
+writer.end();
+```
+
+Only the named page is rewritten, so an object shared by several pages keeps its
+old reference elsewhere. Pass `{ scope: "global" }` to apply the same
+replacement to every page instead.
+
+```javascript
+writer.replaceObject(0, contentsId, replacementId, { scope: "global" });
+```
+
+See [`tests/ObjectReplacementTest.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/ObjectReplacementTest.js) for verified examples.
+
 Modification uses incremental PDF updates, but this documentation does not make
 signature-preservation guarantees. See [`tests/BasicModification2.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/BasicModification2.js),
 [`tests/ModifyExistingPageContent.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/ModifyExistingPageContent.js), and [`tests/BasicModificationWithStreams.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/BasicModificationWithStreams.js).

--- a/packages/native/docs/recipe/modify-and-inspect.md
+++ b/packages/native/docs/recipe/modify-and-inspect.md
@@ -22,4 +22,22 @@ call `structure` on the Recipe instance:
 pdfDoc.structure("pdf-structure.txt").endPDF();
 ```
 
+## Replace Literal Text
+
+`replaceText(text, replacement, pageNumber)` rewrites literal text-showing
+operands in a page's content stream, leaving the surrounding text position and
+font untouched. `pageNumber` is one-based and defaults to the first page.
+
+```javascript
+new Recipe("input.pdf", "output.pdf").replaceText("Before", "After").endPDF();
+```
+
+The match is on the literal string as it appears in the content stream, so text
+split across several show operations, or encoded through a font that does not
+map to the source characters, is not replaced. Pages with more than one content
+stream are rejected with an error. When nothing matches, the page is left
+unchanged.
+
+See [`tests/recipe/replaceText.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/replaceText.js) for a verified example.
+
 See [`tests/recipe/modify.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/modify.js) and [`tests/recipe/info.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/info.js) for verified examples.

--- a/packages/wasm/docs/low-level.md
+++ b/packages/wasm/docs/low-level.md
@@ -25,6 +25,16 @@ page through `createPageModifier(index?, ensureContentEncapsulation?)`. Its
 `end()` returns a new `Uint8Array`. `createModifier(bytes)` is the compact
 drawing facade.
 
+A writer created with `createWriterToModify` also exposes
+`replaceObject(pageIndex, sourceObjectId, replacementObjectId, options?)`, which
+repoints every direct reference to `sourceObjectId` in the zero-based page's
+dictionary at `replacementObjectId`. Only that page is rewritten; pass
+`{ scope: "global" }` to apply the replacement across every page.
+
+```javascript
+writer.replaceObject(0, contentsId, replacementId, { scope: "global" });
+```
+
 `PDFRStreamForBuffer`, `PDFWStreamForBuffer`, and the `ByteReader`/`ByteWriter`
 aliases are byte adapters, not Node or Web streams. A writer adapter exposes
 `buffer`, `toUint8Array()`, `toArrayBuffer()`, and `toBlob()`.

--- a/packages/wasm/index.d.ts
+++ b/packages/wasm/index.d.ts
@@ -1263,12 +1263,14 @@ export interface PDFModifier {
   requireCatalogUpdate(): void;
   /**
    * Replaces matching direct references in one original page dictionary.
+   * Set `scope` to `global` to replace matching references on every page.
    * All IDs must be positive unsigned 32-bit IDs from this modified PDF.
    */
   replaceObject(
     pageIndex: number,
     sourceObjectId: number,
     replacementObjectId: number,
+    options?: { scope?: "global" },
   ): this;
   getObjectsContext(): ObjectsContext;
   getModifiedFileParser(): PDFReader;

--- a/packages/wasm/lib/writer-to-modify.js
+++ b/packages/wasm/lib/writer-to-modify.js
@@ -2122,7 +2122,12 @@ export function createWriterToModifyFactory({
           throw new Error("Unable to require catalog update");
         }
       },
-      replaceObject: function (pageIndex, sourceObjectId, replacementObjectId) {
+      replaceObject: function (
+        pageIndex,
+        sourceObjectId,
+        replacementObjectId,
+        options,
+      ) {
         requireOpen();
         if (
           ![pageIndex, sourceObjectId, replacementObjectId].every(
@@ -2135,6 +2140,16 @@ export function createWriterToModifyFactory({
           throw new RangeError(
             "Page index and object IDs must be unsigned 32-bit integers; object IDs must be positive",
           );
+        }
+        if (options && options.scope === "global") {
+          var parser = this.getModifiedFileParser();
+          var pageCount = parser.getPagesCount();
+
+          parser.end();
+          for (var index = 0; index < pageCount; ++index) {
+            this.replaceObject(index, sourceObjectId, replacementObjectId);
+          }
+          return this;
         }
         if (
           !module._muhammara_wasm_modifier_replace_object(

--- a/packages/wasm/tests/integration/ObjectReplacementTest.test.mjs
+++ b/packages/wasm/tests/integration/ObjectReplacementTest.test.mjs
@@ -111,4 +111,36 @@ describe("ObjectReplacement", function () {
       /has ended/,
     );
   });
+
+  it("replaces matching page references globally when requested", async function () {
+    var muhammara = await createMuhammaraWasm();
+    var sourceWriter = muhammara.createWriter();
+    for (var index = 0; index < 2; ++index) {
+      var page = sourceWriter.createPage(0, 0, 100, 100);
+      sourceWriter.startPageContentContext(page).q().Q();
+      sourceWriter.writePage(page);
+    }
+    var source = sourceWriter.end();
+    var sourceReader = muhammara.createReader(source);
+    var firstContentsId = getPageContentsID(sourceReader, 0);
+    var secondContentsId = getPageContentsID(sourceReader, 1);
+    sourceReader.end();
+
+    var sharingWriter = muhammara.createWriterToModify(source);
+    sharingWriter.replaceObject(1, secondContentsId, firstContentsId);
+    var shared = sharingWriter.end();
+
+    var writer = muhammara.createWriterToModify(shared);
+    var objects = writer.getObjectsContext();
+    var replacementId = objects.startNewIndirectObject();
+    var replacement = objects.startPDFStream();
+    objects.endPDFStream(replacement).endIndirectObject();
+    writer.replaceObject(0, firstContentsId, replacementId, { scope: "global" });
+    var output = writer.end();
+
+    var reader = muhammara.createReader(output);
+    assert.equal(getPageContentsID(reader, 0), replacementId);
+    assert.equal(getPageContentsID(reader, 1), replacementId);
+    reader.end();
+  });
 });

--- a/packages/wasm/tests/integration/ObjectReplacementTest.test.mjs
+++ b/packages/wasm/tests/integration/ObjectReplacementTest.test.mjs
@@ -135,7 +135,9 @@ describe("ObjectReplacement", function () {
     var replacementId = objects.startNewIndirectObject();
     var replacement = objects.startPDFStream();
     objects.endPDFStream(replacement).endIndirectObject();
-    writer.replaceObject(0, firstContentsId, replacementId, { scope: "global" });
+    writer.replaceObject(0, firstContentsId, replacementId, {
+      scope: "global",
+    });
     var output = writer.end();
 
     var reader = muhammara.createReader(output);

--- a/packages/wasm/tests/types/types.test.ts
+++ b/packages/wasm/tests/types/types.test.ts
@@ -215,7 +215,7 @@ async function usesLowLevelSurface() {
     .getSourceDocumentStream()
     .read(1);
   parser.getXrefEntry(parser.getPageObjectID(0));
-  modifier.replaceObject(0, parser.getPageObjectID(0), 11);
+  modifier.replaceObject(0, parser.getPageObjectID(0), 11, { scope: "global" });
   modifier.end();
   var Recipe = await createRecipe();
   Recipe.registerFont("regular", new Uint8Array(), "regular");


### PR DESCRIPTION
## Summary
- add PDFWriter.replaceObject() for replacing direct indirect-object references on a page
- support explicit global scope replacement across pages
- add Recipe.replaceText() for replacing literal Tj text while retaining its source position and font
- add changelog coverage and regression tests

## Testing
- npm test
- npm run test:codestyle