### PR TITLE
Close append file handles on the error paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Release the source PDF file handle that `Recipe` holds, so the source,
   appended, and overlaid files can be deleted right after `endPDF()` instead of
   failing with `EBUSY` on Windows [#381](https://github.com/julianhille/MuhammaraJS/issues/381)
+- Release the file handles `Recipe#appendPage()` opens when the appended PDF
+  cannot be read or a page cannot be copied, instead of leaking them for the
+  life of the process [#381](https://github.com/julianhille/MuhammaraJS/issues/381)
 
 ### Changed
 

--- a/packages/native-core/lib/recipe/appendPage.js
+++ b/packages/native-core/lib/recipe/appendPage.js
@@ -16,10 +16,19 @@ exports.appendPage = function appendPage(pdfSrc, pages = []) {
   }
   // Using stream so it can be closed to release reader resource (Issue #61)
   const instream = new muhammara.PDFRStreamForFile(pdfSrc);
-  const pdfReader = muhammara.createReader(instream);
-  const pageCount = pdfReader.getPagesCount();
-  pdfReader.end();
-  instream.close();
+  let pageCount;
+  try {
+    const pdfReader = muhammara.createReader(instream);
+    try {
+      pageCount = pdfReader.getPagesCount();
+    } finally {
+      pdfReader.end();
+    }
+  } finally {
+    // An unreadable source must not leave the file open, which would keep it
+    // locked on Windows for the life of the process.
+    instream.close();
+  }
 
   // prevent unmatched pagenumber
   const transformPageNumber = (pageNum) => {

--- a/packages/native-core/lib/recipe/utils.js
+++ b/packages/native-core/lib/recipe/utils.js
@@ -14,28 +14,30 @@ function appendPDFPageFromPDFWithAnnotations(
   pageNumber,
 ) {
   const cpyCxt = pdfWriter.createPDFCopyingContext(sourcePDFPath);
-  const cpyCxtParser = cpyCxt.getSourceDocumentParser();
-  const pageDictionary = cpyCxtParser.parsePageDictionary(pageNumber);
+  try {
+    const cpyCxtParser = cpyCxt.getSourceDocumentParser();
+    const pageDictionary = cpyCxtParser.parsePageDictionary(pageNumber);
 
-  if (!pageDictionary.exists(ANNOTATION_PREFIX)) {
-    cpyCxt.appendPDFPageFromPDF(pageNumber);
-  } else {
-    let reffedObjects;
-    pdfWriter.getEvents().once("OnPageWrite", (params) => {
-      params.pageDictionaryContext.writeKey(ANNOTATION_PREFIX);
-      reffedObjects = cpyCxt.copyDirectObjectWithDeepCopy(
-        pageDictionary.queryObject(ANNOTATION_PREFIX),
-      );
-    });
+    if (!pageDictionary.exists(ANNOTATION_PREFIX)) {
+      cpyCxt.appendPDFPageFromPDF(pageNumber);
+    } else {
+      let reffedObjects;
+      pdfWriter.getEvents().once("OnPageWrite", (params) => {
+        params.pageDictionaryContext.writeKey(ANNOTATION_PREFIX);
+        reffedObjects = cpyCxt.copyDirectObjectWithDeepCopy(
+          pageDictionary.queryObject(ANNOTATION_PREFIX),
+        );
+      });
 
-    cpyCxt.appendPDFPageFromPDF(pageNumber);
+      cpyCxt.appendPDFPageFromPDF(pageNumber);
 
-    if (reffedObjects && reffedObjects.length > 0) {
-      cpyCxt.copyNewObjectsForDirectObject(reffedObjects);
+      if (reffedObjects && reffedObjects.length > 0) {
+        cpyCxt.copyNewObjectsForDirectObject(reffedObjects);
+      }
     }
+  } finally {
+    cpyCxt.end();
   }
-
-  cpyCxt.end();
 }
 
 /**
@@ -51,21 +53,23 @@ function appendPDFPagesFromPDFWithAnnotations(
   options = {},
 ) {
   const cpyCxt = pdfWriter.createPDFCopyingContext(sourcePDFPath);
-  const cpyCxtParser = cpyCxt.getSourceDocumentParser();
+  try {
+    const cpyCxtParser = cpyCxt.getSourceDocumentParser();
 
-  if (options.specificRanges && options.specificRanges.length) {
-    for (const [start, end] of options.specificRanges) {
-      for (let i = start; i <= end; ++i) {
+    if (options.specificRanges && options.specificRanges.length) {
+      for (const [start, end] of options.specificRanges) {
+        for (let i = start; i <= end; ++i) {
+          appendPDFPageFromPDFWithAnnotations(pdfWriter, sourcePDFPath, i);
+        }
+      }
+    } else {
+      for (let i = 0; i < cpyCxtParser.getPagesCount(); ++i) {
         appendPDFPageFromPDFWithAnnotations(pdfWriter, sourcePDFPath, i);
       }
     }
-  } else {
-    for (let i = 0; i < cpyCxtParser.getPagesCount(); ++i) {
-      appendPDFPageFromPDFWithAnnotations(pdfWriter, sourcePDFPath, i);
-    }
+  } finally {
+    cpyCxt.end();
   }
-
-  cpyCxt.end();
 }
 
 exports.ANNOTATION_PREFIX = ANNOTATION_PREFIX;


### PR DESCRIPTION
appendPage() closed its read stream only after a successful parse, and the copying-context helpers ended their contexts only after a successful copy. An unreadable PDF or a page that cannot be appended therefore leaked the file handle for the life of the process, which endPDF() does not reclaim and which keeps the file locked on Windows.

Close the stream and end the contexts through finally. Verified by counting /proc/self/fd entries after a throw: 1 leaked handle for an unparseable source and 2 for a failed page copy, now 0 in both cases.

Refs #381