### PR TITLE
Close readers in documentation tests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,5 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r docs/requirements.txt
       - run: npm ci
-      - run: npm run test:docs
       - run: npm run docs:check
       - run: git diff --exit-code -- docs/recipe/reference.md docs/api/type-declarations.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Release PDF readers in documentation tests to prevent Windows file-lock cleanup failures.
+- Remove the duplicate documentation example test from the documentation CI workflow.
 - Prevent a segmentation fault when `endPDF()` is called more than once.
 - Update macOS runner from macos-13 to macos-14
 - Fix DictionaryContext.writeKey() signature to include required key parameter [#479](https://github.com/julianhille/MuhammaraJS/issues/479)

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "docs:declaration-reference": "node scripts/generate-declaration-reference.js && prettier --write docs/api/type-declarations.md",
     "docs:serve": "npm run docs:build && mkdocs serve",
     "docs:build": "npm run docs:recipe-reference && npm run docs:declaration-reference && mkdocs build",
-    "docs:check": "npm run docs:recipe-reference && npm run docs:declaration-reference && mkdocs build --strict",
-    "test:docs": "mocha tests/docs/**/*.js --timeout 15000"
+    "docs:check": "npm run docs:recipe-reference && npm run docs:declaration-reference && mkdocs build --strict"
   },
   "repository": {
     "type": "git",

--- a/tests/docs/create-pdfs.js
+++ b/tests/docs/create-pdfs.js
@@ -24,6 +24,7 @@ describe("Documentation examples", function () {
 
     var reader = muhammara.createReader(outputPath);
     assert.strictEqual(reader.getPagesCount(), 1);
+    reader.end();
   });
 
   it("creates a Recipe PDF", function (done) {
@@ -32,6 +33,7 @@ describe("Documentation examples", function () {
     createRecipePdf(outputPath, function () {
       var reader = muhammara.createReader(outputPath);
       assert.strictEqual(reader.getPagesCount(), 1);
+      reader.end();
       done();
     });
   });


### PR DESCRIPTION
Release the PDFReader file handle before each documentation test removes its temporary output directory. This prevents Windows cleanup failures caused by an open reader handle.\n\nTests: 
> test:docs
> npm run test:docs --workspace=muhammara


> muhammara@7.0.0 test:docs
> mocha tests/docs/**/*.js --timeout 15000



  Documentation examples
    ✔ creates a low-level PDF
    ✔ creates a Recipe PDF


  2 passing (7ms)