### PR TITLE
Cache Wasm compiler artifacts in CI

### DIFF
--- a/.github/actions/setup-wasm-build-cache/action.yml
+++ b/.github/actions/setup-wasm-build-cache/action.yml
@@ -1,0 +1,28 @@
+name: Setup Wasm build cache
+description: Restore the bounded Emscripten compiler cache for one Wasm build configuration.
+
+inputs:
+  sanitize:
+    description: MUHAMMARA_WASM_SANITIZE value the job builds with; sanitizer and normal builds never share a cache.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve the compiler cache for this configuration
+      id: configuration
+      shell: sh
+      env:
+        MUHAMMARA_WASM_SANITIZE: ${{ inputs.sanitize }}
+      run: |
+        directory=$(./packages/wasm/build.sh --print-cache-directory)
+        digest=$(sed -n 's/^image=.*@sha256:\([0-9a-f]\{64\}\)$/\1/p' packages/wasm/build.sh)
+        test -n "$digest"
+        echo "directory=${directory#"$PWD/"}" >> "$GITHUB_OUTPUT"
+        echo "name=$(basename "$directory")" >> "$GITHUB_OUTPUT"
+        echo "digest=$digest" >> "$GITHUB_OUTPUT"
+    - uses: actions/cache@v5
+      with:
+        path: ${{ steps.configuration.outputs.directory }}
+        key: wasm-${{ steps.configuration.outputs.name }}-${{ steps.configuration.outputs.digest }}-${{ hashFiles('packages/wasm/build.sh', 'packages/wasm/CMakeLists.txt', 'packages/wasm/src/**', 'packages/native-with-source/src/**') }}
+        restore-keys: wasm-${{ steps.configuration.outputs.name }}-${{ steps.configuration.outputs.digest }}-

--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/ci-wasm.yml"
+      - ".github/actions/setup-wasm-build-cache/**"
       - "package.json"
       - "package-lock.json"
       - "packages/native-with-source/src/**"
@@ -35,6 +36,9 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      - uses: ./.github/actions/setup-wasm-build-cache
+        with:
+          sanitize: "OFF"
       - run: npm ci --ignore-scripts
       - run: npm run wasm:build
       - name: Verify Wasm package contents
@@ -83,6 +87,9 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      - uses: ./.github/actions/setup-wasm-build-cache
+        with:
+          sanitize: "ON"
       - run: npm ci --ignore-scripts
       - name: Build with Emscripten LeakSanitizer
         run: npm run wasm:build

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ xcode/DerivedData
 #Visual code unwanted
 .vscode
 packages/wasm/build/
+packages/wasm/.ccache/
 packages/wasm/dist/
 packages/wasm/docs/reference.md
 packages/native/docs/recipe/reference.md

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `@muhammara/wasm` are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Cache Emscripten compiler output between builds and give each build
+  configuration its own build directory, so repeat builds reuse compiled
+  objects while sanitizer and normal builds stay separate
+  [#568](https://github.com/julianhille/MuhammaraJS/issues/568)
+
 ## [1.0.0-beta.1] - 2026-09-05
 
 ### Fixed

--- a/packages/wasm/build.sh
+++ b/packages/wasm/build.sh
@@ -3,23 +3,83 @@ set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 image=emscripten/emsdk:3.1.74@sha256:af45409f3199d88db4b1b03af0098532c8fb33a375ac257463eeb0a622870d06
-build="$root/packages/wasm/build"
-dist="$root/packages/wasm/dist"
 sanitize=${MUHAMMARA_WASM_SANITIZE:-OFF}
+buildType=${MUHAMMARA_WASM_BUILD_TYPE:-Release}
+# Sanitizer and normal builds use incompatible objects, so they never share a
+# CMake tree or a compiler cache.
+configuration=$(printf '%s' "$buildType-sanitize-$sanitize" | tr 'A-Z' 'a-z')
+build="$root/packages/wasm/build/$configuration"
+dist="$root/packages/wasm/dist"
+ccache="${MUHAMMARA_WASM_CCACHE_DIR:-$root/packages/wasm/.ccache}/$configuration"
+
+# CI restores the compiler cache before Docker is involved, so the directories
+# are reported by the script that owns their layout instead of being repeated
+# in the workflow.
+if [ $# -gt 0 ]; then
+  case $1 in
+  --print-build-directory)
+    printf '%s\n' "$build"
+    exit 0
+    ;;
+  --print-cache-directory)
+    printf '%s\n' "$ccache"
+    exit 0
+    ;;
+  *)
+    echo "usage: build.sh [--print-build-directory|--print-cache-directory]" >&2
+    exit 2
+    ;;
+  esac
+fi
 
 if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
   echo "Muhammara Wasm builds require a usable Docker daemon; see packages/wasm/docs/development.md." >&2
   exit 1
 fi
 
