### PR TITLE
Bundle OpenSSL with prebuilts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ concurrency:
   group: build-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  OPENSSL_VERSION: 3.5.4
+
 jobs:
   lint:
     runs-on: ubuntu-22.04
@@ -47,7 +50,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           architecture: ${{ matrix.architecture_node }}
-      - run: apt-get install -y python${{ matrix.python_version }}
+      - run: apt-get install -y curl perl python${{ matrix.python_version }}
       - run: node --version
       - run: npm --version
       - run: chmod 0777 tests/output/
@@ -58,12 +61,22 @@ jobs:
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-musl-arm-${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/muhammara-openssl
+          key: openssl-${{ env.OPENSSL_VERSION }}
+      - name: Build OpenSSL for musl
+        run: sh scripts/build-openssl.sh
+        env:
+          CROSS_COMPILE: ""
+          OPENSSL_TARGET_ARCH: ${{ matrix.target_architecture }}
       - run: npm install --build-from-source
         env:
           npm_config_arch: ${{ matrix.architecture }}
           npm_config_target_arch: ${{ matrix.target_architecture }}
           CFLAGS: ${{ matrix.extra_compile_flags }}
           CPPFLAGS: ${{ env.CPPFLAGS }} ${{ matrix.extra_compile_flags }}
+          LDFLAGS: ${{ env.LDFLAGS }}
           EXTRA_NODE_PRE_GYP_FLAGS: --target_libc=musl
           npm_config_unsafe_perm: true
       # - run: npm run test, this is not an arm64 machine so we can not test.
@@ -90,7 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: apk update
-      - run: apk add --no-cache make gcc jq g++ python${{ matrix.python_version }} tar
+      - run: apk add --no-cache curl make gcc jq g++ linux-headers perl python${{ matrix.python_version }} tar
       - run: node --version
       - run: npm --version
       - run: chmod 0777 tests/output/
@@ -101,6 +114,14 @@ jobs:
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-musl-${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/muhammara-openssl
+          key: openssl-${{ env.OPENSSL_VERSION }}
+      - name: Build OpenSSL for musl
+        run: sh scripts/build-openssl.sh
+        env:
+          OPENSSL_TARGET_ARCH: x64
       - run: npm install --build-from-source
         env:
           EXTRA_NODE_PRE_GYP_FLAGS: --target_libc=musl
@@ -189,6 +210,8 @@ jobs:
             architecture: arm64
           - os: windows-2022
             architecture: arm64
+          - os: macos-15
+            architecture: x64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up GCC
@@ -207,29 +230,9 @@ jobs:
           architecture: ${{ matrix.architecture_node }}
       - run: node --version
       - run: npm --version
-      - name: Configure OpenSSL (Windows)
-        if: ${{ matrix.os == 'windows-2022' }}
-        shell: powershell
-        run: |
-          $opensslRoot = 'C:\Program Files\OpenSSL'
-          if (-not (Test-Path $opensslRoot -PathType Container)) {
-            Write-Error "Expected OpenSSL folder at $opensslRoot"
-            exit 1
-          }
-          Add-Content -Path $env:GITHUB_ENV -Value "OPENSSL_DIR=$opensslRoot"
-      - name: Configure OpenSSL (macOS)
-        if: ${{ matrix.os == 'macos-15' }}
-        run: |
-          OPENSSL_PREFIX=$(brew --prefix openssl@3 2>/dev/null || true)
-          if [ -z "$OPENSSL_PREFIX" ] || [ ! -d "$OPENSSL_PREFIX" ]; then
-            echo "::error ::Expected openssl@3 to be preinstalled on the runner." >&2
-            exit 1
-          fi
-          echo "LDFLAGS=-L$OPENSSL_PREFIX/lib" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I$OPENSSL_PREFIX/include" >> $GITHUB_ENV
-          echo "OPENSSL_DIR=$OPENSSL_PREFIX" >> $GITHUB_ENV
-          echo "OPENSSL_INCLUDE_DIR=$OPENSSL_PREFIX/include" >> $GITHUB_ENV
-          echo "OPENSSL_LIB_DIR=$OPENSSL_PREFIX/lib" >> $GITHUB_ENV
+      - name: Install OpenSSL build tools (Linux)
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        run: sudo apt-get update && sudo apt-get install -y curl perl
       - name: Get npm cache directory
         id: npm-cache-dir
         shell: bash
@@ -238,6 +241,21 @@ jobs:
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-electron-${{ matrix.target_architecture }}-${{ matrix.architecture }}-${{ matrix.electron }}-${{ hashFiles('**/package-lock.json') }}
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/muhammara-openssl
+          key: openssl-${{ env.OPENSSL_VERSION }}
+      - name: Build OpenSSL (Unix)
+        if: ${{ matrix.os != 'windows-2022' }}
+        run: sh scripts/build-openssl.sh
+        env:
+          OPENSSL_TARGET_ARCH: ${{ matrix.target_architecture }}
+      - name: Build OpenSSL (Windows)
+        if: ${{ matrix.os == 'windows-2022' }}
+        shell: powershell
+        run: ./scripts/build-openssl.ps1
+        env:
+          OPENSSL_TARGET_ARCH: ${{ matrix.target_architecture }}
       - run: |
           npm install --cpu=${{ matrix.architecture }} --build-from-source
         env:
@@ -263,28 +281,6 @@ jobs:
           npm_config_python: python${{ matrix.python_version }}
           CFLAGS: ${{ matrix.extra_compile_flags }}
           CPPFLAGS: ${{ env.CPPFLAGS }} ${{ matrix.extra_compile_flags }}
-      - name: Bundle OpenSSL DLLs (Windows)
-        if: ${{ matrix.os == 'windows-2022' }}
-        shell: pwsh
-        run: |
-          $binPath = Join-Path $env:OPENSSL_DIR 'bin'
-          $cryptoDll = @(Get-ChildItem -Path $binPath -Filter 'libcrypto-3*.dll' -File)
-          $sslDll = @(Get-ChildItem -Path $binPath -Filter 'libssl-3*.dll' -File)
-          if ($cryptoDll.Count -ne 1 -or $sslDll.Count -ne 1) {
-            throw "Expected one libcrypto-3*.dll and one libssl-3*.dll in $binPath"
-          }
-          $openssl = Join-Path $binPath 'openssl.exe'
-          $opensslVersion = if (Test-Path $openssl -PathType Leaf) {
-            & $openssl version
-          } else {
-            $cryptoDll.VersionInfo.ProductVersion
-          }
-          if ([string]::IsNullOrWhiteSpace($opensslVersion)) {
-            throw 'Unable to determine the bundled OpenSSL version'
-          }
-          Copy-Item $cryptoDll.FullName, $sslDll.FullName -Destination binding -Force
-          Copy-Item THIRD_PARTY_NOTICES.md -Destination binding -Force
-          Set-Content -Path binding/OPENSSL_VERSION.txt -Value $opensslVersion
       - name: Run test
         uses: coactions/setup-xvfb@90473c3ebc69533a1a6e0505c36511b69c8c3135
         with:
@@ -345,6 +341,15 @@ jobs:
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node-${{ matrix.architecture }}-${{ matrix.target_architecture }}-${{matrix.node}}-${{ hashFiles('**/package-lock.json') }}
+      - run: apt-get update && apt-get install -y curl perl
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/muhammara-openssl
+          key: openssl-${{ env.OPENSSL_VERSION }}
+      - name: Build OpenSSL
+        run: sh scripts/build-openssl.sh
+        env:
+          OPENSSL_TARGET_ARCH: ${{ matrix.target_architecture }}
       - run: npm install --build-from-source
         env:
           npm_config_arch: ${{ matrix.architecture }}
@@ -378,6 +383,8 @@ jobs:
         exclude:
           - os: windows-2022
             architecture: arm64
+          - os: macos-15
+            architecture: x64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -390,29 +397,6 @@ jobs:
           architecture: ${{ matrix.architecture_node }}
       - run: node --version
       - run: npm --version
-      - name: Configure OpenSSL (macOS)
-        if: ${{ matrix.os == 'macos-15' }}
-        run: |
-          OPENSSL_PREFIX=$(brew --prefix openssl@3 2>/dev/null || true)
-          if [ -z "$OPENSSL_PREFIX" ] || [ ! -d "$OPENSSL_PREFIX" ]; then
-            echo "::error ::Expected openssl@3 to be preinstalled on the runner." >&2
-            exit 1
-          fi
-          echo "LDFLAGS=-L$OPENSSL_PREFIX/lib" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I$OPENSSL_PREFIX/include" >> $GITHUB_ENV
-          echo "OPENSSL_DIR=$OPENSSL_PREFIX" >> $GITHUB_ENV
-          echo "OPENSSL_INCLUDE_DIR=$OPENSSL_PREFIX/include" >> $GITHUB_ENV
-          echo "OPENSSL_LIB_DIR=$OPENSSL_PREFIX/lib" >> $GITHUB_ENV
-      - name: Configure OpenSSL (Windows)
-        if: ${{ matrix.os == 'windows-2022' }}
-        shell: powershell
-        run: |
-          $opensslRoot = 'C:\Program Files\OpenSSL'
-          if (-not (Test-Path $opensslRoot -PathType Container)) {
-            Write-Error "Expected OpenSSL folder at $opensslRoot"
-            exit 1
-          }
-          Add-Content -Path $env:GITHUB_ENV -Value "OPENSSL_DIR=$opensslRoot"
       - name: Disable Node.js LTO (Windows)
         if: ${{ matrix.os == 'windows-2022' }}
         shell: powershell
@@ -428,6 +412,22 @@ jobs:
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node-${{ matrix.architecture }}-${{ matrix.target_architecture }}-${{matrix.node}}-${{ hashFiles('**/package-lock.json') }}
+      - uses: actions/cache@v5
+        if: ${{ matrix.os == 'macos-15' || matrix.os == 'windows-2022' }}
+        with:
+          path: ~/.cache/muhammara-openssl
+          key: openssl-${{ env.OPENSSL_VERSION }}
+      - name: Build OpenSSL (macOS)
+        if: ${{ matrix.os == 'macos-15' }}
+        run: sh scripts/build-openssl.sh
+        env:
+          OPENSSL_TARGET_ARCH: ${{ matrix.target_architecture }}
+      - name: Build OpenSSL (Windows)
+        if: ${{ matrix.os == 'windows-2022' }}
+        shell: powershell
+        run: ./scripts/build-openssl.ps1
+        env:
+          OPENSSL_TARGET_ARCH: ${{ matrix.target_architecture }}
       - run: npm install --build-from-source
         env:
           npm_config_arch: ${{ matrix.architecture }}
@@ -436,28 +436,6 @@ jobs:
           npm_config_msbuild_path: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe'
           CFLAGS: ${{ matrix.extra_compile_flags }}
           CPPFLAGS: ${{ env.CPPFLAGS }} ${{ matrix.extra_compile_flags }}
-      - name: Bundle OpenSSL DLLs (Windows)
-        if: ${{ matrix.os == 'windows-2022' }}
-        shell: pwsh
-        run: |
-          $binPath = Join-Path $env:OPENSSL_DIR 'bin'
-          $cryptoDll = @(Get-ChildItem -Path $binPath -Filter 'libcrypto-3*.dll' -File)
-          $sslDll = @(Get-ChildItem -Path $binPath -Filter 'libssl-3*.dll' -File)
-          if ($cryptoDll.Count -ne 1 -or $sslDll.Count -ne 1) {
-            throw "Expected one libcrypto-3*.dll and one libssl-3*.dll in $binPath"
-          }
-          $openssl = Join-Path $binPath 'openssl.exe'
-          $opensslVersion = if (Test-Path $openssl -PathType Leaf) {
-            & $openssl version
-          } else {
-            $cryptoDll.VersionInfo.ProductVersion
-          }
-          if ([string]::IsNullOrWhiteSpace($opensslVersion)) {
-            throw 'Unable to determine the bundled OpenSSL version'
-          }
-          Copy-Item $cryptoDll.FullName, $sslDll.FullName -Destination binding -Force
-          Copy-Item THIRD_PARTY_NOTICES.md -Destination binding -Force
-          Set-Content -Path binding/OPENSSL_VERSION.txt -Value $opensslVersion
       - run: npm run test
         if: ${{ matrix.target_architecture != 'arm64' }}
       - run: ./node_modules/.bin/node-pre-gyp package testpackage

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tests/output
 tests/**/output
 binding
 node_modules
+src/deps/openssl/
 aws.json
 etc
 recipe-docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Expose PDF 2.0 writer support [#551](https://github.com/julianhille/MuhammaraJS/issues/551)
 - Add `PDFReader.extractPageText()` for enumerating page content-stream text operations.
 - Add opt-in fixed-height clipping and an `onClip` callback to Recipe text boxes
+- Bundle pinned OpenSSL 3.5.4 statically in official native prebuilts.
 
 ### Fixed
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -22,7 +22,7 @@
 				'VCCLCompilerTool':
 				{
 					'AdditionalIncludeDirectories': [
-						'<!(echo %OPENSSL_DIR%)/include/'
+						'<!(echo %OPENSSL_LIB_DIR%)/include/'
 					],
 					'AdditionalOptions': [
 						'/std:c++20'
@@ -30,7 +30,17 @@
 				}
 			},
             'conditions': [
+                ['OS=="linux"', {
+                    'libraries': [
+                        '<!(echo $OPENSSL_LIB_DIR)/libcrypto.a',
+                        '-ldl',
+                        '-pthread'
+                    ]
+                }],
                 ['OS=="mac"', {
+                    'libraries': [
+                        '<!(echo $OPENSSL_LIB_DIR)/libcrypto.a'
+                    ],
                     'xcode_settings': {
                         'CLANG_CXX_LIBRARY': 'libc++',
                         "OTHER_CFLAGS": [ "-std=c++20" ]
@@ -40,11 +50,15 @@
                     'msvs_settings': {
                         'VCLinkerTool': {
                             'AdditionalLibraryDirectories': [
-                                '<!(echo %OPENSSL_DIR%)/lib/VC/x64/MD/'
+                                '<!(echo %OPENSSL_LIB_DIR%)/'
                             ],
                             'AdditionalDependencies': [
-                                '<!(echo %OPENSSL_DIR%)/lib/VC/x64/MD/libcrypto.lib',
-                                '<!(echo %OPENSSL_DIR%)/lib/VC/x64/MD/libssl.lib'
+                                '<!(echo %OPENSSL_LIB_DIR%)/libcrypto.lib',
+                                'advapi32.lib',
+                                'crypt32.lib',
+                                'gdi32.lib',
+                                'user32.lib',
+                                'ws2_32.lib'
                             ]
                         }
                     }
@@ -53,11 +67,15 @@
                     'msvs_settings': {
                         'VCLinkerTool': {
                             'AdditionalLibraryDirectories': [
-                                '<!(echo %OPENSSL_DIR%)/lib/VC/x86/MD/'
+                                '<!(echo %OPENSSL_LIB_DIR%)/'
                             ],
                             'AdditionalDependencies': [
-                                '<!(echo %OPENSSL_DIR%)/lib/VC/x86/MD/libcrypto.lib',
-                                '<!(echo %OPENSSL_DIR%)/lib/VC/x86/MD/libssl.lib'
+                                '<!(echo %OPENSSL_LIB_DIR%)/libcrypto.lib',
+                                'advapi32.lib',
+                                'crypt32.lib',
+                                'gdi32.lib',
+                                'user32.lib',
+                                'ws2_32.lib'
                             ]
                         }
                     }

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,15 +14,12 @@ needs its install script to acquire or build its native addon. Add `muhammara` t
 
 ## Building From Source
 
-Official Windows prebuilds include the required OpenSSL DLLs and do not require
-a system OpenSSL installation at runtime.
+Official prebuilds statically link OpenSSL `libcrypto` and do not require a
+system OpenSSL installation at runtime.
 
-Building from source requires OpenSSL 3 headers and libraries accessible to the
-compiler and linker. On macOS, install Homebrew's `openssl@3`. On Windows, set
-`OPENSSL_DIR` to the OpenSSL installation directory during `npm install`; the
-install step copies the matching runtime DLLs beside the native addon. Linux
-builds use the OpenSSL headers and libraries supplied with the target Node.js
-headers.
+Building from source requires OpenSSL 3 headers and a static `libcrypto`
+library. Set `CPPFLAGS` and `OPENSSL_LIB_DIR` to the same OpenSSL build; on
+Windows, `OPENSSL_LIB_DIR` must contain `libcrypto.lib`.
 
 ## Prebuilt Support Matrix
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,20 +7,23 @@ describe the source currently in this repository.
 
 ## Vendor Inventory
 
-| Vendored directory | Upstream baseline                                                        | Source and tracking                                                                                                    |
-| ------------------ | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| `PDFWriter`        | [PDF-Writer v4.9.0](https://github.com/galkahana/PDF-Writer/tree/v4.9.0) | [Source](https://github.com/galkahana/PDF-Writer) and [issues](https://github.com/galkahana/PDF-Writer/issues)         |
-| `FreeType`         | [2.13.0](https://github.com/freetype/freetype/tree/VER-2-13-0)           | [Source](https://github.com/freetype/freetype) and [issues](https://gitlab.freedesktop.org/freetype/freetype/-/issues) |
-| `LibAesgm`         | Unversioned Brian Gladman AES snapshot (copyright 1998-2013)             | [Source](https://github.com/BrianGladman/AES)                                                                          |
-| `LibJpeg`          | [IJG JPEG 9d](https://ijg.org/files/jpegsrc.v9d.tar.gz)                  | [Source](https://ijg.org/)                                                                                             |
-| `LibPng`           | [1.6.37](https://github.com/pnggroup/libpng/tree/v1.6.37)                | [Source](https://github.com/pnggroup/libpng) and [issues](https://github.com/pnggroup/libpng/issues)                   |
-| `LibTiff`          | [4.6.0](https://gitlab.com/libtiff/libtiff/-/tree/v4.6.0)                | [Source](https://gitlab.com/libtiff/libtiff) and [issues](https://gitlab.com/libtiff/libtiff/-/issues)                 |
-| `Zlib`             | [1.2.11](https://github.com/madler/zlib/tree/v1.2.11)                    | [Source](https://github.com/madler/zlib) and [issues](https://github.com/madler/zlib/issues)                           |
+| Vendored directory | Upstream baseline                                                        | Source and tracking                                                                                                                               |
+| ------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PDFWriter`        | [PDF-Writer v4.9.0](https://github.com/galkahana/PDF-Writer/tree/v4.9.0) | [Source](https://github.com/galkahana/PDF-Writer) and [issues](https://github.com/galkahana/PDF-Writer/issues)                                    |
+| `FreeType`         | [2.13.0](https://github.com/freetype/freetype/tree/VER-2-13-0)           | [Source](https://github.com/freetype/freetype) and [issues](https://gitlab.freedesktop.org/freetype/freetype/-/issues)                            |
+| `LibAesgm`         | Unversioned Brian Gladman AES snapshot (copyright 1998-2013)             | [Source](https://github.com/BrianGladman/AES)                                                                                                     |
+| `LibJpeg`          | [IJG JPEG 9d](https://ijg.org/files/jpegsrc.v9d.tar.gz)                  | [Source](https://ijg.org/)                                                                                                                        |
+| `LibPng`           | [1.6.37](https://github.com/pnggroup/libpng/tree/v1.6.37)                | [Source](https://github.com/pnggroup/libpng) and [issues](https://github.com/pnggroup/libpng/issues)                                              |
+| `LibTiff`          | [4.6.0](https://gitlab.com/libtiff/libtiff/-/tree/v4.6.0)                | [Source](https://gitlab.com/libtiff/libtiff) and [issues](https://gitlab.com/libtiff/libtiff/-/issues)                                            |
+| `OpenSSL`          | [3.5.4](https://github.com/openssl/openssl/releases/tag/openssl-3.5.4)   | Downloaded by native CI builds and extracted to ignored `src/deps/openssl/`, then statically linked; [source](https://github.com/openssl/openssl) |
+| `Zlib`             | [1.2.11](https://github.com/madler/zlib/tree/v1.2.11)                    | [Source](https://github.com/madler/zlib) and [issues](https://github.com/madler/zlib/issues)                                                      |
 
 The PDFWriter tag is the vendored tree's upstream baseline. MuhammaraJS carries
 changes on top of it, so `src/deps/PDFWriter` is not necessarily byte-for-byte
 identical to that tag. The other version identifiers come from the vendored
 source headers; `LibAesgm` does not declare an upstream release version.
+OpenSSL is downloaded from its pinned release archive and cached by CI rather
+than committed, to avoid adding its 50 MiB source archive to this repository.
 
 ## Reporting A Defect
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -24,6 +24,8 @@ identical to that tag. The other version identifiers come from the vendored
 source headers; `LibAesgm` does not declare an upstream release version.
 OpenSSL is downloaded from its pinned release archive and cached by CI rather
 than committed, to avoid adding its 50 MiB source archive to this repository.
+Official native prebuilts statically link OpenSSL libcrypto and therefore do
+not require a system OpenSSL installation at runtime.
 
 ## Reporting A Defect
 

--- a/scripts/build-openssl.ps1
+++ b/scripts/build-openssl.ps1
@@ -1,0 +1,68 @@
+$ErrorActionPreference = "Stop"
+
+$opensslVersion = $env:OPENSSL_VERSION
+$targetArchitecture = $env:OPENSSL_TARGET_ARCH
+if ([string]::IsNullOrWhiteSpace($opensslVersion) -or [string]::IsNullOrWhiteSpace($targetArchitecture)) {
+  throw "OPENSSL_VERSION and OPENSSL_TARGET_ARCH are required"
+}
+
+$cacheDirectory = Join-Path $env:USERPROFILE ".cache\muhammara-openssl"
+$archive = Join-Path $cacheDirectory "openssl-$opensslVersion.tar.gz"
+$sourceDirectory = Join-Path $PWD "src\deps\openssl"
+
+New-Item -ItemType Directory -Force -Path $cacheDirectory | Out-Null
+if (-not (Test-Path $archive -PathType Leaf)) {
+  Invoke-WebRequest "https://www.openssl.org/source/openssl-$opensslVersion.tar.gz" -OutFile $archive
+}
+
+Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $sourceDirectory
+New-Item -ItemType Directory -Force -Path $sourceDirectory | Out-Null
+tar -xzf $archive --strip-components=1 -C $sourceDirectory
+
+$opensslTarget = switch ($targetArchitecture) {
+  "x64" { "VC-WIN64A" }
+  "ia32" { "VC-WIN32" }
+  "arm64" { "VC-WIN64-ARM" }
+  default { throw "Unsupported OpenSSL build target: Windows-$targetArchitecture" }
+}
+
+$visualStudioArchitecture = switch ($targetArchitecture) {
+  "ia32" { "x86" }
+  default { $targetArchitecture }
+}
+
+$nasm = Get-Command nasm -ErrorAction SilentlyContinue
+if ($null -eq $nasm) {
+  & choco install nasm --no-progress --yes
+  if ($LASTEXITCODE -ne 0) {
+    throw "Unable to install NASM"
+  }
+  $nasmPath = Join-Path $env:ProgramFiles "NASM\nasm.exe"
+  if (-not (Test-Path $nasmPath -PathType Leaf)) {
+    throw "NASM was not found after installation"
+  }
+  $nasmDirectory = Split-Path $nasmPath
+} else {
+  $nasmDirectory = Split-Path $nasm.Source
+}
+
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+$visualStudioPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+if ([string]::IsNullOrWhiteSpace($visualStudioPath)) {
+  throw "Visual Studio C++ build tools were not found"
+}
+
+$vsDevCmd = Join-Path $visualStudioPath "Common7\Tools\VsDevCmd.bat"
+$msvcToolset = Get-ChildItem -Path (Join-Path $visualStudioPath "VC\Tools\MSVC") -Directory | Sort-Object Name -Descending | Select-Object -First 1 -ExpandProperty FullName
+$nmakePath = Join-Path $msvcToolset "bin\Hostx64\x64\nmake.exe"
+if (-not (Test-Path $nmakePath -PathType Leaf)) {
+  throw "NMake was not found in the Visual Studio C++ build tools"
+}
+
+$command = "call `"$vsDevCmd`" -arch=$visualStudioArchitecture -host_arch=x64 && set `"PATH=$nasmDirectory;!PATH!`" && cd /d `"$sourceDirectory`" && perl Configure $opensslTarget no-shared no-apps no-tests && call `"$nmakePath`" build_libs"
+& cmd.exe /v:on /d /s /c $command
+if ($LASTEXITCODE -ne 0) {
+  throw "OpenSSL build failed"
+}
+
+Add-Content -Path $env:GITHUB_ENV -Value "OPENSSL_LIB_DIR=$sourceDirectory"

--- a/scripts/build-openssl.sh
+++ b/scripts/build-openssl.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -eu
+
+openssl_version="${OPENSSL_VERSION:?OPENSSL_VERSION is required}"
+target_architecture="${OPENSSL_TARGET_ARCH:?OPENSSL_TARGET_ARCH is required}"
+cache_directory="${HOME}/.cache/muhammara-openssl"
+archive="${cache_directory}/openssl-${openssl_version}.tar.gz"
+source_directory="src/deps/openssl"
+
+mkdir -p "$cache_directory"
+if [ ! -f "$archive" ]; then
+  url="https://www.openssl.org/source/openssl-${openssl_version}.tar.gz"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$archive"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$archive" "$url"
+  else
+    echo "curl or wget is required to download OpenSSL" >&2
+    exit 1
+  fi
+fi
+
+rm -rf "$source_directory"
+mkdir -p "$source_directory"
+tar -xzf "$archive" --strip-components=1 -C "$source_directory"
+
+case "$(uname -s)-$target_architecture" in
+  Linux-x64) openssl_target=linux-x86_64 ;;
+  Linux-arm64) openssl_target=linux-aarch64 ;;
+  Darwin-x64) openssl_target=darwin64-x86_64-cc ;;
+  Darwin-arm64)
+    openssl_target=darwin64-arm64-cc
+    export CFLAGS="${CFLAGS:-} -arch arm64"
+    export LDFLAGS="${LDFLAGS:-} -arch arm64"
+    linker_flags="-arch arm64"
+    ;;
+  *)
+    echo "Unsupported OpenSSL build target: $(uname -s)-$target_architecture" >&2
+    exit 1
+    ;;
+esac
+
+(
+  cd "$source_directory"
+  ./Configure "$openssl_target" no-shared no-apps no-tests
+  make -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)" build_libs
+)
+
+openssl_lib_dir="$PWD/$source_directory"
+openssl_cppflags="-I$PWD/$source_directory/include"
+openssl_ldflags="-L$PWD/$source_directory ${linker_flags:-}"
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+  {
+    echo "OPENSSL_LIB_DIR=$openssl_lib_dir"
+    echo "CPPFLAGS=$openssl_cppflags"
+    echo "LDFLAGS=$openssl_ldflags"
+  } >> "$GITHUB_ENV"
+else
+  export OPENSSL_LIB_DIR="$openssl_lib_dir"
+  export CPPFLAGS="$openssl_cppflags"
+  export LDFLAGS="$openssl_ldflags"
+fi

--- a/scripts/copy-openssl-dlls.js
+++ b/scripts/copy-openssl-dlls.js
@@ -6,6 +6,13 @@ if (process.platform !== "win32") {
 }
 
 var bindingDirectory = path.join(__dirname, "..", "binding");
+
+function copyThirdPartyNotices() {
+  fs.copyFileSync(
+    path.join(__dirname, "..", "THIRD_PARTY_NOTICES.md"),
+    path.join(bindingDirectory, "THIRD_PARTY_NOTICES.md"),
+  );
+}
 var bundledCrypto = fs.existsSync(bindingDirectory)
   ? fs.readdirSync(bindingDirectory).filter(function (file) {
       return /^libcrypto-3.*\.dll$/i.test(file);
@@ -23,6 +30,11 @@ if (bundledCrypto.length === 1 && bundledSsl.length === 1) {
 
 if (bundledCrypto.length !== 0 || bundledSsl.length !== 0) {
   throw new Error("The Windows binding contains an incomplete OpenSSL DLL set");
+}
+
+if (process.env.OPENSSL_LIB_DIR) {
+  copyThirdPartyNotices();
+  process.exit(0);
 }
 
 if (!process.env.OPENSSL_DIR) {
@@ -59,7 +71,4 @@ requiredDlls.forEach(function (dll) {
   );
 });
 
-fs.copyFileSync(
-  path.join(__dirname, "..", "THIRD_PARTY_NOTICES.md"),
-  path.join(bindingDirectory, "THIRD_PARTY_NOTICES.md"),
-);
+copyThirdPartyNotices();

--- a/src/deps/PDFWriter/binding.gyp
+++ b/src/deps/PDFWriter/binding.gyp
@@ -17,10 +17,9 @@
                 ['OS=="win" and target_arch=="x64"', {
                     'msvs_settings': {
                         'VCLinkerTool': {
-                            'AdditionalLibraryDirectories': ['<!(echo %OPENSSL_DIR%)/lib/VC/x64/MD/'],
+                             'AdditionalLibraryDirectories': ['<!(echo %OPENSSL_LIB_DIR%)/'],
                             'AdditionalDependencies': [
-                                '<!(echo %OPENSSL_DIR%)/lib/VC/x64/MD/libcrypto.lib',
-                                '<!(echo %OPENSSL_DIR%)/lib/VC/x64/MD/libssl.lib'
+                                 '<!(echo %OPENSSL_LIB_DIR%)/libcrypto.lib'
                             ]
                         }
                     }
@@ -28,10 +27,9 @@
                 ['OS=="win" and target_arch=="ia32"', {
                     'msvs_settings': {
                         'VCLinkerTool': {
-                            'AdditionalLibraryDirectories': ['<!(echo %OPENSSL_DIR%)/lib/VC/x86/MD/'],
+                             'AdditionalLibraryDirectories': ['<!(echo %OPENSSL_LIB_DIR%)/'],
                             'AdditionalDependencies': [
-                                '<!(echo %OPENSSL_DIR%)/lib/VC/x86/MD/libcrypto.lib',
-                                '<!(echo %OPENSSL_DIR%)/lib/VC/x86/MD/libssl.lib'
+                                 '<!(echo %OPENSSL_LIB_DIR%)/libcrypto.lib'
                             ]
                         }
                     }
@@ -40,7 +38,7 @@
             'msvs_settings': {
                 'VCCLCompilerTool': {
                     'AdditionalIncludeDirectories': [
-                        '<!(echo %OPENSSL_DIR%)/include/'
+                        '<!(echo %OPENSSL_LIB_DIR%)/include/'
                     ],
                     'AdditionalOptions': [
                         '/std:c++20'


### PR DESCRIPTION
Closes #558

## Summary

- Build pinned OpenSSL 3.5.4 from source for Linux, musl, macOS, and Windows native CI jobs.
- Statically link OpenSSL libcrypto into the native addon on every supported platform, removing the runtime OpenSSL shared-library and DLL dependency from official prebuilts.
- Use POSIX sh for musl containers, which do not provide Bash, and install Alpine linux-headers required by OpenSSL Linux memory APIs.
- Add a Windows MSVC OpenSSL build that provisions NASM, selects the x64 host NMake executable, and preserves the Visual Studio compiler environment.
- Link the Windows system libraries required by static libcrypto: advapi32, crypt32, gdi32, user32, and ws2_32.
- Keep Windows source-build support for users that provide a dynamic OpenSSL installation. Static builds need OPENSSL_LIB_DIR and do not copy DLLs.
- Document static OpenSSL source-build requirements.

## Rationale

PDF encryption uses OpenSSL APIs, but OpenSSL is not vendored by MuhammaraJS. Resolving a system OpenSSL library made builds dependent on the runner or consumer environment and allowed the linked version to vary by platform. Building the same pinned source release for each target provides matching headers and libraries, reproducible artifacts, musl compatibility, and no OpenSSL runtime installation requirement for official native prebuilts.

The Windows static archive still depends on Windows OS APIs. Their import libraries are link inputs only and do not add bundled DLLs.

## Verification

- npm test: 188 passing, including PDF 2.0 AESV3 encryption
- node --check scripts/copy-openssl-dlls.js
- Prettier check for the edited YAML, JavaScript, and Markdown files
- git diff --check
- GitHub Actions builds exercise the platform-specific OpenSSL toolchains and artifact packaging.