### PR TITLE
Back-port npm trusted publishing fixes from the 7.0.0-alpha.1 release

### DIFF
--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -500,6 +500,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+      - run: npm install --global npm@11.5.1
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -500,7 +500,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -104,7 +104,6 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          registry-url: https://registry.npmjs.org
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -104,6 +104,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      - run: npm install --global npm@11.5.1
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"


### PR DESCRIPTION
Two publishing fixes were made directly on `release/v7.0.0-alpha.1` while cutting
the alpha and never landed on `develop`. Without them the next release cut from
`develop` would hit the same npm publish failures again.

Cherry-picked from the release branch (clean, no conflicts):

- `Use OIDC for npm publishing` (e69935a) — drop `registry-url` from
  `actions/setup-node` in the native and Wasm publish jobs, so npm uses the
  workflow's OIDC token (`id-token: write`) instead of writing an `.npmrc` that
  expects an auth token.
- `Use supported npm for trusted publishing` (39e605b) — install npm 11.5.1
  globally in those jobs, since the npm bundled with Node 22 predates trusted
  publishing support.

Scope is limited to the two publish jobs in `.github/workflows/ci-native.yml`
and `.github/workflows/ci-wasm.yml`; no package or source changes.

Note: `release/v7.0.0-alpha.1` also carries `Prepare 7.0.0-alpha.1 release`
(version bumps + CHANGELOG release section). That one is deliberately left out
here — `develop` has picked up further `Unreleased` entries since the branch was
cut, so it needs a separate integration rather than a cherry-pick.