+# The pinned Emscripten image ships no ccache, so compiler caching runs in a
+# thin layer on top of it. The tag follows the pinned digest: bumping the image
+# builds a new toolchain instead of reusing the previous one.
+toolchain=$image
+if [ "${MUHAMMARA_WASM_CCACHE:-ON}" != "OFF" ]; then
+  digest=${image##*@sha256:}
+  toolchainTag="muhammara-wasm-emsdk-ccache:$(printf '%s' "$digest" | cut -c1-12)"
+  if docker image inspect "$toolchainTag" >/dev/null 2>&1; then
+    toolchain=$toolchainTag
+  elif printf '%s\n' \
+    "FROM $image" \
+    "RUN apt-get update && apt-get install -y --no-install-recommends ccache && rm -rf /var/lib/apt/lists/*" |
+    docker build -t "$toolchainTag" - >&2; then
+    toolchain=$toolchainTag
+  else
+    echo "Could not build the ccache toolchain image; continuing without a compiler cache." >&2
+  fi
+fi
+
 mkdir -p "$build" "$dist"
+if [ "$toolchain" = "$image" ]; then
+  set --
+else
+  mkdir -p "$ccache"
+  set -- \
+    --mount "type=bind,src=$ccache,dst=/ccache" \
+    -e CCACHE_DIR=/ccache \
+    -e CCACHE_MAXSIZE="${MUHAMMARA_WASM_CCACHE_MAXSIZE:-1G}" \
+    -e EM_COMPILER_WRAPPER=ccache
+fi
+
 docker run --rm \
   --user "$(id -u):$(id -g)" \
   --mount "type=bind,src=$root,dst=/src,readonly" \
   --mount "type=bind,src=$build,dst=/build" \
   --mount "type=bind,src=$dist,dst=/out" \
+  -e MUHAMMARA_WASM_BUILD_TYPE="$buildType" \
+  -e MUHAMMARA_WASM_SANITIZE="$sanitize" \
+  "$@" \
   -w /build \
-  "$image" \
-  sh -c "emcmake cmake -S /src/packages/wasm -B /build -DCMAKE_BUILD_TYPE=Release -DMUHAMMARA_WASM_SANITIZE=$sanitize -DPDFHUMMUS_NO_OPENSSL=ON &&
-    cmake --build /build --target muhammara-wasm --parallel &&
-    cp /build/muhammara-wasm.js /build/muhammara-wasm.wasm /out/"
+  "$toolchain" \
+  sh -c 'set -eu
+emcmake cmake -S /src/packages/wasm -B /build -DCMAKE_BUILD_TYPE="$MUHAMMARA_WASM_BUILD_TYPE" -DMUHAMMARA_WASM_SANITIZE="$MUHAMMARA_WASM_SANITIZE" -DPDFHUMMUS_NO_OPENSSL=ON
+cmake --build /build --target muhammara-wasm --parallel
+cp /build/muhammara-wasm.js /build/muhammara-wasm.wasm /out/
+if command -v ccache >/dev/null 2>&1; then ccache --show-stats; fi'

--- a/packages/wasm/docs/development.md
+++ b/packages/wasm/docs/development.md
@@ -15,6 +15,38 @@ the command; the build intentionally has no local-Emscripten fallback so release
 artifacts use the pinned image. Release CI builds `dist/` first and publishes the
 validated result with npm lifecycle scripts disabled.
 
+## Compiler Cache
+
+The pinned Emscripten image ships no `ccache`, so the build adds it in a thin
+layer on top of that image and tags the result with the pinned digest. The
+layer is built once per digest and reused afterwards; when it cannot be built,
+for example without network access, the build falls back to the pinned image
+and compiles without a cache.
+
+Compiled objects are kept in `packages/wasm/.ccache/<configuration>` and the
+CMake tree in `packages/wasm/build/<configuration>`, where the configuration
+is derived from the build type and the sanitizer setting
+(`release-sanitize-off`, `release-sanitize-on`). Sanitizer and normal builds
+therefore never share objects. Wasm CI restores the cache per configuration
+through `.github/actions/setup-wasm-build-cache`, keyed on the Emscripten image
+digest, the build script, `CMakeLists.txt`, and the Wasm and shared C++
+sources. Cached and uncached builds produce identical `dist/` bytes.
+
+These environment variables adjust the build:
+
+| Variable                        | Default                 | Effect                                                |
+| ------------------------------- | ----------------------- | ----------------------------------------------------- |
+| `MUHAMMARA_WASM_SANITIZE`       | `OFF`                   | Build with Emscripten LeakSanitizer.                  |
+| `MUHAMMARA_WASM_BUILD_TYPE`     | `Release`               | `CMAKE_BUILD_TYPE` for the build.                     |
+| `MUHAMMARA_WASM_CCACHE`         | `ON`                    | Set to `OFF` to build straight from the pinned image. |
+| `MUHAMMARA_WASM_CCACHE_DIR`     | `packages/wasm/.ccache` | Root directory holding the per-configuration caches.  |
+| `MUHAMMARA_WASM_CCACHE_MAXSIZE` | `1G`                    | Upper bound for one configuration's cache.            |
+
+`./packages/wasm/build.sh --print-cache-directory` and
+`--print-build-directory` report the directories for the current settings
+without touching Docker; CI uses the first one so the workflow never repeats
+the layout the script owns.
+
 After a build, run the focused checks:
 
 ```sh

--- a/packages/wasm/tests/BuildCacheConfiguration.test.mjs
+++ b/packages/wasm/tests/BuildCacheConfiguration.test.mjs
@@ -1,0 +1,95 @@
+// The compiler cache is only safe while sanitizer and normal builds stay in
+// separate directories, and only effective while CI derives those directories
+// from the build script instead of repeating its layout.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+var repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
+var buildScript = fileURLToPath(new URL("../build.sh", import.meta.url));
+
+function directory(flag, environment) {
+  return execFileSync(buildScript, [flag], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    env: Object.assign({}, process.env, environment),
+  }).trim();
+}
+
+describe("BuildCacheConfiguration", function () {
+  it("keeps sanitizer and normal builds in separate directories", function () {
+    var normalCache = directory("--print-cache-directory", {
+      MUHAMMARA_WASM_SANITIZE: "OFF",
+    });
+    var sanitizerCache = directory("--print-cache-directory", {
+      MUHAMMARA_WASM_SANITIZE: "ON",
+    });
+    var normalBuild = directory("--print-build-directory", {
+      MUHAMMARA_WASM_SANITIZE: "OFF",
+    });
+    var sanitizerBuild = directory("--print-build-directory", {
+      MUHAMMARA_WASM_SANITIZE: "ON",
+    });
+
+    assert.notEqual(normalCache, sanitizerCache);
+    assert.notEqual(normalBuild, sanitizerBuild);
+    assert.match(normalCache, /packages\/wasm\/\.ccache\/[^/]+$/);
+    assert.match(sanitizerCache, /packages\/wasm\/\.ccache\/[^/]+$/);
+    assert.match(normalBuild, /packages\/wasm\/build\/[^/]+$/);
+    assert.match(sanitizerBuild, /packages\/wasm\/build\/[^/]+$/);
+  });
+
+  it("honours the cache directory and build type overrides", function () {
+    assert.equal(
+      directory("--print-cache-directory", {
+        MUHAMMARA_WASM_CCACHE_DIR: "/tmp/muhammara-wasm-cache",
+        MUHAMMARA_WASM_SANITIZE: "OFF",
+      }),
+      "/tmp/muhammara-wasm-cache/release-sanitize-off",
+    );
+    assert.match(
+      directory("--print-build-directory", {
+        MUHAMMARA_WASM_BUILD_TYPE: "Debug",
+        MUHAMMARA_WASM_SANITIZE: "ON",
+      }),
+      /\/debug-sanitize-on$/,
+    );
+  });
+
+  it("rejects unknown arguments instead of starting a build", function () {
+    var status = null;
+    try {
+      execFileSync(buildScript, ["--print-cache-dir"], {
+        cwd: repositoryRoot,
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+    } catch (error) {
+      status = error.status;
+    }
+
+    assert.equal(status, 2);
+  });
+
+  it("lets the Wasm workflow derive its cache from the build script", function () {
+    var action = readFileSync(
+      new URL(
+        "../../../.github/actions/setup-wasm-build-cache/action.yml",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    var workflow = readFileSync(
+      new URL("../../../.github/workflows/ci-wasm.yml", import.meta.url),
+      "utf8",
+    );
+
+    assert.ok(action.includes("--print-cache-directory"));
+    assert.ok(action.includes("packages/wasm/CMakeLists.txt"));
+    assert.ok(action.includes("packages/wasm/src/**"));
+    assert.ok(action.includes("packages/native-with-source/src/**"));
+    assert.ok(workflow.includes('sanitize: "OFF"'));
+    assert.ok(workflow.includes('sanitize: "ON"'));
+  });
+});


### PR DESCRIPTION
Closes #568.

The Wasm workflow cached npm downloads but recompiled every PDFWriter, FreeType,
LibTiff and Wasm translation unit on every run.

## Compiler cache

The pinned `emscripten/emsdk:3.1.74` image ships no `ccache`, so `build.sh`
stacks a thin layer on top of the pinned digest that installs one, tags it after
that digest, and runs the compile with `EM_COMPILER_WRAPPER=ccache` against a
bind-mounted cache directory. Bumping the image builds a new toolchain instead of
reusing the previous one. When the layer cannot be built — without network
access, for example — the build falls back to the pinned image and compiles
uncached with a warning, so an offline build still works.

## Separating the configurations

Both the CMake tree and the compiler cache now live under a per-configuration
directory derived from `MUHAMMARA_WASM_BUILD_TYPE` and `MUHAMMARA_WASM_SANITIZE`
(`build/release-sanitize-on`, `.ccache/release-sanitize-off`, …), so sanitizer
and normal builds never share objects. The sanitizer job keeps building
independently with sanitization enabled and still never downloads the build job
artifact.

`.github/actions/setup-wasm-build-cache` takes the job's `MUHAMMARA_WASM_SANITIZE`
value, asks `build.sh --print-cache-directory` for the directory rather than
repeating the layout the script owns, and keys `actions/cache` on the Emscripten
image digest, `build.sh`, `CMakeLists.txt`, `packages/wasm/src/**` and the shared
C++ sources in `packages/native-with-source/src/**`, with a digest-scoped
`restore-keys` prefix. This mirrors how `setup-native-build-cache` is used in
`ci-native.yml`.

The issue asks for the native-core sources in the key; `@muhammara/native-core`
is JS only, so the sources the Wasm build actually compiles —
`packages/native-with-source/src` — are what the key hashes.

## Verified locally

- A build from an emptied build tree drops from **54s to 15s** with a warm cache,
  330 of 332 compilations served from it. The two misses are CMake's compiler-id
  probes.
- `dist/muhammara-wasm.js` and `dist/muhammara-wasm.wasm` are **byte identical**
  (sha256) with the cache and with `MUHAMMARA_WASM_CCACHE=OFF`.
- The sanitizer build lands in its own tree and cache with 0 of 664 hits against
  the normal cache — no sharing — and `MemoryLifecycle.test.mjs` passes on it.
- Full Wasm suite green (136 tests), plus `wasm:verify`, `wasm:test:paths`,
  `wasm:test:exports`, `wasm:test:types` and Prettier.

## Definition of done

- **Parity**: Wasm-side CI and build tooling only; native already caches through
  `setup-native-build-cache`. No user-visible API changes, so no `DIFFERENCES.md`
  entry.
- **Tests**: `packages/wasm/tests/BuildCacheConfiguration.test.mjs` asserts the
  two configurations never share a build or cache directory, that the overrides
  are honoured, that an unknown flag exits 2 instead of starting a build, and
  that the workflow derives its cache from `build.sh`.
- **Types**: none affected.
- **Docs**: a Compiler Cache section in `packages/wasm/docs/development.md`
  covering the layer, the directory layout, the environment variables and the
  reporting flags. `docs:check` was not run locally (mkdocs is not installed
  here); the edit adds no links or nav entries.
- **Browser example**: not applicable, this is build infrastructure.
- **Changelog**: `### Changed` under `## [Unreleased]` in
  `packages/wasm/CHANGELOG.md`, linking the issue. No breaking change.
