### PR TITLE
Document adding metadata to an existing PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Document watermarking a PDF in place and watermarking a `Buffer`, including
   the overwrite, incremental-update, and buffer-mode caveats
   [#297](https://github.com/julianhille/MuhammaraJS/issues/297)
+- Document adding standard and custom Info dictionary metadata, including
+  dotted OID keys, to an existing PDF, and the lower-cased read-back, dropped
+  custom entries, and stamped provenance that come with it
+  [#450](https://github.com/julianhille/MuhammaraJS/issues/450)
 - Add `PDFReader.extractPageContentItems()` for detecting page-marking content operations [#275](https://github.com/julianhille/MuhammaraJS/issues/275)
 - Add an optional `limits` argument to `PDFReader.extractPageText()` and
   `PDFReader.extractPageContentItems()`, matching the Wasm reader. Requests are

--- a/packages/native/docs/how-to/add-metadata-to-existing-pdfs.md
+++ b/packages/native/docs/how-to/add-metadata-to-existing-pdfs.md
@@ -1,0 +1,64 @@
+# Add Metadata To An Existing PDF
+
+Open the document with Recipe, set standard fields with `info(options)`, and add
+your own Info dictionary keys with `custom(key, value)`. Both queue values that
+are written when the document is finalized.
+
+```javascript
+var Recipe = require("@muhammara/native").Recipe;
+var pdfDoc = new Recipe("input.pdf", "output.pdf");
+
+pdfDoc
+  .info({
+    author: "Example Clinic",
+    title: "Prescription",
+    subject: "Issued 2026-03-01",
+    keywords: ["prescription", "signed"],
+  })
+  .custom("2.16.76.1.4.2.2.1", "oid-professional")
+  .custom("2.16.76.1.4.2.2.2", "oid-uf-professional")
+  .custom("2.16.76.1.12.1.1", "oid-document")
+  .endPDF();
+```
+
+Omit the output path to write back over the source. `info()` with no arguments
+returns the current metadata, which is how you read the values back:
+
+```javascript
+var metadata = new Recipe("output.pdf").info();
+
+console.log(metadata["2.16.76.1.4.2.2.1"]); // "oid-professional"
+```
+
+`info` covers `author`, `title`, `subject`, and `keywords`; `keywords` accepts an
+array and a single value alike. Every other key belongs to `custom`, whose key
+and value are both coerced with `toString()`. Any name the PDF Info dictionary
+accepts works, including dotted OID strings, so identifiers such as
+`2.16.76.1.4.2.2.1` need no escaping.
+
+## What The Round Trip Changes
+
+Three behaviours are worth knowing before you rely on custom entries.
+
+**Keys come back lower-cased.** When `info()` reads a reopened document, custom
+names are normalized, so `ReportId` returns as `reportid`. Numeric OID keys are
+unaffected because they contain no letters. Read custom values by their
+lower-cased name, or use keys that are already lower-case.
+
+**Custom entries do not survive the next modification.** Recipe carries the
+standard fields of a source document into its output, but not custom Info
+entries, so a second editing pass drops them. Re-apply every `custom` call each
+time you rewrite a document that must keep them.
+
+**Recipe stamps its own provenance.** `Producer` and `Creator` are always set to
+MuhammaraJS values, and the source document's originals are preserved as
+`source-Producer`, `source-Creator`, and `source-ModDate`. `ModDate` is set to
+the time of the edit.
+
+These entries live in the document Info dictionary. Writing XMP metadata is a
+separate mechanism and is not exposed by Recipe.
+
+See [`tests/recipe/info.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/info.js)
+for the verified workflow, and
+[Metadata And Custom Data](../recipe/metadata-and-custom-data.md) for metadata on
+newly created documents.

--- a/packages/native/docs/recipe/metadata-and-custom-data.md
+++ b/packages/native/docs/recipe/metadata-and-custom-data.md
@@ -18,3 +18,6 @@ For an existing document, `info()` without arguments reads current metadata;
 `info(options)` queues updates for finalization. `structure(path)` writes a
 debugging view of an opened source PDF. See [`tests/recipe/info.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/info.js) and
 [`tests/recipe/modify.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/modify.js).
+
+To add metadata to a document that already exists, including dotted OID keys,
+see [Add Metadata to an Existing PDF](../how-to/add-metadata-to-existing-pdfs.md).

--- a/packages/native/mkdocs.yml
+++ b/packages/native/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
           - Find Text Positions: how-to/find-text-positions.md
           - Add Clickable URL Links: how-to/add-url-links.md
           - Change PDF Passwords: how-to/change-pdf-passwords.md
+          - Add Metadata to an Existing PDF: how-to/add-metadata-to-existing-pdfs.md
           - Add Content to Rotated Pages: how-to/add-content-to-rotated-pages.md
           - Place and Transform Images: how-to/place-and-transform-images.md
           - Set Page Boxes: how-to/set-page-boxes.md

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to `@muhammara/wasm` are documented in this file.
 - Document watermarking in place with the byte-first Recipe, and how it
   differs from the native package's path-based overwrite
   [#297](https://github.com/julianhille/MuhammaraJS/issues/297)
+- Document adding standard and custom Info dictionary metadata, including
+  dotted OID keys, to an existing PDF, and the lower-cased read-back, dropped
+  custom entries, and stamped provenance that come with it
+  [#450](https://github.com/julianhille/MuhammaraJS/issues/450)
 - Add `PDFReader.extractPageContentItems(pageIndex, limits?)` for detecting
   page-marking content operations, matching the Node reader, along with the
   `ePDFPageContentItemText`, `ePDFPageContentItemPath`,

--- a/packages/wasm/docs/how-to/add-metadata-to-existing-pdfs.md
+++ b/packages/wasm/docs/how-to/add-metadata-to-existing-pdfs.md
@@ -1,0 +1,64 @@
+# Add Metadata To An Existing PDF
+
+Open the document bytes with Recipe, set standard fields with `info(options)`,
+and add your own Info dictionary keys with `custom(key, value)`. Both are written
+when `endPDF()` returns the finished document.
+
+```javascript
+import { createRecipe } from "@muhammara/wasm";
+
+var Recipe = await createRecipe();
+var pdf = new Recipe(inputBytes);
+
+var outputBytes = pdf
+  .info({
+    author: "Example Clinic",
+    title: "Prescription",
+    subject: "Issued 2026-03-01",
+    keywords: ["prescription", "signed"],
+  })
+  .custom("2.16.76.1.4.2.2.1", "oid-professional")
+  .custom("2.16.76.1.4.2.2.2", "oid-uf-professional")
+  .custom("2.16.76.1.12.1.1", "oid-document")
+  .endPDF();
+```
+
+`info()` with no arguments returns the current metadata, which is how you read
+the values back:
+
+```javascript
+var metadata = new Recipe(outputBytes).info();
+
+console.log(metadata["2.16.76.1.4.2.2.1"]); // "oid-professional"
+```
+
+`info` covers `author`, `title`, `subject`, and `keywords`; an array of keywords
+is joined into a single Info value. Every other key is added as a custom Info
+entry, so `custom(key, value)` is shorthand for `info({ [key]: value })`. Any
+name the PDF Info dictionary accepts works, including dotted OID strings, so
+identifiers such as `2.16.76.1.4.2.2.1` need no escaping.
+
+## What The Round Trip Changes
+
+Three behaviours are worth knowing before you rely on custom entries.
+
+**Keys come back lower-cased from a reopened document.** While the Recipe is
+open, `info()` reports the names you supplied. Read back from the produced bytes
+they are normalized, so `ReportId` returns as `reportid`. Numeric OID keys are
+unaffected because they contain no letters.
+
+**Custom entries do not survive the next modification.** Recipe carries the
+standard fields of a source document into its output, but not custom Info
+entries, so a second editing pass drops them. Re-apply every `custom` call each
+time you rewrite a document that must keep them.
+
+**Recipe stamps its own provenance.** `Producer` and `Creator` are always set to
+MuhammaraJS values, and the source document's originals are preserved as
+`source-Producer`, `source-Creator`, and `source-ModDate`. `ModDate` is set to
+the time of the edit.
+
+These entries live in the document Info dictionary. Writing XMP metadata is a
+separate mechanism and is not exposed by Recipe.
+
+See [`tests/recipe/info-composition.test.mjs`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/wasm/tests/recipe/info-composition.test.mjs)
+for the verified workflow.

--- a/packages/wasm/mkdocs.yml
+++ b/packages/wasm/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
       - Find Text Positions: how-to/find-text-positions.md
       - Add Clickable URL Links: how-to/add-url-links.md
       - Change PDF Passwords: how-to/change-pdf-passwords.md
+      - Add Metadata to an Existing PDF: how-to/add-metadata-to-existing-pdfs.md
       - Add Content to Rotated Pages: how-to/add-content-to-rotated-pages.md
       - Place and Transform Images: how-to/place-and-transform-images.md
       - Set Page Boxes: how-to/set-page-boxes.md


### PR DESCRIPTION
Closes #450

The requested workflow is already supported: `info(options)` sets the standard
fields and `custom(key, value)` writes arbitrary Info dictionary entries, and
dotted OID names such as `2.16.76.1.4.2.2.1` need no escaping. There was no
guide for doing it to a document that already exists, only for newly created
ones.

## Changes

- New how-to `add-metadata-to-existing-pdfs.md` on **both** doc sets, with nav
  entries in `packages/native/mkdocs.yml` and `packages/wasm/mkdocs.yml`.
- Cross-link from `packages/native/docs/recipe/metadata-and-custom-data.md`,
  which previously only covered new documents.
- Changelog entries under `### Added` in both changelogs.

## Verified behaviour, not assumed

I ran the exact OID example from the issue against both backends before writing
the guide, which turned up three round-trip behaviours the guide now states:

1. **Custom keys are lower-cased when read back from a reopened document.**
   `ReportId` returns as `reportid`. Numeric OID keys are unaffected, which is
   why the issue's own use case works cleanly. Native normalizes in
   `_readInfo()`; Wasm reports the supplied names while the Recipe is open and
   the normalized ones after reopening — the guide says so on each side.
2. **Custom entries are dropped by the next modification pass.** Standard fields
   are carried from source to output, custom ones are not, so re-editing a
   document loses them unless every `custom` call is re-applied. Both backends
   behave the same way.
3. **Recipe stamps `Producer` and `Creator`** and preserves the source values as
   `source-Producer`, `source-Creator`, and `source-ModDate`.

Point 2 is documented here as current behaviour, but it looks more like a defect
than a decision — `_writeInfo()` copies unknown source keys with
`infoDictionary[key] = oldInfo[key]`, which does not reach
`addAdditionalInfoEntry()`. Happy to open a separate issue for it rather than
leave it as a documented quirk; say the word and I will.

The guide also states plainly that Info entries and XMP metadata are separate
mechanisms and that XMP is not exposed by Recipe, as agreed for this scope.

Documentation only — no implementation or example files, so no new tests. Each
guide names its verification source (`tests/recipe/info.js` and
`tests/recipe/info-composition.test.mjs`), both of which already assert
`info()` plus `custom()` on an existing document.

`npx prettier -c` passes. `mkdocs` is not installed in my environment, so the
strict docs build was not run locally; the one new internal link
(`../recipe/metadata-and-custom-data.md`) and both nav paths were checked by
hand.