### PR TITLE
Reject invalid page and object indices in the native reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- The native `PDFReader` methods that take a page index or object ID —
+  `parseNewObject()`, `getPageObjectID()`, `parsePageDictionary()`,
+  `parsePage()`, `extractPageText()`, `extractPageContentItems()`, and
+  `getXrefEntry()` — now throw a `TypeError` instead of coercing the argument.
+  `reader.parsePage(-1)`, which used to read page 4294967295, and
+  `reader.extractPageText(1.5)`, which used to read page 1, now fail with
+  `Page index must be a non-negative integer`; pass a non-negative integer below
+  2^32 [#581](https://github.com/julianhille/MuhammaraJS/issues/581)
+
 ### Added
 
 - Add `PDFReader.extractPageContentItems()` for detecting page-marking content operations [#275](https://github.com/julianhille/MuhammaraJS/issues/275)

--- a/packages/native-with-source/src/PDFReaderDriver.cpp
+++ b/packages/native-with-source/src/PDFReaderDriver.cpp
@@ -41,6 +41,25 @@ using namespace v8;
 
 namespace
 {
+const char* scPageIndexError = "Page index must be a non-negative integer";
+const char* scObjectIDError = "Object ID must be a non-negative integer";
+
+// Page indices and object IDs are unsigned in PDFWriter. Accepting whatever a
+// v8 number can hold and coercing it with TO_UINT32 turns -1 into 4294967295
+// and 1.5 into 1, so validate the argument up front and let the caller throw.
+bool ReadIndexArgument(const Local<Value>& inValue, unsigned long& outIndex)
+{
+    if(!inValue->IsNumber())
+        return false;
+
+    double raw = inValue.As<Number>()->Value();
+    if(!(raw >= 0) || raw > 4294967295.0 || raw != std::floor(raw))
+        return false;
+
+    outIndex = static_cast<unsigned long>(raw);
+    return true;
+}
+
 // Mirrors the Wasm reader's limits validation so both backends accept the same
 // object and reject the same values. Absent or undefined fields keep the
 // built-in ceiling; PDFExtractionLimits::Clamp() then caps anything higher.
@@ -324,16 +343,22 @@ METHOD_RETURN_TYPE PDFReaderDriver::ParseNewObject(const ARGS_TYPE& args)
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
 
-    if(args.Length() != 1 ||
-       !args[0]->IsNumber())
+    if(args.Length() != 1)
     {
- 		THROW_EXCEPTION("Wrong arguments. Provide an Object ID");
+        THROW_EXCEPTION("Wrong arguments. Provide an Object ID");
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+
+    unsigned long objectID;
+    if(!ReadIndexArgument(args[0], objectID))
+    {
+        THROW_EXCEPTION(scObjectIDError);
         SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
     
     PDFReaderDriver* reader = ObjectWrap::Unwrap<PDFReaderDriver>(args.This());
     
-    RefCountPtr<PDFObject> newObject = reader->mPDFReader->ParseNewObject(TO_UINT32(args[0])->Value());
+    RefCountPtr<PDFObject> newObject = reader->mPDFReader->ParseNewObject(objectID);
     
     if(!newObject)
     {
@@ -349,16 +374,22 @@ METHOD_RETURN_TYPE PDFReaderDriver::GetPageObjectID(const ARGS_TYPE& args)
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    if(args.Length() != 1 ||
-       !args[0]->IsNumber())
+    if(args.Length() != 1)
     {
- 		THROW_EXCEPTION("Wrong arguments. Provide a page index");
+        THROW_EXCEPTION("Wrong arguments. Provide a page index");
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+
+    unsigned long index;
+    if(!ReadIndexArgument(args[0], index))
+    {
+        THROW_EXCEPTION(scPageIndexError);
         SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
     
     PDFReaderDriver* reader = ObjectWrap::Unwrap<PDFReaderDriver>(args.This());
     
-    SET_FUNCTION_RETURN_VALUE(NEW_NUMBER(reader->mPDFReader->GetPageObjectID(TO_UINT32(args[0])->Value())))
+    SET_FUNCTION_RETURN_VALUE(NEW_NUMBER(reader->mPDFReader->GetPageObjectID(index)))
 }
 
 
@@ -367,16 +398,22 @@ METHOD_RETURN_TYPE PDFReaderDriver::ParsePageDictionary(const ARGS_TYPE& args)
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    if(args.Length() != 1 ||
-       !args[0]->IsNumber())
+    if(args.Length() != 1)
     {
- 		THROW_EXCEPTION("Wrong arguments. Provide a page index");
+        THROW_EXCEPTION("Wrong arguments. Provide a page index");
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+
+    unsigned long index;
+    if(!ReadIndexArgument(args[0], index))
+    {
+        THROW_EXCEPTION(scPageIndexError);
         SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
     
     PDFReaderDriver* reader = ObjectWrap::Unwrap<PDFReaderDriver>(args.This());
     
-    RefCountPtr<PDFDictionary> newObject = reader->mPDFReader->ParsePage(TO_UINT32(args[0])->Value());
+    RefCountPtr<PDFDictionary> newObject = reader->mPDFReader->ParsePage(index);
     
     if(!newObject)
     {
@@ -393,16 +430,22 @@ METHOD_RETURN_TYPE PDFReaderDriver::ParsePage(const ARGS_TYPE& args)
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    if(args.Length() != 1 ||
-       !args[0]->IsNumber())
+    if(args.Length() != 1)
     {
- 		THROW_EXCEPTION("Wrong arguments. Provide a page index");
+        THROW_EXCEPTION("Wrong arguments. Provide a page index");
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+
+    unsigned long index;
+    if(!ReadIndexArgument(args[0], index))
+    {
+        THROW_EXCEPTION(scPageIndexError);
         SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
     
     PDFReaderDriver* reader = ObjectWrap::Unwrap<PDFReaderDriver>(args.This());
     
-    RefCountPtr<PDFDictionary> newObject = reader->mPDFReader->ParsePage(TO_UINT32(args[0])->Value());
+    RefCountPtr<PDFDictionary> newObject = reader->mPDFReader->ParsePage(index);
     
     if(!newObject)
     {
@@ -422,9 +465,16 @@ METHOD_RETURN_TYPE PDFReaderDriver::ExtractPageText(const ARGS_TYPE& args)
     CREATE_ISOLATE_CONTEXT;
     CREATE_ESCAPABLE_SCOPE;
 
-    if(args.Length() < 1 || args.Length() > 2 || !args[0]->IsNumber())
+    if(args.Length() < 1 || args.Length() > 2)
     {
         THROW_EXCEPTION("Wrong arguments. Provide a page index and optional extraction limits");
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+
+    unsigned long index;
+    if(!ReadIndexArgument(args[0], index))
+    {
+        THROW_EXCEPTION(scPageIndexError);
         SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
 
@@ -435,7 +485,7 @@ METHOD_RETURN_TYPE PDFReaderDriver::ExtractPageText(const ARGS_TYPE& args)
     }
 
     PDFReaderDriver* reader = ObjectWrap::Unwrap<PDFReaderDriver>(args.This());
-    RefCountPtr<PDFDictionary> page(reader->mPDFReader->ParsePage(TO_UINT32(args[0])->Value()));
+    RefCountPtr<PDFDictionary> page(reader->mPDFReader->ParsePage(index));
     if(!page)
     {
         THROW_EXCEPTION("Unable to read page, page index is wrong or page is null");
@@ -469,9 +519,16 @@ METHOD_RETURN_TYPE PDFReaderDriver::ExtractPageContentItems(const ARGS_TYPE& arg
     CREATE_ISOLATE_CONTEXT;
     CREATE_ESCAPABLE_SCOPE;
 
-    if(args.Length() < 1 || args.Length() > 2 || !args[0]->IsNumber())
+    if(args.Length() < 1 || args.Length() > 2)
     {
         THROW_EXCEPTION("Wrong arguments. Provide a page index and optional extraction limits");
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+
+    unsigned long index;
+    if(!ReadIndexArgument(args[0], index))
+    {
+        THROW_EXCEPTION(scPageIndexError);
         SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
 
@@ -482,7 +539,7 @@ METHOD_RETURN_TYPE PDFReaderDriver::ExtractPageContentItems(const ARGS_TYPE& arg
     }
 
     PDFReaderDriver* reader = ObjectWrap::Unwrap<PDFReaderDriver>(args.This());
-    RefCountPtr<PDFDictionary> page(reader->mPDFReader->ParsePage(TO_UINT32(args[0])->Value()));
+    RefCountPtr<PDFDictionary> page(reader->mPDFReader->ParsePage(index));
     if(!page)
     {
         THROW_EXCEPTION("Unable to read page, page index is wrong or page is null");
@@ -538,16 +595,22 @@ METHOD_RETURN_TYPE PDFReaderDriver::GetXrefEntry(const ARGS_TYPE& args)
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     
-    if(args.Length() != 1 ||
-       !args[0]->IsNumber())
+    if(args.Length() != 1)
     {
- 		THROW_EXCEPTION("Wrong arguments. Provide an Object ID");
+        THROW_EXCEPTION("Wrong arguments. Provide an Object ID");
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+
+    unsigned long objectID;
+    if(!ReadIndexArgument(args[0], objectID))
+    {
+        THROW_EXCEPTION(scObjectIDError);
         SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
     
     PDFReaderDriver* reader = ObjectWrap::Unwrap<PDFReaderDriver>(args.This());
     
-    XrefEntryInput* xrefEntry = reader->mPDFReader->GetXrefEntry(TO_UINT32(args[0])->Value());
+    XrefEntryInput* xrefEntry = reader->mPDFReader->GetXrefEntry(objectID);
     if(!xrefEntry)
     {
  		THROW_EXCEPTION("Unable to read object xref entry, page index is wrong or page is null");

--- a/packages/native-with-source/tests/PDFParser.js
+++ b/packages/native-with-source/tests/PDFParser.js
@@ -94,4 +94,63 @@ describe("PDFParser", function () {
     assert.equal(pdfReader.getPagesCount(), 2, "getPagesCount");
     pdfReader.end();
   });
+
+  it("should reject invalid page indices and object IDs", function () {
+    var pdfReader = muhammara.createReader(
+      __dirname + "/TestMaterials/XObjectContent.PDF",
+    );
+    var pageIndexMethods = [
+      "getPageObjectID",
+      "parsePageDictionary",
+      "parsePage",
+      "extractPageText",
+      "extractPageContentItems",
+    ];
+    var objectIDMethods = ["parseNewObject", "getXrefEntry"];
+    var invalidIndices = [
+      -1,
+      1.5,
+      NaN,
+      Infinity,
+      4294967296,
+      "0",
+      null,
+      undefined,
+    ];
+
+    pageIndexMethods.concat(objectIDMethods).forEach(function (method) {
+      invalidIndices.forEach(function (index) {
+        assert.throws(
+          function () {
+            pdfReader[method](index);
+          },
+          /must be a non-negative integer/,
+          undefined,
+          method + "(" + String(index) + ")",
+        );
+      });
+      assert.throws(function () {
+        pdfReader[method]();
+      }, /Wrong arguments/);
+    });
+
+    // Valid indices keep working, and out of range ones still report the read
+    // failure rather than being wrapped into another page.
+    var pageObjectID = pdfReader.getPageObjectID(0);
+    assert.isAbove(pageObjectID, 0);
+    assert.isObject(pdfReader.parsePageDictionary(0).toJSObject());
+    assert.lengthOf(pdfReader.parsePage(0).getMediaBox(), 4);
+    assert.isArray(pdfReader.extractPageText(0));
+    assert.isArray(pdfReader.extractPageContentItems(0));
+    assert.equal(
+      pdfReader.parseNewObject(pageObjectID).getType(),
+      muhammara.ePDFObjectDictionary,
+    );
+    assert.isNumber(pdfReader.getXrefEntry(pageObjectID).objectPosition);
+    assert.throws(function () {
+      pdfReader.parsePage(2);
+    }, /Unable to read page/);
+
+    pdfReader.end();
+  });
 });

--- a/packages/native/docs/api/reader-and-objects.md
+++ b/packages/native/docs/api/reader-and-objects.md
@@ -22,6 +22,13 @@ default, and values above it are clamped down, so a caller can tighten the
 extraction budget but never raise it past the ceiling the extractor enforces.
 See [Find Text Positions](../how-to/find-text-positions.md) for the field table.
 
+Every method that takes a page index or object ID — `parsePage`,
+`parsePageDictionary`, `getPageObjectID`, `extractPageText`,
+`extractPageContentItems`, `parseNewObject`, and `getXrefEntry` — requires a
+non-negative integer below 2^32 and throws a `TypeError` otherwise. Negative and
+fractional values are rejected rather than coerced, so `parsePage(-1)` throws
+instead of reading a wildly out-of-range page.
+
 Parsed `PDFObject` values expose `getType`, conversion methods such as
 `toPDFDictionary()` and `toPDFArray()`, and scalar conversion through
 `toNumber()` and `toString()`. A dictionary provides `exists`, `queryObject`,

--- a/packages/native/docs/breaking-changes.md
+++ b/packages/native/docs/breaking-changes.md
@@ -5,6 +5,17 @@ For release-by-release changes, see the [Changelog](https://github.com/julianhil
 
 ## Version 7.x
 
+- `PDFReader` methods that take a page index or object ID — `parseNewObject()`,
+  `getPageObjectID()`, `parsePageDictionary()`, `parsePage()`,
+  `extractPageText()`, `extractPageContentItems()`, and `getXrefEntry()` —
+  reject anything that is not a non-negative integer below 2^32. Negative,
+  fractional, `NaN`, `Infinity`, and out-of-range arguments used to be coerced
+  silently, so `reader.parsePage(-1)` read page 4294967295 and
+  `reader.extractPageText(1.5)` read page 1; they now throw
+  `TypeError: Page index must be a non-negative integer` (or
+  `Object ID must be a non-negative integer`). Round or validate the value
+  before passing it, bounding page indices with `getPagesCount()` and object IDs
+  with `getObjectsCount()`.
 - The unscoped `muhammara` package is deprecated and receives no further
   releases. Install `@muhammara/native` instead, or use an npm alias when an
   existing `require("muhammara")` import must remain unchanged. See

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to `@muhammara/wasm` are documented in this file.
 
 ### Changed
 
+- Reject invalid page indices and object IDs in the reader's `getPageObjectID()`
+  and `getXrefEntry()`, and reject values of 2^32 and above in every reader
+  method that takes an index, so both ends fail the same way [#581](https://github.com/julianhille/MuhammaraJS/issues/581)
 - Cache Emscripten compiler output between builds and give each build
   configuration its own build directory, so repeat builds reuse compiled
   objects while sanitizer and normal builds stay separate

--- a/packages/wasm/docs/low-level.md
+++ b/packages/wasm/docs/low-level.md
@@ -18,7 +18,11 @@ var pdfBytes = writer.end();
 `createReader(bytes)` exposes page counts, page information, PDF objects,
 streams, xref data, and raw content-string extraction. Call `end()` when the
 reader is no longer needed; parser and object handles are owned by it and become
-invalid afterwards.
+invalid afterwards. Every reader method that takes a page index or object ID —
+`parsePage`, `parsePageDictionary`, `getPageObjectID`, `extractPageText`,
+`extractPageContentItems`, `parseNewObject`, and `getXrefEntry` — requires a
+non-negative integer below 2^32 and throws a `TypeError` otherwise, exactly as
+the native reader does.
 
 `createWriterToModify(bytes, options?)` appends pages or changes an existing
 page through `createPageModifier(index?, ensureContentEncapsulation?)`. Its

--- a/packages/wasm/lib/reader.js
+++ b/packages/wasm/lib/reader.js
@@ -1,3 +1,10 @@
+/** Rejects page indices and object IDs the native reader would silently wrap. */
+function requireIndex(value, label) {
+  if (!Number.isInteger(value) || value < 0 || value > 0xffffffff) {
+    throw new TypeError(`${label} must be a non-negative integer`);
+  }
+}
+
 /** Creates a factory for low-level PDF readers. */
 export function createReaderFactory({
   module,
@@ -453,9 +460,7 @@ export function createReaderFactory({
     // same object. Values are validated here and clamped to the built-in
     // ceilings in the Wasm module, matching the Node reader.
     function extractionLimits(pageIndex, limits) {
-      if (!Number.isInteger(pageIndex) || pageIndex < 0) {
-        throw new TypeError("Page index must be a non-negative integer");
-      }
+      requireIndex(pageIndex, "Page index");
       if (!limits || typeof limits !== "object" || Array.isArray(limits)) {
         throw new TypeError("Extraction limits must be an object");
       }
@@ -500,6 +505,7 @@ export function createReaderFactory({
       },
       getPageObjectID: function (index) {
         requireReader();
+        requireIndex(index, "Page index");
         var id = module._muhammara_wasm_reader_get_page_object_id(
           reader,
           index,
@@ -531,6 +537,7 @@ export function createReaderFactory({
       },
       getXrefEntry: function (objectId) {
         requireReader();
+        requireIndex(objectId, "Object ID");
         var valuesPointer = module._malloc(24);
         try {
           if (
@@ -605,9 +612,7 @@ export function createReaderFactory({
       },
       parseNewObject: function (objectId) {
         requireReader();
-        if (!Number.isInteger(objectId) || objectId < 0) {
-          throw new TypeError("Object ID must be a non-negative integer");
-        }
+        requireIndex(objectId, "Object ID");
         var object = wrapObject(
           module._muhammara_wasm_reader_parse_object(reader, objectId),
         );
@@ -616,9 +621,7 @@ export function createReaderFactory({
       },
       parsePageDictionary: function (index) {
         requireReader();
-        if (!Number.isInteger(index) || index < 0) {
-          throw new TypeError("Page index must be a non-negative integer");
-        }
+        requireIndex(index, "Page index");
         var object = wrapObject(
           module._muhammara_wasm_reader_parse_page_dictionary(reader, index),
         );
@@ -627,9 +630,7 @@ export function createReaderFactory({
       },
       parsePage: function (index) {
         requireReader();
-        if (!Number.isInteger(index) || index < 0) {
-          throw new TypeError("Page index must be a non-negative integer");
-        }
+        requireIndex(index, "Page index");
         var page = module._muhammara_wasm_reader_parse_page(reader, index);
         if (!page) throw new RangeError(`Unable to read page ${index}`);
 

--- a/packages/wasm/tests/integration/PDFParser.test.mjs
+++ b/packages/wasm/tests/integration/PDFParser.test.mjs
@@ -126,4 +126,60 @@ describe("PDFParser", function () {
     );
     copiedReader.end();
   });
+
+  it("rejects invalid page indices and object IDs", async function () {
+    var muhammara = await createMuhammaraWasm();
+    var writer = muhammara.createWriter();
+    var page = new muhammara.PDFPage(0, 0, 200, 200);
+    writer.startPageContentContext(page).re(10, 10, 20, 20).f();
+    writer.writePage(page);
+    var bytes = writer.end();
+
+    var reader = muhammara.createReader(bytes);
+    var methods = [
+      "getPageObjectID",
+      "parsePageDictionary",
+      "parsePage",
+      "extractPageText",
+      "extractPageContentItems",
+      "parseNewObject",
+      "getXrefEntry",
+    ];
+    var invalidIndices = [
+      -1,
+      1.5,
+      NaN,
+      Infinity,
+      4294967296,
+      "0",
+      null,
+      undefined,
+    ];
+
+    for (var method of methods) {
+      for (var index of invalidIndices) {
+        assert.throws(
+          () => reader[method](index),
+          /must be a non-negative integer/,
+          `${method}(${String(index)})`,
+        );
+      }
+    }
+
+    // Valid indices keep working, and out of range ones still report the read
+    // failure rather than being wrapped into another page.
+    var pageObjectID = reader.getPageObjectID(0);
+    assert.ok(pageObjectID > 0);
+    assert.ok(reader.parsePageDictionary(0));
+    assert.equal(reader.parsePage(0).getMediaBox().length, 4);
+    assert.ok(Array.isArray(reader.extractPageText(0)));
+    assert.ok(Array.isArray(reader.extractPageContentItems(0)));
+    assert.equal(
+      reader.parseNewObject(pageObjectID).getType(),
+      muhammara.ePDFObjectDictionary,
+    );
+    assert.ok(reader.getXrefEntry(pageObjectID).objectPosition >= 0);
+    assert.throws(() => reader.parsePage(1), /Unable to read page 1/);
+    reader.end();
+  });
 });


### PR DESCRIPTION
Closes #581.

## What changed

The native `PDFReader` methods that take a page index or object ID checked only
`IsNumber()` and then coerced the value with `TO_UINT32`, so `parsePage(-1)`
read page 4294967295 and `extractPageText(1.5)` read page 1. A new
`ReadIndexArgument()` helper in `PDFReaderDriver.cpp` validates the argument up
front, and all seven methods now throw a `TypeError` instead:

- `parseNewObject`
- `getPageObjectID`
- `parsePageDictionary`
- `parsePage`
- `extractPageText`
- `extractPageContentItems`
- `getXrefEntry`

The messages match the Wasm reader's: `Page index must be a non-negative
integer` and `Object ID must be a non-negative integer`.

## Parity

The Wasm reader already rejected bad indices in `parseNewObject`,
`parsePageDictionary`, `parsePage`, `extractPageText`, and
`extractPageContentItems`, but not in `getPageObjectID` or `getXrefEntry` —
tightening only the native side would have created a new divergence, so both
gained the same check. The Wasm validations now go through one `requireIndex()`
helper, which also adds the 2^32 ceiling the native side enforces; without it
the value wraps on its way into the wasm `i32` parameter, the same defect on the
other end.

## Notes

- `extractPageContentItems` was added by #275 while this branch was in progress;
  it is included after rebasing onto the merged work.
- `queryArrayObject` also takes an index and still coerces it natively, while
  the Wasm reader throws a `RangeError` there. That divergence is out of scope
  for #581 and left as is.

## Definition of done

- [x] Implemented on both native and Wasm
- [x] Tests on both ends, mirrored: `tests/PDFParser.js` and
      `tests/integration/PDFParser.test.mjs`
- [x] Types unchanged — both `.d.ts` already declare these arguments as `number`
- [x] Docs: native reader API page and Wasm low-level page
- [x] Browser example consciously declined — argument validation is not a
      feature a browser user reaches for
- [x] Changelog in both files; breaking-change paperwork in
      `packages/native/docs/breaking-changes.md`. No migration guide: the remedy
      is passing a valid index. The Wasm side gets a `Changed` entry only, since
      `getPageObjectID`/`getXrefEntry` never shipped outside a prerelease.

## Verification

- `npm test` — 203 passing
- `npm run wasm:test` — 145 passing
- `npm run test:docs` — 7 passing
- `npm run test:codestyle`, all three `test:types`, `wasm:test:paths`,
  `wasm:test:exports` — clean
- `npm run docs:check` not run locally (`mkdocs` is not installed here); the
  changes are prose edits inside existing pages with no nav changes.