### PR TITLE
Document watermarking a PDF in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Document watermarking a PDF in place and watermarking a `Buffer`, including
+  the overwrite, incremental-update, and buffer-mode caveats
+  [#297](https://github.com/julianhille/MuhammaraJS/issues/297)
 - Add `PDFReader.extractPageContentItems()` for detecting page-marking content operations [#275](https://github.com/julianhille/MuhammaraJS/issues/275)
 - Add an optional `limits` argument to `PDFReader.extractPageText()` and
   `PDFReader.extractPageContentItems()`, matching the Wasm reader. Requests are

--- a/packages/native/docs/how-to/watermark-pdfs.md
+++ b/packages/native/docs/how-to/watermark-pdfs.md
@@ -23,3 +23,67 @@ pdfDoc.endPDF();
 ```
 
 See [`tests/recipe/text.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/text.js) for the verified workflow.
+
+## Watermark In Place
+
+Omit the output path and Recipe writes back over the source file, so no second
+document is produced:
+
+```javascript
+var pdfDoc = new Recipe("input.pdf");
+
+for (var page = 1; page <= pdfDoc.metadata.pages; page++) {
+  pdfDoc
+    .editPage(page)
+    .text("WATERMARK", "center", "center", {
+      bold: true,
+      size: 60,
+      color: "#0000FF",
+      align: "center center",
+      opacity: 0.3,
+    })
+    .endPage();
+}
+
+pdfDoc.endPDF();
+```
+
+The source is overwritten with no backup, and modification appends an
+incremental update rather than rewriting the file, so a repeatedly watermarked
+document keeps growing. Watermark once into a new file when you need to keep the
+original or the smallest possible output.
+
+See [`tests/recipe/modify-in-place.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/modify-in-place.js)
+for the verified workflow.
+
+## Watermark A Buffer
+
+When the PDF is already in memory, pass the `Buffer` as the source and omit the
+output path. `endPDF(callback)` then hands the finished document back as a
+`Buffer` instead of writing a file:
+
+```javascript
+var pdfDoc = new Recipe(inputBuffer);
+
+for (var page = 1; page <= pdfDoc.metadata.pages; page++) {
+  pdfDoc
+    .editPage(page)
+    .text("WATERMARK", "center", "center", {
+      size: 60,
+      align: "center center",
+      opacity: 0.3,
+    })
+    .endPage();
+}
+
+pdfDoc.endPDF(function (outputBuffer) {
+  // outputBuffer holds the watermarked PDF.
+});
+```
+
+Passing an output path alongside a `Buffer` source writes that file and gives
+the path to the callback instead of the bytes. Page insertion and encryption are
+not available in buffer mode.
+
+See [`tests/recipe/createWithBuffer.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/createWithBuffer.js)
+for the verified workflow.

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to `@muhammara/wasm` are documented in this file.
 
 ### Added
 
+- Document watermarking in place with the byte-first Recipe, and how it
+  differs from the native package's path-based overwrite
+  [#297](https://github.com/julianhille/MuhammaraJS/issues/297)
 - Add `PDFReader.extractPageContentItems(pageIndex, limits?)` for detecting
   page-marking content operations, matching the Node reader, along with the
   `ePDFPageContentItemText`, `ePDFPageContentItemPath`,

--- a/packages/wasm/docs/how-to/watermark-pdfs.md
+++ b/packages/wasm/docs/how-to/watermark-pdfs.md
@@ -36,3 +36,47 @@ Recipe.unregisterFont("watermark-font");
 The reader uses zero-based page indexes for page operations, while Recipe
 editing uses one-based page numbers. `pageInfo()` accounts for rotated page
 dimensions before the watermark center is calculated.
+
+## Watermark In Place
+
+The WebAssembly package is byte-first, so there is no second file to avoid:
+`endPDF()` returns the finished document and the source bytes stay untouched.
+"In place" means replacing whatever held the input with the returned bytes.
+
+```javascript
+var pdf = new Recipe(inputBytes);
+
+for (var pageNumber = 1; pageNumber <= pageCount; pageNumber++) {
+  var page = pdf.pageInfo(pageNumber);
+  pdf
+    .editPage(pageNumber)
+    .text("WATERMARK", page.width / 2, page.height / 2, {
+      font: "watermark-font",
+      fontSize: 60,
+      align: "center center",
+      opacity: 0.3,
+    })
+    .endPage();
+}
+
+inputBytes = pdf.endPDF();
+```
+
+The result is a separate `Uint8Array`; the input is never modified, so both
+documents are briefly in memory. Drop your reference to the source, as above,
+when only the watermarked bytes are needed.
+
+Editing an existing document appends an incremental update rather than rewriting
+it, so feeding the output back in as the next input grows the document each
+round. Watermark once from the original when size matters.
+
+In Node, write the bytes back over the file the input came from:
+
+```javascript
+await writeFile("input.pdf", pdf.endPDF());
+```
+
+In the browser, hand them to a download or upload as described in
+[Preview, Download, or Upload a PDF](serve-a-pdf-response.md). The native package
+can instead overwrite the source file directly by omitting the Recipe output
+path; see [Differences and Restrictions](../differences.md).


### PR DESCRIPTION
Closes #297

The requested workflow — watermark `input.pdf` and save it, without producing a
second document — is already supported and was simply undocumented. Recipe sets
`this.output = output || src`, so omitting the output path overwrites the
source, and a `Buffer` source with no output returns the finished bytes to the
`endPDF()` callback. The only published watermark guide wrote to a new file.

## Changes

- `packages/native/docs/how-to/watermark-pdfs.md` — add **Watermark In Place**
  and **Watermark A Buffer** sections, with the caveats that matter: the source
  is overwritten with no backup, modification appends an incremental update so
  repeated runs grow the file, and buffer mode supports neither page insertion
  nor encryption.
- `packages/wasm/docs/how-to/watermark-pdfs.md` — mirror the guide. The
  byte-first API has no second file by construction, so the section covers what
  "in place" means there, that source and output briefly coexist in memory, and
  the same incremental-update growth. The path-based overwrite is pointed at as
  the native-only behaviour already recorded in `differences.md`.
- Changelog entries under `### Added` in both `CHANGELOG.md` and
  `packages/wasm/CHANGELOG.md`.

Documentation only — no implementation, type, or example-file changes, so no
new tests. Each section names its verification source:
[`tests/recipe/modify-in-place.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/modify-in-place.js)
and
[`tests/recipe/createWithBuffer.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/createWithBuffer.js),
which assert exactly the buffer-versus-path callback behaviour described.

`npx prettier -c` passes on all four files. `mkdocs` is not installed in my
environment, so the strict docs build was not run locally; the new internal
links (`serve-a-pdf-response.md`, `../differences.md`) were checked by hand and
both targets exist.