### PR TITLE
Rename leftover Hummus identifiers in Recipe code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Store every text file with LF line endings, enforced by `.gitattributes` and
   checked in CI. Vendored PDFWriter sources and PDF fixtures keep their bytes
   untouched.
+- Set the `Creator` Info entry that `Recipe` writes to
+  `Muhammara-Recipe (https://github.com/julianhille/MuhammaraJS)`, replacing the
+  inherited `Hummus-Recipe` value. PDFs edited with `Recipe` still record the
+  source document's own creator as `source-Creator`.
 
 ## [7.0.0-beta.1] - 2026-09-05
 

--- a/packages/native-core/lib/recipe/appendPage.js
+++ b/packages/native-core/lib/recipe/appendPage.js
@@ -1,5 +1,5 @@
 const muhammara = require("../muhammara");
-const hummusUtils = require("./utils");
+const utils = require("./utils");
 
 /**
  * Append pages from the other pdf to the current pdf
@@ -44,11 +44,11 @@ exports.appendPage = function appendPage(pdfSrc, pages = []) {
     }
   });
   if (pages.length > 0) {
-    hummusUtils.appendPDFPagesFromPDFWithAnnotations(this.writer, pdfSrc, {
+    utils.appendPDFPagesFromPDFWithAnnotations(this.writer, pdfSrc, {
       specificRanges: pages,
     });
   } else {
-    hummusUtils.appendPDFPagesFromPDFWithAnnotations(this.writer, pdfSrc);
+    utils.appendPDFPagesFromPDFWithAnnotations(this.writer, pdfSrc);
   }
   return this;
 };

--- a/packages/native-core/lib/recipe/info.js
+++ b/packages/native-core/lib/recipe/info.js
@@ -171,7 +171,7 @@ exports._writeInfo = function _writeInfo() {
   infoDictionary.producer =
     "MuhammaraJS (https://github.com/julianhille/MuhammaraJS)";
   infoDictionary.creator =
-    "Hummus-Recipe (https://github.com/chunyenHuang/hummusRecipe)";
+    "Muhammara-Recipe (https://github.com/julianhille/MuhammaraJS)";
 
   fields.forEach((item) => {
     let value = options[item.key];

--- a/packages/native-core/lib/recipe/insertPage.js
+++ b/packages/native-core/lib/recipe/insertPage.js
@@ -1,6 +1,6 @@
 const muhammara = require("../muhammara");
 const fs = require("fs");
-const hummusUtils = require("./utils");
+const utils = require("./utils");
 /**
  * Insert a page from the other pdf
  * @name insertPage
@@ -53,7 +53,7 @@ exports._insertPages = function _insertPages() {
     const toAppendPage = pageNumber - 1;
     if (toAppendPage >= 0) {
       const specificRanges = [[lastInsertedOriginal, toAppendPage]];
-      hummusUtils.appendPDFPagesFromPDFWithAnnotations(pdfWriter, tmp, {
+      utils.appendPDFPagesFromPDFWithAnnotations(pdfWriter, tmp, {
         specificRanges,
       });
     }
@@ -65,11 +65,9 @@ exports._insertPages = function _insertPages() {
         const specificRanges = [
           [info.srcPageNumber - 1, info.srcPageNumber - 1],
         ];
-        hummusUtils.appendPDFPagesFromPDFWithAnnotations(
-          pdfWriter,
-          info.pdfSrc,
-          { specificRanges },
-        );
+        utils.appendPDFPagesFromPDFWithAnnotations(pdfWriter, info.pdfSrc, {
+          specificRanges,
+        });
       });
     }
   });

--- a/packages/native-core/lib/recipe/split.js
+++ b/packages/native-core/lib/recipe/split.js
@@ -1,6 +1,6 @@
 const muhammara = require("../muhammara");
 const path = require("path");
-const hummusUtils = require("./utils");
+const utils = require("./utils");
 
 /**
  * Split the pdf
@@ -16,11 +16,7 @@ exports.split = function split(outputDir = "", prefix) {
   for (let i = 0; i < this.metadata.pages; i++) {
     const newPdf = path.join(outputDir, `${prefix}-${i + 1}.pdf`);
     const pdfWriter = muhammara.createWriter(newPdf);
-    hummusUtils.appendPDFPageFromPDFWithAnnotations(
-      pdfWriter,
-      this._getReader(),
-      i,
-    );
+    utils.appendPDFPageFromPDFWithAnnotations(pdfWriter, this._getReader(), i);
     pdfWriter.end();
   }
   return this;

--- a/packages/native-with-source/tests/recipe/annotation-comment.js
+++ b/packages/native-with-source/tests/recipe/annotation-comment.js
@@ -1,10 +1,10 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Annotation: Comment", () => {
   it("Add comment", (done) => {
     const output = path.join(__dirname, "../output/Add comment.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     recipe
       // 1st Page
       .createPage("letter")
@@ -30,7 +30,7 @@ describe("Annotation: Comment", () => {
       __dirname,
       "../output/Add comment with rich text.pdf",
     );
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const textContent = [
       '<p style="text-align: center">Align Center</p>',
       '<span style="font-family: Helvetica">Plain Text</span>',
@@ -58,7 +58,7 @@ describe("Annotation: Comment", () => {
   });
   it("Add FreeText", (done) => {
     const output = path.join(__dirname, "../output/Add FreeText.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     recipe
       // 1st Page
       .createPage("letter")
@@ -76,7 +76,7 @@ describe("Annotation: Comment", () => {
   // Ticket #20, need to link annotation to text
   it("Add highlight", (done) => {
     const output = path.join(__dirname, "../output/Add highlight.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     recipe
       // 1st Page
       .createPage("letter")

--- a/packages/native-with-source/tests/recipe/annotation-coordinate.js
+++ b/packages/native-with-source/tests/recipe/annotation-coordinate.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Annotation: Coordinate", () => {
   const rotations = [0, 90, 180, 270];
@@ -14,7 +14,7 @@ describe("Annotation: Coordinate", () => {
         __dirname,
         `../output/annotation-rotation-${rotation}.pdf`,
       );
-      const recipe = new HummusRecipe(src, output);
+      const recipe = new Recipe(src, output);
       recipe
         .editPage(1)
         .text("Should be printed horizontally", "center", "center", {

--- a/packages/native-with-source/tests/recipe/annotation-square.js
+++ b/packages/native-with-source/tests/recipe/annotation-square.js
@@ -1,10 +1,10 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Annotation: Square", () => {
   it("Add a simple square.", (done) => {
     const output = path.join(__dirname, "../output/annotation-square.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     recipe
       .createPage("letter")
       .annot("center", "center", "Square", {

--- a/packages/native-with-source/tests/recipe/annotation-text.js
+++ b/packages/native-with-source/tests/recipe/annotation-text.js
@@ -1,10 +1,10 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Annotation: Text Annotations", () => {
   it("Add a simple hightlight with text.", (done) => {
     const output = path.join(__dirname, "../output/annotation-text.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     recipe
       .createPage("letter")
       .annot(50, 50, "Highlight", {
@@ -75,7 +75,7 @@ describe("Annotation: Text Annotations", () => {
       __dirname,
       "../output/annotation-with-textbox.pdf",
     );
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     const textContent =
       `${Date.now()} Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ` +
       "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).";
@@ -107,7 +107,7 @@ describe("Annotation: Text Annotations", () => {
 
   it("Add annotation replies to annotations.", (done) => {
     const output = path.join(__dirname, "../output/annotation-replies.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
 
     const replies1 = [
       {

--- a/packages/native-with-source/tests/recipe/appendPages.js
+++ b/packages/native-with-source/tests/recipe/appendPages.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const fs = require("fs");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Append Pages", () => {
   const taskAP = "Append pages from other pdf";
@@ -11,7 +11,7 @@ describe("Append Pages", () => {
       "../TestMaterials/recipe/compressed.tracemonkey-pldi-09.pdf",
     );
     const output = path.join(__dirname, `../output/${taskAP}.pdf`);
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe
       .appendPage(longPDF, 10)
       .appendPage(longPDF, [4, 6])
@@ -31,7 +31,7 @@ describe("Append Pages", () => {
     fs.copyFileSync(material, source);
     fs.copyFileSync(material, appended);
 
-    new HummusRecipe(source, output).appendPage(appended).endPDF();
+    new Recipe(source, output).appendPage(appended).endPDF();
 
     // Windows refuses the unlink with EBUSY while a reader still holds the
     // file, which is what https://github.com/julianhille/MuhammaraJS/issues/381

--- a/packages/native-with-source/tests/recipe/arcs.js
+++ b/packages/native-with-source/tests/recipe/arcs.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 function getRandomColor() {
   var letters = "0123456789ABCDEF";
@@ -205,7 +205,7 @@ function pie(x, y, radius, chart) {
 describe("Arc test", () => {
   it("Simple Arcs", (done) => {
     const output = path.join(__dirname, "../output/arcs.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     let x = 120;
     let y = 120;
     let r = 50;
@@ -258,7 +258,7 @@ describe("Arc test", () => {
 
   it("Pie Charts", (done) => {
     const output = path.join(__dirname, "../output/arcs.pdf");
-    const recipe = new HummusRecipe(output, output);
+    const recipe = new Recipe(output, output);
 
     const movies = [
       { label: "Comedy", value: 8, fill: "red" },

--- a/packages/native-with-source/tests/recipe/color.js
+++ b/packages/native-with-source/tests/recipe/color.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 const muhammara = require("@muhammara/native-with-source");
 
 describe("Color", () => {
@@ -44,7 +44,7 @@ describe("Color", () => {
 
   it("RGB explicit, global setting", (done) => {
     const output = path.join(__dirname, "../output/color-rgb.pdf");
-    const recipe = new HummusRecipe("new", output, {
+    const recipe = new Recipe("new", output, {
       colorspace: "rgb",
     });
     recipe
@@ -69,7 +69,7 @@ describe("Color", () => {
 
   it("RGB implicit", (done) => {
     const output = path.join(__dirname, "../output/color-rgb-implicit.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     recipe
       .createPage("letter")
       .text("blue circle, red lines in center", 400, 200)
@@ -112,7 +112,7 @@ describe("Color", () => {
 
   it("CMYK explicit, global setting", (done) => {
     const output = path.join(__dirname, "../output/color-cmyk.pdf");
-    const recipe = new HummusRecipe("new", output, {
+    const recipe = new Recipe("new", output, {
       colorspace: "cmyk",
     });
     recipe
@@ -137,7 +137,7 @@ describe("Color", () => {
 
   it("CMYK implicit", (done) => {
     const output = path.join(__dirname, "../output/color-cmyk-implicit.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     recipe
       .createPage("letter")
       .text("cyan circle, green lines in center", 400, 200)
@@ -180,7 +180,7 @@ describe("Color", () => {
 
   it("Gray explicit, global setting", (done) => {
     const output = path.join(__dirname, "../output/color-gray.pdf");
-    const recipe = new HummusRecipe("new", output, {
+    const recipe = new Recipe("new", output, {
       colorspace: "gray",
     });
     recipe
@@ -205,7 +205,7 @@ describe("Color", () => {
 
   it("Gray implicit", (done) => {
     const output = path.join(__dirname, "../output/color-gray-implicit.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     recipe
       .createPage("letter")
       .text("black circle, fill gray,", 450, 200, { color: [0] })
@@ -249,7 +249,7 @@ describe("Color", () => {
 
   it("All color spaces", (done) => {
     const output = path.join(__dirname, "../output/color-all.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     let font = "Courier New";
     let title = 30;
     let ts = 190;

--- a/packages/native-with-source/tests/recipe/coloring.js
+++ b/packages/native-with-source/tests/recipe/coloring.js
@@ -1,10 +1,10 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Coloring", () => {
   it("Using Names", (done) => {
     const output = path.join(__dirname, "../output/color-special.pdf");
-    const recipe = new HummusRecipe("new", output, {
+    const recipe = new Recipe("new", output, {
       colorspace: "rgb",
     });
     recipe
@@ -34,7 +34,7 @@ describe("Coloring", () => {
       "../TestMaterials/recipe/rgb-colors.json",
     );
     const lineOpt = { lineWidth: 0.5 };
-    const recipe = new HummusRecipe(output, output, {
+    const recipe = new Recipe(output, output, {
       colorspace: "rgb",
     });
     recipe
@@ -151,7 +151,7 @@ describe("Coloring", () => {
   it("Special Color Space Names", (done) => {
     const output = path.join(__dirname, "../output/color-special.pdf");
     const lineOpt = { lineWidth: 0.5 };
-    const recipe = new HummusRecipe(output, output, {
+    const recipe = new Recipe(output, output, {
       colorspace: "separation",
     });
     recipe

--- a/packages/native-with-source/tests/recipe/create.js
+++ b/packages/native-with-source/tests/recipe/create.js
@@ -1,10 +1,10 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Create", () => {
   it("blank pdf", (done) => {
     const output = path.join(__dirname, "../output/blank.pdf");
-    const recipe = new HummusRecipe("new", output, {
+    const recipe = new Recipe("new", output, {
       version: 1.6,
       author: "someone",
       title: "No title",
@@ -22,7 +22,7 @@ describe("Create", () => {
 
   it("new pdf", (done) => {
     const output = path.join(__dirname, "../output/new.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     const myCats = path.join(__dirname, "../TestMaterials/recipe/myCats.jpg");
     recipe
       // 1st Page
@@ -70,7 +70,7 @@ describe("Create", () => {
       .moveTo(200, 600)
       .lineTo("center", 650)
       .lineTo(412, 600)
-      .text("Welcome to Hummus-Recipe", "center", 250, {
+      .text("Welcome to Muhammara-Recipe", "center", 250, {
         color: "066099",
         fontSize: 30,
         bold: true,

--- a/packages/native-with-source/tests/recipe/createWithBuffer.js
+++ b/packages/native-with-source/tests/recipe/createWithBuffer.js
@@ -1,14 +1,14 @@
 const path = require("path");
 const fs = require("fs");
 const assert = require("chai").assert;
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Modify", () => {
   it("Create Writer With buffer", (done) => {
     const src = path.join(__dirname, "../TestMaterials/recipe/test.pdf");
     const myCats = path.join(__dirname, "../TestMaterials/recipe/myCats.jpg");
     const buffer = fs.readFileSync(src);
-    const recipe = new HummusRecipe(buffer);
+    const recipe = new Recipe(buffer);
     recipe
       .editPage(1)
       .image(myCats, "center", "center", {
@@ -44,7 +44,7 @@ describe("Modify", () => {
     );
     const myCats = path.join(__dirname, "../TestMaterials/recipe/myCats.jpg");
     const buffer = fs.readFileSync(src);
-    const recipe = new HummusRecipe(buffer, output);
+    const recipe = new Recipe(buffer, output);
     recipe
       .editPage(1)
       .image(myCats, "center", "center", {
@@ -70,10 +70,10 @@ describe("Modify", () => {
   });
 
   it("Create new Writer With new buffer and file output", (done) => {
-    const pdfDoc = new HummusRecipe(Buffer.from("new"), null, {
+    const pdfDoc = new Recipe(Buffer.from("new"), null, {
       version: 1.6,
       author: "John Doe",
-      title: "Hummus Recipe",
+      title: "Muhammara-Recipe",
       subject: "A brand new PDF",
     });
     const pdfBuffer = pdfDoc

--- a/packages/native-with-source/tests/recipe/encryption.js
+++ b/packages/native-with-source/tests/recipe/encryption.js
@@ -2,7 +2,7 @@ const path = require("path");
 const assert = require("assert");
 const fs = require("fs");
 const muhammara = require("@muhammara/native-with-source");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 function assertPdfEncryption(filePath, password, encrypted) {
   const reader = muhammara.createReader(filePath, password ? { password } : {});
@@ -30,7 +30,7 @@ describe("Encryption", () => {
     const src = path.join(__dirname, "../TestMaterials/recipe/test2.pdf");
     const output = path.join(__dirname, `../output/${taskAVP}.pdf`);
     fs.rmSync(output, { force: true });
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe
       .encrypt({
         userPassword: "123",
@@ -49,7 +49,7 @@ describe("Encryption", () => {
     const output = path.join(__dirname, `../output/${taskAEP}.pdf`);
     fs.rmSync(output, { force: true });
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe
       .encrypt({
         ownerPassword: "123",
@@ -67,7 +67,7 @@ describe("Encryption", () => {
     const output = path.join(__dirname, `../output/${taskAPP}.pdf`);
     fs.rmSync(output, { force: true });
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe
       .encrypt({
         password: "123",
@@ -82,7 +82,7 @@ describe("Encryption", () => {
   it(taskCPF, (done) => {
     const output = path.join(__dirname, `../output/${taskCPF}.pdf`);
     fs.rmSync(output, { force: true });
-    const recipe = new HummusRecipe("new", output, { userPassword: "123" });
+    const recipe = new Recipe("new", output, { userPassword: "123" });
     recipe
       .createPage("letter")
       .text("When creating file, the viewing password (userPassword)", 150, 300)
@@ -98,7 +98,7 @@ describe("Encryption", () => {
   it(taskCPP, (done) => {
     const output = path.join(__dirname, `../output/${taskCPP}.pdf`);
     fs.rmSync(output, { force: true });
-    const recipe = new HummusRecipe("new", output, { password: "123" });
+    const recipe = new Recipe("new", output, { password: "123" });
     recipe
       .createPage("letter")
       .text(
@@ -118,7 +118,7 @@ describe("Encryption", () => {
   it(taskCPE, (done) => {
     const output = path.join(__dirname, `../output/${taskCPE}.pdf`);
     fs.rmSync(output, { force: true });
-    const recipe = new HummusRecipe("new", output, {
+    const recipe = new Recipe("new", output, {
       ownerPassword: "123",
       userProtectionFlag: 3900,
     });
@@ -142,7 +142,7 @@ describe("Encryption", () => {
   // it(taskMPF, (done) => {
   //     const input = path.join(__dirname, `../output/${taskCPF}.pdf`);
   //     const output = path.join(__dirname, `../output/${taskMPF}.pdf`);
-  //     const recipe = new HummusRecipe(input, output, { userPassword: '123' });
+  //     const recipe = new Recipe(input, output, { userPassword: '123' });
 
   //     recipe
   //         .editPage(1)

--- a/packages/native-with-source/tests/recipe/endPDF-twice.js
+++ b/packages/native-with-source/tests/recipe/endPDF-twice.js
@@ -1,11 +1,11 @@
 const path = require("path");
 const { expect } = require("chai");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("endPDF called twice", () => {
   it("should not throw when endPDF is called twice", (done) => {
     const output = path.join(__dirname, "../output/endPDF-twice.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
 
     recipe.createPage("letter").endPage().endPDF();
 

--- a/packages/native-with-source/tests/recipe/font.js
+++ b/packages/native-with-source/tests/recipe/font.js
@@ -1,6 +1,6 @@
 const fs = require("fs-extra");
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Font", () => {
   before(() => {
@@ -11,7 +11,7 @@ describe("Font", () => {
       __dirname,
       "../output/Add text with custom fonts.pdf",
     );
-    const recipe = new HummusRecipe("new", output, {
+    const recipe = new Recipe("new", output, {
       fontSrcPath: path.join(__dirname, "../output/recipe/fonts"),
     });
     recipe

--- a/packages/native-with-source/tests/recipe/images-many.js
+++ b/packages/native-with-source/tests/recipe/images-many.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Modify", () => {
   it("Add many images", (done) => {
@@ -7,7 +7,7 @@ describe("Modify", () => {
     const output = path.join(__dirname, "../output/Add many images.pdf");
     const myCats = path.join(__dirname, "../TestMaterials/recipe/myCats.jpg");
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe.editPage(1);
     const repeats = 300;
     for (let i = 0; i < repeats; i++) {

--- a/packages/native-with-source/tests/recipe/images.js
+++ b/packages/native-with-source/tests/recipe/images.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Modify", () => {
   const taskAI = "Add images";
@@ -9,7 +9,7 @@ describe("Modify", () => {
     const myCats = path.join(__dirname, "../TestMaterials/recipe/myCats.jpg");
     const wiki = path.join(__dirname, "../TestMaterials/recipe/wiki.png");
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe
       .editPage(1)
       .image(myCats, "center", "center", {
@@ -64,7 +64,7 @@ describe("Modify", () => {
     const output = path.join(__dirname, `../output/${taskATP}.pdf`);
     const wikiPng = path.join(__dirname, "../TestMaterials/recipe/wiki.png");
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe
       .editPage(1)
       .image(wikiPng, "center", 50, {

--- a/packages/native-with-source/tests/recipe/info.js
+++ b/packages/native-with-source/tests/recipe/info.js
@@ -1,12 +1,12 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 const assert = require("chai").assert;
 
 describe("Modify", () => {
   it("Change info pdf", (done) => {
     const src = path.join(__dirname, "../TestMaterials/recipe/blank.pdf");
     const output = path.join(__dirname, "../output/change info.pdf");
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe
       .info({
         author: "yo man" + new Date().toString(),
@@ -19,7 +19,7 @@ describe("Modify", () => {
       })
       .endPage()
       .endPDF(() => {
-        const info = new HummusRecipe(output).info();
+        const info = new Recipe(output).info();
         assert.equal(info.title, "Hello World");
         done();
       });
@@ -30,7 +30,7 @@ describe("Modify", () => {
       __dirname,
       "../output/change info with IndirectObjectReference.pdf",
     );
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe
       .info({
         author: "Me",
@@ -41,7 +41,7 @@ describe("Modify", () => {
     const file = "test3";
     const src = path.join(__dirname, `../TestMaterials/recipe/${file}.pdf`);
     const output = path.join(__dirname, `../output/${file}.pdf`);
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe
       .structure(path.join(__dirname, `../output/${file}.txt`))
       .endPDF(done);

--- a/packages/native-with-source/tests/recipe/insertPage.js
+++ b/packages/native-with-source/tests/recipe/insertPage.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const fs = require("fs");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Insert Pages", () => {
   // https://github.com/galkahana/HummusJS/blob/d4aec0ea9200f702ccea9fcada5a3e955feef65e/src/PDFWriterDriver.cpp#L861
@@ -16,7 +16,7 @@ describe("Insert Pages", () => {
       "../output/Insert page from other pdf.pdf",
     );
     fs.rmSync(output, { force: true });
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe
       .insertPage(0, longPDF, 3)
       .insertPage(2, longPDF, 3)
@@ -38,7 +38,7 @@ describe("Insert Pages", () => {
       "../output/Insert page from other pdf (revert).pdf",
     );
     fs.rmSync(output, { force: true });
-    const recipe = new HummusRecipe(primary, output);
+    const recipe = new Recipe(primary, output);
     for (let page = 1; page <= 14; page++) {
       recipe.insertPage(page, insertSrc, 2);
     }

--- a/packages/native-with-source/tests/recipe/layout.js
+++ b/packages/native-with-source/tests/recipe/layout.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Layout", () => {
   it(`Flow text into column layouts (OS:${process.platform})`, () => {
@@ -7,7 +7,7 @@ describe("Layout", () => {
     const times = "times";
     const courier = "courier new";
     const fontDir = path.join(__dirname, "../../../native-core/fonts");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
 
     // Use checked-in fonts so rendering does not depend on the runner image.
     recipe.registerFont(times, path.join(fontDir, "Helvetica.ttf"));

--- a/packages/native-with-source/tests/recipe/modify-in-place.js
+++ b/packages/native-with-source/tests/recipe/modify-in-place.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Modify in Place", () => {
   it("Add something to an existing pdf and overwrite it.", (done) => {
@@ -13,7 +13,7 @@ describe("Modify in Place", () => {
     const cp = fs.createWriteStream(output);
     rs.pipe(cp);
     cp.on("finish", () => {
-      const recipe = new HummusRecipe(output);
+      const recipe = new Recipe(output);
       recipe
         .info({
           author: "wahaha",

--- a/packages/native-with-source/tests/recipe/modify.js
+++ b/packages/native-with-source/tests/recipe/modify.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Modify", () => {
   it("Add something to an existing pdf", (done) => {
@@ -8,7 +8,7 @@ describe("Modify", () => {
       __dirname,
       "../output/Add something to an existing.pdf",
     );
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe
       .info({
         author: "wahaha",
@@ -42,7 +42,7 @@ describe("Modify", () => {
       __dirname,
       "../output/Add something to an existing (with annots).pdf",
     );
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe
       .info({
         author: "wahaha",

--- a/packages/native-with-source/tests/recipe/overlay.js
+++ b/packages/native-with-source/tests/recipe/overlay.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const fs = require("fs");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Modify", () => {
   it("Add Overlay from other PDF", (done) => {
@@ -11,7 +11,7 @@ describe("Modify", () => {
     );
     const output = path.join(__dirname, "../output/Add overlay.pdf");
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe.editPage(1).overlay(overlayPDF).endPage().endPDF(done);
   });
 
@@ -29,7 +29,7 @@ describe("Modify", () => {
       "../output/Add overlay (#28) - position.pdf",
     );
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const options = {};
     recipe
       .editPage(1)
@@ -52,7 +52,7 @@ describe("Modify", () => {
       "../output/Add overlay (#28) - scale.pdf",
     );
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const options = {
       keepAspectRatio: true,
       scale: 3,
@@ -74,7 +74,7 @@ describe("Modify", () => {
       "../output/Add overlay (#28) - fitWidth.pdf",
     );
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const options = {
       keepAspectRatio: true,
       fitWidth: true,
@@ -96,7 +96,7 @@ describe("Modify", () => {
       "../output/Add overlay (#28) - fitHeight.pdf",
     );
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const options = {
       keepAspectRatio: true,
       fitHeight: true,
@@ -118,7 +118,7 @@ describe("Modify", () => {
       "../output/Add overlay (#28) - stretch.pdf",
     );
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const options = {
       fitHeight: true,
       fitWidth: true,
@@ -134,7 +134,7 @@ describe("Modify", () => {
     );
     const output = path.join(__dirname, "../output/Add overlay with page.pdf");
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe.editPage(1).overlay(overlayPDF, { page: 1 }).endPage().endPDF(done);
   });
 
@@ -152,7 +152,7 @@ describe("Modify", () => {
       "../output/Add overlay (#28) with page - position.pdf",
     );
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const options = { page: 1 };
     recipe
       .editPage(1)
@@ -175,7 +175,7 @@ describe("Modify", () => {
       "../output/Add overlay (#28) with page - scale.pdf",
     );
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const options = {
       keepAspectRatio: true,
       scale: 3,
@@ -198,7 +198,7 @@ describe("Modify", () => {
       "../output/Add overlay (#28) with page - fitWidth.pdf",
     );
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const options = {
       keepAspectRatio: true,
       fitWidth: true,
@@ -221,7 +221,7 @@ describe("Modify", () => {
       "../output/Add overlay (#28) with page - fitHeight.pdf",
     );
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const options = {
       keepAspectRatio: true,
       fitHeight: true,
@@ -244,7 +244,7 @@ describe("Modify", () => {
       "../output/Add overlay (#28) with page - stretch.pdf",
     );
 
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const options = {
       fitHeight: true,
       fitWidth: true,
@@ -261,11 +261,7 @@ describe("Modify", () => {
     fs.copyFileSync(material, source);
     fs.copyFileSync(material, overlaid);
 
-    new HummusRecipe(source, output)
-      .editPage(1)
-      .overlay(overlaid)
-      .endPage()
-      .endPDF();
+    new Recipe(source, output).editPage(1).overlay(overlaid).endPage().endPDF();
 
     // Both files stay locked on Windows while a reader still holds them: #381.
     fs.unlinkSync(source);

--- a/packages/native-with-source/tests/recipe/pdf-generator.js
+++ b/packages/native-with-source/tests/recipe/pdf-generator.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("PDF Generator", () => {
   const pdf = {
@@ -37,7 +37,7 @@ describe("PDF Generator", () => {
 
   it("Create a pdf", (done) => {
     const output = path.join(__dirname, `../output/${pdf.filename}.pdf`);
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     recipe.info(pdf.info);
 
     pdf.pages.forEach((page, index) => {

--- a/packages/native-with-source/tests/recipe/positioning.js
+++ b/packages/native-with-source/tests/recipe/positioning.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 function frame(recipe, left, top, width, height) {
   const cut = 8;
@@ -45,7 +45,7 @@ describe("Graphic Object Positioning", () => {
 
   it("Location, location...", (done) => {
     const output = path.join(__dirname, "../output/positioning.pdf");
-    const recipe = new HummusRecipe("new", output, {
+    const recipe = new Recipe("new", output, {
       colorspace: "rgb",
     });
     const col = [0, 90, 205, 320, 435];
@@ -162,7 +162,7 @@ describe("Graphic Object Positioning", () => {
 
   it("Rotation", (done) => {
     const output = path.join(__dirname, "../output/objectRotation.pdf");
-    const recipe = new HummusRecipe("new", output, {
+    const recipe = new Recipe("new", output, {
       colorspace: "rgb",
     });
     const defOrigColor = "#ff00ff";

--- a/packages/native-with-source/tests/recipe/rotation.js
+++ b/packages/native-with-source/tests/recipe/rotation.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Rotation", () => {
   const pdfs = [
@@ -43,7 +43,7 @@ describe("Rotation", () => {
         `../TestMaterials/recipe/${pdf.filename}`,
       );
       const output = path.join(__dirname, `../output/${pdf.filename}`);
-      const recipe = new HummusRecipe(src, output);
+      const recipe = new Recipe(src, output);
       const { width, height } = recipe.pageInfo(1);
       recipe
         .editPage(1)

--- a/packages/native-with-source/tests/recipe/shapes.js
+++ b/packages/native-with-source/tests/recipe/shapes.js
@@ -1,10 +1,10 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Regular Polygons, Stars, Arrows", () => {
   it("Add N sided regular polygons", (done) => {
     const output = path.join(__dirname, "../output/Add N-gons.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     const rota = { stroke: "#ff0000", opacity: 0.3, rotation: 45, debug: 1 };
     const nops = { stroke: "#ff0000", opacity: 0.3, rotation: 0, debug: 1 };
     recipe
@@ -30,7 +30,7 @@ describe("Regular Polygons, Stars, Arrows", () => {
 
   it("Add N pointed stars", (done) => {
     const output = path.join(__dirname, "../output/Add N-pointed stars.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     recipe
       .createPage("letter")
       .star(300, 340, 50, { fill: "#0000ff" })
@@ -47,7 +47,7 @@ describe("Regular Polygons, Stars, Arrows", () => {
 
   it("Add arrows", (done) => {
     const output = path.join(__dirname, "../output/arrowAnatomy.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
 
     recipe
       .createPage("letter")

--- a/packages/native-with-source/tests/recipe/split.js
+++ b/packages/native-with-source/tests/recipe/split.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 const fs = require("fs");
 
 describe("Split", () => {
@@ -14,7 +14,7 @@ describe("Split", () => {
       "split.compressed.tracemonkey-pldi-09.pdf",
     );
     fs.copyFileSync(originalSrc, src);
-    const recipe = new HummusRecipe(src);
+    const recipe = new Recipe(src);
     return recipe.split(outputDir).endPDF(done);
   });
 });

--- a/packages/native-with-source/tests/recipe/table.js
+++ b/packages/native-with-source/tests/recipe/table.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 const fs = require("fs");
 
 function compare(a, b) {
@@ -26,7 +26,7 @@ describe("Text - Columns", () => {
   it("Table", () => {
     const output = path.join(__dirname, "../output/table.pdf");
     const pplFile = path.join(__dirname, "../TestMaterials/recipe/people.json");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     const peeps = fs.readFileSync(pplFile, "utf8");
     const people = JSON.parse(peeps);
 

--- a/packages/native-with-source/tests/recipe/text-centering.js
+++ b/packages/native-with-source/tests/recipe/text-centering.js
@@ -1,10 +1,10 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Text - Centering", () => {
   it("should horizontally center the text correctly with multiple font sizes", (done) => {
     const output = path.join(__dirname, "../output/Center Text.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
 
     recipe
       .createPage("letter")

--- a/packages/native-with-source/tests/recipe/text-charSpace.js
+++ b/packages/native-with-source/tests/recipe/text-charSpace.js
@@ -1,10 +1,10 @@
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 const path = require("path");
 
 describe("Text", () => {
   it("Simple text", (done) => {
     const output = path.join(__dirname, "../output/text-charSpace.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     const lorem =
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
 Etiam in suscipit purus. Vestibulum ante ipsum primis in faucibus orci luctus \

--- a/packages/native-with-source/tests/recipe/text-columns.js
+++ b/packages/native-with-source/tests/recipe/text-columns.js
@@ -1,10 +1,10 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Text - Columns", () => {
   it("Text columns", (done) => {
     const output = path.join(__dirname, "../output/column-text.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     const lorem =
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
 Etiam in suscipit purus. Vestibulum ante ipsum primis in faucibus orci luctus \

--- a/packages/native-with-source/tests/recipe/text-continued.js
+++ b/packages/native-with-source/tests/recipe/text-continued.js
@@ -1,10 +1,10 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Text - Continued", () => {
   it("Simple text segmentation", (done) => {
     const output = path.join(__dirname, "../output/continued-text.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     const lorem =
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
 Etiam in suscipit purus. Vestibulum ante ipsum primis in faucibus orci luctus \

--- a/packages/native-with-source/tests/recipe/text-rotation.js
+++ b/packages/native-with-source/tests/recipe/text-rotation.js
@@ -1,11 +1,11 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Text Rotation", () => {
   it("Add text with rotation", (done) => {
     const src = path.join(__dirname, "../TestMaterials/recipe/test.pdf");
     const output = path.join(__dirname, "../output/Add text - rotation1.pdf");
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
 
     const pages = recipe.metadata.pages;
     const angles = [

--- a/packages/native-with-source/tests/recipe/text.js
+++ b/packages/native-with-source/tests/recipe/text.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 const htmlCodes = fs.readFileSync(
   path.join(__dirname, "../TestMaterials/recipe/text.html"),
   "utf8",
@@ -10,7 +10,7 @@ describe("Text", () => {
   it("Add watermark", (done) => {
     const src = path.join(__dirname, "../TestMaterials/recipe/test.pdf");
     const output = path.join(__dirname, "../output/Add text - watermark.pdf");
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
 
     const pages = recipe.metadata.pages;
     for (let i = 1; i <= pages; i++) {
@@ -30,7 +30,7 @@ describe("Text", () => {
   it("Add text", (done) => {
     const src = path.join(__dirname, "../TestMaterials/recipe/test.pdf");
     const output = path.join(__dirname, "../output/Add text.pdf");
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe
       .editPage(1)
       .circle("center", 100, 5, {
@@ -90,7 +90,7 @@ describe("Text", () => {
       __dirname,
       "../output/Add text with html codes.pdf",
     );
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     recipe
       .createPage("letter")
       .text(htmlCodes, 0, 0, {
@@ -105,7 +105,7 @@ describe("Text", () => {
       __dirname,
       "../output/Add text with html codes inside textbox.pdf",
     );
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     recipe
       .createPage(600, 1200)
       .text(htmlCodes, 10, 10, {
@@ -133,7 +133,7 @@ describe("Text", () => {
       __dirname,
       "../output/Add text inside textbox.pdf",
     );
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const textContent =
       `${Date.now()} Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ` +
       `${Date.now()} It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).`;
@@ -221,7 +221,7 @@ describe("Text", () => {
       __dirname,
       "../output/Add text with bolded format inside textbox.pdf",
     );
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const textContent =
       `${Date.now()} Lorem Ipsum is simply dummy text of the printing and typesetting industry. This <b>word</b> should be bolded. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. <b>This entire sentence should be bolded.</b> <b>It was popularised in the 1960s with the release </b>of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ` +
       `${Date.now()} It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. <b>The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English.</b> Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).`;
@@ -316,7 +316,7 @@ describe("Text", () => {
       __dirname,
       "../output/Add text with italic format inside textbox.pdf",
     );
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const textContent =
       `${Date.now()} Lorem Ipsum is simply dummy text of the printing and typesetting industry. This <i>word</i> should have the italic format. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. <i>This entire sentence should be italicized.</i> <i>It was popularised in the 1960s with the release </i>of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ` +
       `${Date.now()} It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. <i>The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English.</i> Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).`;
@@ -411,7 +411,7 @@ describe("Text", () => {
       __dirname,
       "../output/Add text with underline inside textbox.pdf",
     );
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const textContent =
       `${Date.now()} Lorem Ipsum is simply dummy text of the printing and typesetting industry. This <u>word</u> should be underlined. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. <u>This entire sentence should be underlined.</u> It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ` +
       `${Date.now()} It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).`;
@@ -506,7 +506,7 @@ describe("Text", () => {
       __dirname,
       "../output/Add text with strikethrough effect inside textbox.pdf",
     );
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const textContent =
       `${Date.now()} Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. This <del>word</del> should have the strikethrough effect. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ` +
       `${Date.now()} It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. <del>This entire sentence should have the strikethrough format.</del> The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).`;
@@ -598,7 +598,7 @@ describe("Text", () => {
       __dirname,
       "../output/Add text with highlight inside textbox.pdf",
     );
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const textContent =
       `${Date.now()} Lorem Ipsum is simply dummy text of the printing and typesetting industry. This <mark>word</mark> should have the highlight format. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ` +
       `${Date.now()} It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. <mark>This entire sentence should have the highlight format.</mark> The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).`;

--- a/packages/native-with-source/tests/recipe/triangle.js
+++ b/packages/native-with-source/tests/recipe/triangle.js
@@ -1,10 +1,10 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Triangles", () => {
   it("SSS, SAS, ASA", (done) => {
     const output = path.join(__dirname, "../output/Add triangles.pdf");
-    const recipe = new HummusRecipe("new", output);
+    const recipe = new Recipe("new", output);
     let x = 50;
     let y = 100;
     let txtOps = { color: "#000000", size: 10 };

--- a/packages/native-with-source/tests/recipe/vector.js
+++ b/packages/native-with-source/tests/recipe/vector.js
@@ -1,11 +1,11 @@
 const path = require("path");
-const HummusRecipe = require("@muhammara/native-with-source").Recipe;
+const Recipe = require("@muhammara/native-with-source").Recipe;
 
 describe("Vector", () => {
   it("Add vectors", (done) => {
     const src = path.join(__dirname, "../TestMaterials/recipe/test.pdf");
     const output = path.join(__dirname, "../output/Add vectors.pdf");
-    const recipe = new HummusRecipe(src, output);
+    const recipe = new Recipe(src, output);
     const { width, height } = recipe.pageInfo(1);
     recipe
       .editPage(1)

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -29,6 +29,10 @@ All notable changes to `@muhammara/wasm` are documented in this file.
   extractors. The old name remains as a deprecated alias.
 - Reword the limits shape error to `Extraction limits must be an object` so both
   readers report it identically.
+- Set the `Creator` Info entry that `Recipe` writes to
+  `Muhammara-Recipe (https://github.com/julianhille/MuhammaraJS)`, replacing the
+  inherited `Hummus-Recipe` value. PDFs edited with `Recipe` still record the
+  source document's own creator as `source-Creator`.
 
 ## [1.0.0-beta.1] - 2026-09-05
 

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -303,7 +303,7 @@ by `text(..., { html: true })`. `read(bytes)` only inspects page metadata and
 does not replace the current PDF; construct with bytes to edit a source PDF.
 `endPDF(callback?)` is idempotent, returns the same cached `Uint8Array`, and
 passes that in-memory array to its optional callback. New PDFs receive creation
-and modification dates plus canonical MuhammaraJS Producer and Hummus-Recipe
+and modification dates plus canonical MuhammaraJS Producer and Muhammara-Recipe
 Creator values. Editing preserves source creation metadata and records source
 modification, producer, and creator values as `source-*` Info entries.
 

--- a/packages/wasm/lib/recipe/info.js
+++ b/packages/wasm/lib/recipe/info.js
@@ -70,7 +70,7 @@ export function createInfoMethods({ call, withString }) {
         info.producer =
           "MuhammaraJS (https://github.com/julianhille/MuhammaraJS)";
         info.creator =
-          "Hummus-Recipe (https://github.com/chunyenHuang/hummusRecipe)";
+          "Muhammara-Recipe (https://github.com/julianhille/MuhammaraJS)";
         return this;
       }
       withString(pdfDate(now), (datePointer) => {
@@ -94,7 +94,7 @@ export function createInfoMethods({ call, withString }) {
         ],
         [
           "creator",
-          "Hummus-Recipe (https://github.com/chunyenHuang/hummusRecipe)",
+          "Muhammara-Recipe (https://github.com/julianhille/MuhammaraJS)",
         ],
       ].forEach(([key, value]) =>
         withString(key, (keyPointer) =>

--- a/packages/wasm/tests/recipe/foundation.test.mjs
+++ b/packages/wasm/tests/recipe/foundation.test.mjs
@@ -59,12 +59,15 @@ describe("Recipe foundation", function () {
     assert.match(new TextDecoder().decode(bytes), /\/CreationDate \(D:/);
     assert.match(new TextDecoder().decode(bytes), /\/ModDate \(D:/);
     assert.match(new TextDecoder().decode(bytes), /\/Producer \(MuhammaraJS/);
-    assert.match(new TextDecoder().decode(bytes), /\/Creator \(Hummus-Recipe/);
+    assert.match(
+      new TextDecoder().decode(bytes),
+      /\/Creator \(Muhammara-Recipe/,
+    );
 
     var modified = new Recipe(bytes).editPage(1).endPage().endPDF();
     var modifiedText = new TextDecoder().decode(modified);
     assert.match(modifiedText, /\/source-ModDate \(D:/);
-    assert.match(modifiedText, /\/source-Creator \(Hummus-Recipe/);
+    assert.match(modifiedText, /\/source-Creator \(Muhammara-Recipe/);
     assert.match(modifiedText, /\/source-Producer \(MuhammaraJS/);
   });
 


### PR DESCRIPTION
Clears the last of the pre-MuhammaraJS naming out of the Recipe code.

**Internal renames** (no behaviour change):

- The whole `packages/native-with-source/tests/recipe/` suite aliased the
  exported class as `HummusRecipe` (`const HummusRecipe = require(...).Recipe`).
  Two files there already used `Recipe`; now all of them do.
- `appendPage.js`, `insertPage.js` and `split.js` in `packages/native-core/lib/recipe/`
  imported `./utils` as `hummusUtils`. Renamed to `utils`. Both names were
  module-local, never exported, and absent from every `.d.ts`.
- The two sample strings in the create tests now say `Muhammara-Recipe`.

**Creator metadata** (user-visible, changelogged):

`Recipe` stamped every PDF it produced with a Creator of
`Hummus-Recipe (https://github.com/chunyenHuang/hummusRecipe)`, pointing users at
an unrelated upstream project. It now writes
`Muhammara-Recipe (https://github.com/julianhille/MuhammaraJS)`, matching the
`MuhammaraJS (...)` Producer set on the line above it. Changed on both ends —
`native-core/lib/recipe/info.js` and both the source-mode and new-PDF paths in
`wasm/lib/recipe/info.js` — with a `### Changed` entry in both changelogs and the
`wasm/README.md` prose updated.

Not treated as a breaking change: nothing keys off this value, and the `source-*`
preservation behaviour is untouched, so a PDF edited with `Recipe` still records
whatever creator its source carried.

The two Wasm assertions on the old value build their source PDF inside the test,
so they move with the default. The `TestMaterials` fixtures that carry the old
Creator are *inputs*, not generated output, and keep the value they were authored
with.

`npm test` (194/194) and `npm run wasm:test` (137/137) pass; `npx prettier -c` is
clean on the changed files.
