### PR TITLE
Accept PDF 2.0 in Recipe options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add runnable `detect-blank-pages` and `find-text-positions` documentation
   examples, executed by the documentation test suite
   [#275](https://github.com/julianhille/MuhammaraJS/issues/275)
+- Accept PDF 2.0 in `Recipe` options for both the native and Wasm packages.
+  `version: 2.0` (and the `20` enum in the Wasm package) now writes a PDF 2.0
+  header instead of falling back to 1.7, the Wasm `RecipePDFVersion` type
+  includes it, and unsupported values still fall back to 1.7.
 
 ### Fixed
 

--- a/packages/native-core/lib/Recipe.js
+++ b/packages/native-core/lib/Recipe.js
@@ -11,7 +11,7 @@ const streams = require("memory-streams");
  * @param {string|Buffer} src - The file path or Buffer of the source file.
  * @param {string} [output] - The path of the output file uses src if its not a buffer.
  * @param {Object} [options] - The options for pdfDoc
- * @param {number} [options.version] - The pdf version
+ * @param {number} [options.version] - The pdf version: 1.0 through 1.7 or 2.0, defaults to 1.7
  * @param {string} [options.author] - The author
  * @param {string} [options.title] - The title
  * @param {string} [options.subject] - The subject
@@ -121,7 +121,7 @@ class Recipe {
   }
 
   _getVersion(version) {
-    const supportedVersions = [1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7];
+    const supportedVersions = [1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 2.0];
     if (!supportedVersions.includes(version)) {
       version = 1.7;
     }

--- a/packages/native-with-source/tests/recipe/version.js
+++ b/packages/native-with-source/tests/recipe/version.js
@@ -1,0 +1,33 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+
+const header = (output) => {
+  const buffer = Buffer.alloc(8);
+  const file = fs.openSync(output, "r");
+  try {
+    fs.readSync(file, buffer, 0, buffer.length, 0);
+  } finally {
+    fs.closeSync(file);
+  }
+  return buffer.toString("latin1");
+};
+
+const write = (name, options) => {
+  const output = path.join(__dirname, `../output/version-${name}.pdf`);
+  new HummusRecipe("new", output, options).createPage().endPage().endPDF();
+  return header(output);
+};
+
+describe("Version", () => {
+  it("writes the requested pdf version", () => {
+    assert.strictEqual(write("1-5", { version: 1.5 }), "%PDF-1.5");
+    assert.strictEqual(write("2-0", { version: 2.0 }), "%PDF-2.0");
+  });
+
+  it("falls back to 1.7 for unsupported versions", () => {
+    assert.strictEqual(write("default", {}), "%PDF-1.7");
+    assert.strictEqual(write("1-9", { version: 1.9 }), "%PDF-1.7");
+  });
+});

--- a/packages/native/docs/recipe/create-pdfs.md
+++ b/packages/native/docs/recipe/create-pdfs.md
@@ -19,6 +19,24 @@ Pages accept named sizes such as `letter` and `A4`. Within a page, use chainable
 methods such as `text`, `circle`, `polygon`, `rectangle`, `image`, and `comment`.
 Call `endPage()` before creating or editing another page.
 
+## PDF Version
+
+`version` sets the PDF level written into the file header. Recipe accepts the
+canonical decimal levels `1.0` through `1.7` and `2.0`. Any other value falls
+back to `1.7` without an error, so check the header when a specific level
+matters.
+
+```javascript
+var pdfDoc = new Recipe("new", "output.pdf", { version: 2.0 });
+
+pdfDoc.createPage("letter").endPage().endPDF();
+// output.pdf now starts with %PDF-2.0
+```
+
+The low-level `createWriter` API takes the integer enums instead; see
+[Create A PDF](../low-level/create-a-pdf.md). Version handling is exercised in
+[`tests/recipe/version.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/version.js).
+
 ## Buffer Output
 
 Pass `Buffer.from("new")` as the input and omit the output path to receive the

--- a/packages/wasm/docs/recipe.md
+++ b/packages/wasm/docs/recipe.md
@@ -25,6 +25,22 @@ Recipe provides pages, text, shapes, images, tables, composition, annotations,
 metadata, and byte-safe splitting. `setPageBox()` uses PDF bottom-left
 coordinates even though the high-level drawing API uses top-left coordinates.
 
+## PDF Version
+
+`version` sets the PDF level written into the byte output. Recipe accepts the
+canonical decimal levels `1.0` through `1.7` and `2.0`, and the equivalent
+integer enums `10` through `17` and `20` (the `ePDFVersion*` constants on a
+loaded runtime). Any other value falls back to `1.7` without an error.
+
+```js
+var Recipe = await createRecipe();
+var bytes = new Recipe({ version: 2.0 })
+  .createPage(595, 842)
+  .endPage()
+  .endPDF();
+// bytes now start with %PDF-2.0; new Recipe({ version: 20 }) is equivalent
+```
+
 Read [Differences And Restrictions](differences.md) before relying on HTML,
 plugins, encryption, composition annotations, or Node Recipe behavior.
 

--- a/packages/wasm/index.d.ts
+++ b/packages/wasm/index.d.ts
@@ -22,6 +22,7 @@ export type RecipePDFVersion =
   | 1.5
   | 1.6
   | 1.7
+  | 2
   | 10
   | 11
   | 12
@@ -29,7 +30,8 @@ export type RecipePDFVersion =
   | 14
   | 15
   | 16
-  | 17;
+  | 17
+  | 20;
 
 export interface WriterOptions {
   version?: PDFVersion;
@@ -46,7 +48,7 @@ export interface RecipeMargins {
   bottom?: number;
 }
 export interface RecipeOptions {
-  /** PDF version; canonical decimal levels 1.0 through 1.7 and integer enums 10 through 17 are accepted. */
+  /** PDF version; canonical decimal levels 1.0 through 1.7 and 2.0, and integer enums 10 through 17 and 20, are accepted. */
   version?: RecipePDFVersion;
   /** Enables stream compression. Defaults to true. */
   compress?: boolean;

--- a/packages/wasm/lib/recipe/parameters.js
+++ b/packages/wasm/lib/recipe/parameters.js
@@ -56,7 +56,8 @@ export function recipeVersion(version) {
   if (typeof version === "number" && version >= 1 && version < 3) {
     version *= 10;
   }
-  return Number.isInteger(version) && version >= 10 && version <= 17
+  return Number.isInteger(version) &&
+    ((version >= 10 && version <= 17) || version === 20)
     ? version
     : 17;
 }

--- a/packages/wasm/tests/browser/validation.mjs
+++ b/packages/wasm/tests/browser/validation.mjs
@@ -120,7 +120,7 @@ export async function runValidation() {
   equal(recipe.endPDF(), recipeBytes, "recipe finalization cache");
   equal(
     (await createMuhammaraWasm()).createReader(recipeBytes).getPDFLevel(),
-    1.7,
+    2,
     "recipe version",
   );
   assertions += 2;

--- a/packages/wasm/tests/recipe/foundation.test.mjs
+++ b/packages/wasm/tests/recipe/foundation.test.mjs
@@ -54,7 +54,7 @@ describe("Recipe foundation", function () {
     assert.strictEqual(recipe.endPDF(), bytes);
     var muhammara = await createMuhammaraWasm();
     var reader = muhammara.createReader(bytes);
-    assert.equal(reader.getPDFLevel(), 1.7);
+    assert.equal(reader.getPDFLevel(), 2);
     reader.end();
     assert.match(new TextDecoder().decode(bytes), /\/CreationDate \(D:/);
     assert.match(new TextDecoder().decode(bytes), /\/ModDate \(D:/);

--- a/packages/wasm/tests/types/types.test.ts
+++ b/packages/wasm/tests/types/types.test.ts
@@ -247,9 +247,9 @@ async function usesLowLevelSurface() {
   Recipe.permission("print, copy");
   var recipe = new Recipe({ version: 1.7, compress: false, title: "Byte PDF" });
   new Recipe({ version: 17 });
-  // @ts-expect-error Recipe does not support PDF 2.0.
+  new Recipe({ version: 2 });
   new Recipe({ version: 20 });
-  // @ts-expect-error Recipe versions stop at PDF 1.7.
+  // @ts-expect-error PDF 1.8 is not a real PDF version.
   new Recipe({ version: 1.8 });
   recipe.endPDF((bytes) => bytes.byteLength);
   recipe.registerFont("instance-font", new Uint8Array());


### PR DESCRIPTION
Recipe clamped the requested version to 1.7 in both packages, so version: 2.0 silently produced a PDF 1.7 header even though the underlying writers already accept ePDFVersion20.

Allow 2.0 through the native and Wasm Recipe version normalizers, add 2 and 20 to the Wasm RecipePDFVersion type, and document the accepted values and the 1.7 fallback in both Recipe guides.