### PR TITLE
Fix npm trusted publishing and prepare 7.0.0-beta.1

### DIFF
--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -500,6 +500,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+      - run: npm install --global npm@11.5.1
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -500,7 +500,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -104,7 +104,6 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          registry-url: https://registry.npmjs.org
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -104,6 +104,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      - run: npm install --global npm@11.5.1
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.0.0-beta.1] - 2026-09-05
+
 ### Added
 
 - Add `PDFWriter.replaceObject()` for page-scoped indirect object replacement, with optional global scope [#315](https://github.com/julianhille/MuhammaraJS/issues/315)
 - Add `Recipe.replaceText()` for replacing literal text in a page content stream [#315](https://github.com/julianhille/MuhammaraJS/issues/315)
+- Add Electron 38.x through 44.x build targets [#537](https://github.com/julianhille/MuhammaraJS/issues/537)
 
 ### Fixed
 
 - Generate native API reference pages during Read the Docs builds and cache the
   native addon used to validate executable documentation examples [#566](https://github.com/julianhille/MuhammaraJS/issues/566)
+- Build current Electron versions with V8 external pointer tags [#537](https://github.com/julianhille/MuhammaraJS/issues/537)
 
 ### Changed
 
 - Skip native package CI for documentation-only changes; Documentation CI
   validates those updates.
 
-## [7.0.0-alpha.0] - 2026-09-02
+## [7.0.0-alpha.1] - 2026-09-04
 
 ### Breaking Changes
 
@@ -56,7 +60,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add opt-in fixed-height clipping and an `onClip` callback to Recipe text boxes
 - Bundle pinned OpenSSL 3.5.4 statically in official native prebuilts.
 - Speed up native source builds with parallel compilation and ccache-backed CI caches [#562](https://github.com/julianhille/MuhammaraJS/issues/562)
-- Add Electron 38.x through 44.x build targets [#537](https://github.com/julianhille/MuhammaraJS/issues/537)
 
 ### Fixed
 
@@ -68,7 +71,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add native sanitizer coverage for lifecycle cleanup.
 - Release PDF readers in documentation tests to prevent Windows file-lock cleanup failures.
 - Remove the duplicate documentation example test from the documentation CI workflow.
-- Build current Electron versions with V8 external pointer tags [#537](https://github.com/julianhille/MuhammaraJS/issues/537)
 - Prevent a segmentation fault when `endPDF()` is called more than once.
 - Update macOS runner from macos-13 to macos-14
 - Fix DictionaryContext.writeKey() signature to include required key parameter [#479](https://github.com/julianhille/MuhammaraJS/issues/479)
@@ -641,7 +643,9 @@ with the following changes.
 
 - Initial release
 
-[unreleased]: https://github.com/julianhille/MuhammaraJS/compare/6.0.6...HEAD
+[unreleased]: https://github.com/julianhille/MuhammaraJS/compare/native-v7.0.0-beta.1...HEAD
+[7.0.0-beta.1]: https://github.com/julianhille/MuhammaraJS/compare/native-v7.0.0-alpha.1...native-v7.0.0-beta.1
+[7.0.0-alpha.1]: https://github.com/julianhille/MuhammaraJS/compare/6.0.6...native-v7.0.0-alpha.1
 [6.0.6]: https://github.com/julianhille/MuhammaraJS/compare/6.0.5...6.0.6
 [6.0.5]: https://github.com/julianhille/MuhammaraJS/compare/6.0.4...6.0.5
 [6.0.4]: https://github.com/julianhille/MuhammaraJS/compare/6.0.3...6.0.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -2971,12 +2971,12 @@
     },
     "packages/native": {
       "name": "@muhammara/native",
-      "version": "7.0.0-alpha.0",
+      "version": "7.0.0-beta.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^2.0.3",
-        "@muhammara/native-core": "7.0.0-alpha.0"
+        "@muhammara/native-core": "7.0.0-beta.1"
       },
       "engines": {
         "node": "20 || 22 || 24 || >=25"
@@ -2984,7 +2984,7 @@
     },
     "packages/native-core": {
       "name": "@muhammara/native-core",
-      "version": "7.0.0-alpha.0",
+      "version": "7.0.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.10",
@@ -2997,12 +2997,12 @@
     },
     "packages/native-with-source": {
       "name": "@muhammara/native-with-source",
-      "version": "7.0.0-alpha.0",
+      "version": "7.0.0-beta.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^2.0.3",
-        "@muhammara/native-core": "7.0.0-alpha.0"
+        "@muhammara/native-core": "7.0.0-beta.1"
       },
       "bin": {
         "muhammara-clean-source": "scripts/remove-source.js"
@@ -3024,7 +3024,7 @@
     },
     "packages/wasm": {
       "name": "@muhammara/wasm",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0-beta.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "jsdoc-to-markdown": "^9.1.3",

--- a/packages/native-core/package.json
+++ b/packages/native-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muhammara/native-core",
-  "version": "7.0.0-alpha.0",
+  "version": "7.0.0-beta.1",
   "description": "Shared JavaScript API for MuhammaraJS native packages",
   "homepage": "https://muhammarajs.readthedocs.io/",
   "license": "Apache-2.0",

--- a/packages/native-with-source/package.json
+++ b/packages/native-with-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muhammara/native-with-source",
-  "version": "7.0.0-alpha.0",
+  "version": "7.0.0-beta.1",
   "description": "HummusJS-compatible native PDF addon with C++ source for local Node.js and Electron builds",
   "homepage": "https://muhammarajs.readthedocs.io/",
   "license": "Apache-2.0",
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "@mapbox/node-pre-gyp": "^2.0.3",
-    "@muhammara/native-core": "7.0.0-alpha.0"
+    "@muhammara/native-core": "7.0.0-beta.1"
   },
   "devDependencies": {
     "@types/node": "^22.2.0",

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muhammara/native",
-  "version": "7.0.0-alpha.0",
+  "version": "7.0.0-beta.1",
   "description": "HummusJS-compatible native PDF addon with prebuilt binaries",
   "homepage": "https://muhammarajs.readthedocs.io/",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@mapbox/node-pre-gyp": "^2.0.3",
-    "@muhammara/native-core": "7.0.0-alpha.0"
+    "@muhammara/native-core": "7.0.0-beta.1"
   },
   "binary": {
     "module_name": "muhammara",

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `@muhammara/wasm` are documented in this file.
 
 ## [Unreleased]
 
+## [1.0.0-beta.1] - 2026-09-05
+
 ### Fixed
 
 - Generate the API reference during Read the Docs builds [#566](https://github.com/julianhille/MuhammaraJS/issues/566)
@@ -13,7 +15,7 @@ All notable changes to `@muhammara/wasm` are documented in this file.
 - Skip Wasm package CI for documentation-only changes; Documentation CI
   validates those updates.
 
-## [1.0.0-alpha.0] - 2026-09-02
+## [1.0.0-alpha.1] - 2026-09-04
 
 ### Added
 
@@ -27,5 +29,6 @@ All notable changes to `@muhammara/wasm` are documented in this file.
 - Validate Wasm ABI exports, resource ownership, temporary-file cleanup, and
   bounded byte input/output handling.
 
-[Unreleased]: https://github.com/julianhille/MuhammaraJS/compare/wasm-v1.0.0-alpha.0...HEAD
-[1.0.0-alpha.0]: https://github.com/julianhille/MuhammaraJS/releases/tag/wasm-v1.0.0-alpha.0
+[Unreleased]: https://github.com/julianhille/MuhammaraJS/compare/wasm-v1.0.0-beta.1...HEAD
+[1.0.0-beta.1]: https://github.com/julianhille/MuhammaraJS/compare/wasm-v1.0.0-alpha.1...wasm-v1.0.0-beta.1
+[1.0.0-alpha.1]: https://github.com/julianhille/MuhammaraJS/releases/tag/wasm-v1.0.0-alpha.1

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muhammara/wasm",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-beta.1",
   "description": "Browser-safe, byte-first WebAssembly API for Muhammara",
   "license": "Apache-2.0",
   "homepage": "https://muhammarajs-wasm.readthedocs.io/",


### PR DESCRIPTION
Supersedes #574: this PR carries the same two cherry-picks plus the release
preparation, so only this one needs to merge.

## Publish fixes, cherry-picked from `release/v7.0.0-alpha.1`

Both were made directly on the release branch while cutting the alpha and never
came back to `develop`, so the next release cut from `develop` would hit the same
npm publish failures.

- `Use OIDC for npm publishing` (e69935a) — drop `registry-url` from
  `actions/setup-node` in the native and Wasm publish jobs, so npm uses the
  workflow's OIDC token (`id-token: write`) instead of writing an `.npmrc` that
  expects an auth token.
- `Use supported npm for trusted publishing` (39e605b) — install npm 11.5.1
  globally in those jobs, since the npm bundled with Node 22 predates trusted
  publishing support.

## Release preparation

- `@muhammara/native`, `@muhammara/native-core`, `@muhammara/native-with-source`
  → `7.0.0-beta.1`; `@muhammara/wasm` → `1.0.0-beta.1` (plus `package-lock.json`).
- Both changelogs get a `7.0.0-beta.1` / `1.0.0-beta.1` section holding the
  entries that accumulated since the alpha, with an empty `[Unreleased]` above it
  and updated compare links.
- The released section was still headed `7.0.0-alpha.0` / `1.0.0-alpha.0` on
  `develop`; the release branch had relabelled it to `alpha.1` when it shipped,
  and only `alpha.1` was ever tagged and published. This corrects the headings to
  `7.0.0-alpha.1` - 2026-09-04 and `1.0.0-alpha.1` - 2026-09-04.
- The two Electron #537 entries landed on `develop` after the alpha branch was
  cut, so they were sitting in the already-released section; they move into the
  beta.1 section where they actually ship.

No tags are created here — tagging `native-v7.0.0-beta.1` / `wasm-v1.0.0-beta.1`
is what triggers publishing, and that stays a manual step after this merges.
