### PR TITLE
Generate API references in Read the Docs builds

### DIFF
--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - ".github/workflows/ci-native.yml"
       - "packages/native/**"
+      - "!packages/native/docs/**"
+      - "!packages/native/mkdocs.yml"
+      - "!packages/native/.readthedocs.yaml"
       - "packages/native-core/**"
       - "packages/native-with-source/**"
       - ".github/actions/setup-native-build-cache/**"

--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -11,6 +11,9 @@ on:
       - "package-lock.json"
       - "packages/native-with-source/src/**"
       - "packages/wasm/**"
+      - "!packages/wasm/docs/**"
+      - "!packages/wasm/mkdocs.yml"
+      - "!packages/wasm/.readthedocs.yaml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           node-version: 24
           cache: npm
+      - uses: ./.github/actions/setup-native-build-cache
+        with:
+          key: native-docs-${{ hashFiles('packages/native-with-source/binding.gyp', 'packages/native-with-source/src/**') }}
+          restore-keys: native-docs-
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r packages/native/docs/requirements.txt
       - run: sudo apt-get update && sudo apt-get install -y curl perl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Generate native API reference pages during Read the Docs builds and cache the
+  native addon used to validate executable documentation examples [#566](https://github.com/julianhille/MuhammaraJS/issues/566)
+
+### Changed
+
+- Skip native package CI for documentation-only changes; Documentation CI
+  validates those updates.
+
 ## [7.0.0-alpha.0] - 2026-09-02
 
 ### Breaking Changes

--- a/packages/native/.readthedocs.yaml
+++ b/packages/native/.readthedocs.yaml
@@ -5,6 +5,10 @@ build:
   tools:
     python: "3.12"
     nodejs: "24"
+  jobs:
+    pre_build:
+      - npm ci --ignore-scripts
+      - npm run docs:generate --workspace=@muhammara/native
 
 mkdocs:
   configuration: packages/native/mkdocs.yml

--- a/packages/wasm/.readthedocs.yaml
+++ b/packages/wasm/.readthedocs.yaml
@@ -4,6 +4,11 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.12"
+    nodejs: "24"
+  jobs:
+    pre_build:
+      - npm ci --ignore-scripts
+      - npm run docs:generate --workspace=@muhammara/wasm
 
 mkdocs:
   configuration: packages/wasm/mkdocs.yml

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `@muhammara/wasm` are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Generate the API reference during Read the Docs builds [#566](https://github.com/julianhille/MuhammaraJS/issues/566)
+
+### Changed
+
+- Skip Wasm package CI for documentation-only changes; Documentation CI
+  validates those updates.
+
 ## [1.0.0-alpha.0] - 2026-09-02
 
 ### Added


### PR DESCRIPTION
Closes #566

## Summary
- generate native API references before the Read the Docs MkDocs build
- provision Node.js and generate the WASM API reference before its build
- install lockfile-pinned workspace tooling without package lifecycle scripts
- skip native and WASM package CI for documentation-only changes, which Documentation CI validates
- cache the native addon build used by executable documentation examples
- document the native and WASM changes in their Unreleased changelogs

## Testing
- npx prettier --check CHANGELOG.md packages/wasm/CHANGELOG.md .github/workflows/ci-native.yml .github/workflows/ci-wasm.yml .github/workflows/docs.yml
- Python YAML parsing for all updated workflows
- npm ci --ignore-scripts
- npm run docs:check (reference generation passed; local MkDocs was unavailable until Python requirements were installed)
- npm run docs:check --workspace=@muhammara/wasm (reference generation passed; local MkDocs was unavailable until Python requirements were installed)
- .docs-venv/bin/mkdocs build --strict --config-file packages/native/mkdocs.yml
- .docs-venv/bin/mkdocs build --strict --config-file packages/wasm/mkdocs.yml