### PR TITLE
ci: run native and wasm builds on develop pushes to warm the shared cache

### DIFF
--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -2,6 +2,8 @@ name: Native CI
 
 on:
   push:
+    branches:
+      - develop
     tags:
       - "native-v*"
   pull_request:
@@ -20,7 +22,7 @@ on:
 
 concurrency:
   group: build-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -2,6 +2,8 @@ name: Wasm CI
 
 on:
   push:
+    branches:
+      - develop
     tags:
       - "wasm-v*"
   pull_request:
@@ -18,7 +20,7 @@ on:
 
 concurrency:
   group: wasm-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #569 (step 1).

## Why

Every `feature/*` and `fix/*` branch starts from a **cold ccache**, recompiling OpenSSL and the addon from scratch on each new PR, on every matrix leg.

GitHub scopes Actions caches per ref. A run can restore from its own ref and from the repository default branch (`develop`). Caches written during a `pull_request` run land in `refs/pull/<n>/merge` and are readable **only by that same PR**.

`ci-native.yml` and `ci-wasm.yml` triggered only on `pull_request` and release tags — never on a push to `develop` — so the one scope every branch is allowed to inherit from stayed empty:

| Ref | Entries | Size | Reachable from a new PR? |
|---|---:|---:|---|
| `refs/heads/refs/tags/native-v7.0.0-alpha.1` | 193 | 4.67 GB | never |
| `refs/pull/538/merge` | 116 | 2.21 GB | only PR 538 |
| `refs/pull/555/merge` | 107 | 1.96 GB | only PR 555 |
| `refs/pull/554/merge` | 70 | 1.12 GB | only PR 554 |
| **`refs/heads/develop`** | **2** | **0.03 GB** | yes |

Both develop entries were written by `docs.yml`, the only workflow with a develop push trigger — which is the proof of mechanism.

## What changed

**`push: branches: [develop]`** added to both workflows, so the full matrix runs on merge and writes into `refs/heads/develop`.

No change to `.github/actions/setup-native-build-cache` — the `restore-keys` prefixes (`native-node-<os>-<arch>-<node>-` etc.) are already the fallback lookup this depends on. Once develop holds an entry under a prefix, PRs pick it up automatically.

**`cancel-in-progress` fixed.** It evaluated `!startsWith(github.ref, 'refs/tags/')`, which is **true** for develop pushes — back-to-back merges would cancel each other and the cancelled run would save no cache. Now cancels only `pull_request` runs; tags keep their existing no-cancel behaviour.

## Deliberately not included

No `paths:` filter on the push block. `on.push` is a single block, so a filter there would also apply to the `native-v*` / `wasm-v*` tag pushes, and a tag pointing at an already-pushed commit can evaluate to zero changed files and **silently skip the release build**.

The cost is that unrelated merges to develop (docs, README, other workflows) also trigger the full matrix, re-saving a cache under an unchanged key. If that proves noisy, the safe fix is a thin wrapper workflow triggered on push-to-develop *with* `paths`, calling the main workflow via `workflow_call` — reusable workflows run under the caller's ref, so caches still land in the develop scope. Tracked as step 3 in #569.

## Verification

- Both files parse; push triggers resolve to `{branches: [develop], tags: [native-v*]}` / `{branches: [develop], tags: [wasm-v*]}` across 9 and 5 jobs respectively.
- Release jobs remain gated on `startsWith(github.ref, 'refs/tags/native-v')` / `wasm-v`, so develop pushes build and cache but publish nothing.

Note that the cache quota is saturated (~10.1 GB against 10 GB), with 4.67 GB on an unreachable tag ref. Until that is reclaimed (step 2 in #569), LRU eviction may drop the new develop entries before branches benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
