### PR TITLE
ci: fix build-node-linux on EOL Debian bullseye

### DIFF
--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -383,7 +383,21 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           architecture: ${{ matrix.architecture_node }}
-      - run: apt-get update && apt-get install -y ccache perl
+      - name: Install build tools from the Debian archive
+        run: |
+          # Debian 11 LTS ended 2026-08-31. deb.debian.org is dropping bullseye
+          # pool files while its indexes still advertise them, so pin to the
+          # archive. bullseye-security is not on archive.debian.org yet, so drop
+          # it -- this container is an ephemeral builder and ships nothing
+          # (OpenSSL is built from source and statically linked).
+          # perl is not installed here: it ships with the image already and
+          # OpenSSL's build needs it. The musl and dockcross jobs still install
+          # it explicitly because their images do not carry it.
+          sed -i -e '/bullseye-security/d' \
+                 -e 's|deb.debian.org|archive.debian.org|g' \
+                 /etc/apt/sources.list
+          echo 'Acquire::Check-Valid-Until "0";' > /etc/apt/apt.conf.d/99no-check-valid-until
+          apt-get update && apt-get install -y ccache
       - uses: ./.github/actions/setup-native-build-cache
         with:
           key: native-node-linux-${{ matrix.target_architecture }}-${{ matrix.node }}-${{ hashFiles('packages/native-with-source/binding.gyp', 'packages/native-with-source/src/**') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Build Linux prebuilds against the Debian archive now that Debian 11
+  bullseye is end of life [#577](https://github.com/julianhille/MuhammaraJS/issues/577)
+
 ## [7.0.0-beta.1] - 2026-09-05
 
 ### Added


### PR DESCRIPTION
Fixes #577.

`build-node-linux` has been failing on the `apt-get update && apt-get install -y ccache perl`
step ([run 33987690684](https://github.com/julianhille/MuhammaraJS/actions/runs/33987690684)):

```
Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [27.2 kB]   <- index OK
Err:1 .../libperl5.32 amd64 5.32.1-4+deb11u5
  404  Not Found
```

Debian 11 LTS ended **2026-08-31**, and `deb.debian.org` has begun removing bullseye pool files
while its indexes still advertise them. `perl` is already in the image, so the install was only
attempting an *upgrade* into that hole — which is what killed the step. The failure looked
intermittent (arm64 and node 20.9.0 passed in the same run) because it is CDN-edge dependent; it
would have become permanent.

## Changes

- Pin apt to `archive.debian.org` and **drop** the `bullseye-security` entry. That suite is not on
  the archive — `archive.debian.org/debian-security/dists/` stops at `buster` — so redirecting it
  there would leave a repo with no `Release` file and fail `apt-get update` instead. Dropping it is
  fine: this container is an ephemeral builder that ships nothing (OpenSSL is compiled from source
  and statically linked, which the workflow already asserts).
- Disable `Acquire::Check-Valid-Until`, since archived `Release` files are past their expiry.
- Stop installing `perl` in this job only. The musl and dockcross jobs keep installing it, because
  their images genuinely do not carry it.

Scope is limited to `build-node-linux`. The `sudo apt-get` steps elsewhere run on the Ubuntu runner,
not in a Debian container, and `build-musl` uses `apk`.

## Verification

Run locally against the real container:

- Failure reproduced in a pristine `gcc:11-bullseye` — identical `libperl5.32` 404.
- With the fix, `apt-get install` exits 0 and ccache 4.2 installs.
- `perl` confirmed image-provided at `5.32.1-4+deb11u3`, with the workflow no longer installing it.
- **Full** `build-openssl.sh` run (`Configure` + `make build_libs`) produces `libcrypto.a`, with the
  39 perlasm-generated `.s` files present — so perl is exercised through `make`, not just configure.
- `archive.debian.org` bullseye main confirmed to carry `ccache 4.2-1` and `perl 5.32.1-4+deb11u3`
  for **both** amd64 and arm64.
- The step now fetches **446 kB instead of 9294 kB**.

arm64 was not run locally (no binfmt on this machine); it is covered by the archive index check
above and by CI.

## Follow-up

This keeps a frozen, unsupported base alive. #576 tracks moving off bullseye, and the measured
glibc-floor consequences of doing so.
