### PR TITLE
Document the Perl modules RPM distributions need for source builds

### DIFF
--- a/packages/native-with-source/README.md
+++ b/packages/native-with-source/README.md
@@ -18,6 +18,12 @@ platform C/C++ toolchain, Perl, and `make` on Unix-like systems or Perl, NMake,
 and Visual Studio Build Tools on Windows; no separate OpenSSL installation is
 required.
 
+RPM-based distributions such as Fedora, RHEL, and openSUSE split the Perl core
+library into separate packages, and OpenSSL's `./Configure` needs some of them.
+Install them alongside `perl` with `dnf install perl-FindBin perl-IPC-Cmd`.
+Without them the build stops while configuring OpenSSL with `Can't locate
+FindBin.pm in @INC`. Debian and Ubuntu ship these modules with `perl` itself.
+
 Windows builds use `OPENSSL_VS_INSTALL_PATH`, `GYP_MSVS_OVERRIDE_PATH`,
 `VSINSTALLDIR`, or `npm_config_msbuild_path` when set, then fall back to
 discovering Visual Studio with `vswhere`.

--- a/packages/native/docs/getting-started/installation.md
+++ b/packages/native/docs/getting-started/installation.md
@@ -45,6 +45,23 @@ Perl and `make` on Unix-like systems or Perl, NMake, and Visual Studio Build
 Tools on Windows; no `OPENSSL_LIB_DIR`, `CPPFLAGS`, or separate OpenSSL
 installation is required.
 
+RPM-based distributions such as Fedora, RHEL, and openSUSE split the Perl core
+library into separate packages, and OpenSSL's `./Configure` needs some of them.
+Install them alongside `perl`:
+
+```sh
+dnf install perl-FindBin perl-IPC-Cmd
+```
+
+Without them the build stops while configuring OpenSSL:
+
+```
+Can't locate FindBin.pm in @INC (you may need to install the FindBin module) at ./Configure line 15.
+```
+
+Debian and Ubuntu ship these modules with `perl` itself, so no extra packages
+are needed there.
+
 On Unix-like systems, optionally set `CC="ccache cc"` and `CXX="ccache c++"` to
 speed up repeated source builds when `ccache` is installed.
 


### PR DESCRIPTION
Fedora, RHEL, and openSUSE split the Perl core library into separate packages, so a source build fails in OpenSSL's `./Configure` with `Can't locate FindBin.pm in @INC` unless `perl-FindBin` and `perl-IPC-Cmd` are installed. Debian and Ubuntu ship them with `perl`, which is why CI never hits this.

Both build-prerequisite sections now name the extra packages, the `dnf install` command, and the error text so it is searchable:

- `packages/native/docs/getting-started/installation.md` — full version with the error output
- `packages/native-with-source/README.md` — condensed to one paragraph

Docs only; no code or build changes.

Closes #582