### PR TITLE
Document editing and removing an existing annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   dotted OID keys, to an existing PDF, and the lower-cased read-back, dropped
   custom entries, and stamped provenance that come with it
   [#450](https://github.com/julianhille/MuhammaraJS/issues/450)
+- Document editing and removing an annotation that already exists in a PDF,
+  with a runnable `edit-annotation` example executed by the documentation test
+  suite [#385](https://github.com/julianhille/MuhammaraJS/issues/385)
 - Add `PDFReader.extractPageContentItems()` for detecting page-marking content operations [#275](https://github.com/julianhille/MuhammaraJS/issues/275)
 - Add an optional `limits` argument to `PDFReader.extractPageText()` and
   `PDFReader.extractPageContentItems()`, matching the Wasm reader. Requests are

--- a/packages/native-with-source/docs/tests/modify-pdfs.js
+++ b/packages/native-with-source/docs/tests/modify-pdfs.js
@@ -6,6 +6,7 @@ var muhammara = require("@muhammara/native-with-source");
 require.cache[require.resolve("@muhammara/native")] = { exports: muhammara };
 var replacePageObject = require("../../../native/docs/examples/replace-page-object");
 var replaceRecipeText = require("../../../native/docs/examples/replace-recipe-text");
+var editAnnotation = require("../../../native/docs/examples/edit-annotation");
 
 var fontPath = path.join(
   __dirname,
@@ -34,6 +35,51 @@ function writeSourcePdf(sourcePath) {
     .ET();
   writer.writePage(page);
   writer.end();
+}
+
+function writeAnnotatedPdf(annotatedPath) {
+  var Recipe = muhammara.Recipe;
+
+  return new Promise(function (resolve) {
+    new Recipe("new", annotatedPath)
+      .createPage("letter")
+      .annot(100, 200, "FreeText", { text: "Keep me", width: 200, height: 60 })
+      .annot(100, 400, "FreeText", { text: "Edit me", width: 200, height: 60 })
+      .endPage()
+      .endPDF(resolve);
+  });
+}
+
+function readAnnotations(pdfPath) {
+  var reader = muhammara.createReader(pdfPath);
+
+  try {
+    var page = reader.parsePage(0).getDictionary();
+    var annotations = reader.queryDictionaryObject(page, "Annots");
+
+    if (!annotations) {
+      return [];
+    }
+
+    return annotations
+      .toPDFArray()
+      .toJSArray()
+      .map(function (annotation) {
+        var id = annotation.toPDFIndirectObjectReference().getObjectID();
+        var dictionary = reader
+          .parseNewObject(id)
+          .toPDFDictionary()
+          .toJSObject();
+
+        return {
+          id: id,
+          subtype: dictionary.Subtype.toString(),
+          contents: dictionary.Contents ? dictionary.Contents.toText() : "",
+        };
+      });
+  } finally {
+    reader.end();
+  }
 }
 
 describe("Documentation examples", function () {
@@ -77,5 +123,63 @@ describe("Documentation examples", function () {
     assert.strictEqual(text[0].content, "After");
     assert.deepStrictEqual(text[0].textMatrix, [1, 0, 0, 1, 20, 30]);
     reader.end();
+  });
+  it("edits an existing annotation without losing its other keys", async function () {
+    var annotatedPath = path.join(outputDirectory, "annotated.pdf");
+    var outputPath = path.join(outputDirectory, "edited-annotation.pdf");
+
+    await writeAnnotatedPdf(annotatedPath);
+
+    var annotationId = editAnnotation.findAnnotationId(
+      annotatedPath,
+      0,
+      "Edit me",
+    );
+
+    assert.isNumber(annotationId);
+    editAnnotation.editAnnotationContents(
+      annotatedPath,
+      outputPath,
+      annotationId,
+      "Edited",
+    );
+
+    var before = readAnnotations(annotatedPath);
+    var after = readAnnotations(outputPath);
+    var edited = after.find(function (annotation) {
+      return annotation.id === annotationId;
+    });
+
+    assert.strictEqual(after.length, before.length);
+    assert.strictEqual(edited.contents, "Edited");
+    assert.strictEqual(edited.subtype, "FreeText");
+    assert.deepStrictEqual(
+      after.map(function (annotation) {
+        return annotation.id;
+      }),
+      before.map(function (annotation) {
+        return annotation.id;
+      }),
+    );
+  });
+
+  it("removes an annotation from a page", async function () {
+    var annotatedPath = path.join(outputDirectory, "annotated.pdf");
+    var outputPath = path.join(outputDirectory, "removed-annotation.pdf");
+
+    await writeAnnotatedPdf(annotatedPath);
+
+    var annotationId = editAnnotation.findAnnotationId(
+      annotatedPath,
+      0,
+      "Edit me",
+    );
+
+    editAnnotation.removeAnnotation(annotatedPath, outputPath, 0, annotationId);
+
+    var remaining = readAnnotations(outputPath);
+
+    assert.strictEqual(remaining.length, 1);
+    assert.strictEqual(remaining[0].contents, "Keep me");
   });
 });

--- a/packages/native/docs/examples/edit-annotation.js
+++ b/packages/native/docs/examples/edit-annotation.js
@@ -1,0 +1,110 @@
+var muhammara = require("@muhammara/native");
+
+function getAnnotationIds(reader, pageIndex) {
+  var page = reader.parsePage(pageIndex).getDictionary();
+  var annotations = reader.queryDictionaryObject(page, "Annots");
+
+  if (!annotations) {
+    return [];
+  }
+
+  return annotations
+    .toPDFArray()
+    .toJSArray()
+    .map(function (annotation) {
+      return annotation.toPDFIndirectObjectReference().getObjectID();
+    });
+}
+
+function readContents(reader, annotationId) {
+  var contents = reader
+    .parseNewObject(annotationId)
+    .toPDFDictionary()
+    .toJSObject().Contents;
+
+  return contents ? contents.toText() : "";
+}
+
+function findAnnotationId(inputPath, pageIndex, contents) {
+  var reader = muhammara.createReader(inputPath);
+
+  try {
+    return getAnnotationIds(reader, pageIndex).find(function (annotationId) {
+      return readContents(reader, annotationId) === contents;
+    });
+  } finally {
+    reader.end();
+  }
+}
+
+function editAnnotationContents(inputPath, outputPath, annotationId, contents) {
+  var writer = muhammara.createWriterToModify(inputPath, {
+    modifiedFilePath: outputPath,
+  });
+  var copyingContext = writer.createPDFCopyingContextForModifiedFile();
+  var existing = copyingContext
+    .getSourceDocumentParser()
+    .parseNewObject(annotationId)
+    .toPDFDictionary()
+    .toJSObject();
+  var objectsContext = writer.getObjectsContext();
+
+  objectsContext.startModifiedIndirectObject(annotationId);
+
+  var dictionary = objectsContext.startDictionary();
+
+  Object.keys(existing).forEach(function (key) {
+    // Contents is rewritten below; AP caches the rendered look of the old text.
+    if (key === "Contents" || key === "AP") {
+      return;
+    }
+    dictionary.writeKey(key);
+    copyingContext.copyDirectObjectAsIs(existing[key]);
+  });
+  dictionary.writeKey("Contents").writeLiteralStringValue(contents);
+  objectsContext.endDictionary(dictionary);
+  objectsContext.endIndirectObject();
+  copyingContext.end();
+  writer.end();
+}
+
+function removeAnnotation(inputPath, outputPath, pageIndex, annotationId) {
+  var writer = muhammara.createWriterToModify(inputPath, {
+    modifiedFilePath: outputPath,
+  });
+  var copyingContext = writer.createPDFCopyingContextForModifiedFile();
+  var parser = copyingContext.getSourceDocumentParser();
+  var pageId = parser.getPageObjectID(pageIndex);
+  var page = parser.parsePage(pageIndex).getDictionary().toJSObject();
+  var keptIds = getAnnotationIds(parser, pageIndex).filter(function (id) {
+    return id !== annotationId;
+  });
+  var objectsContext = writer.getObjectsContext();
+
+  objectsContext.startModifiedIndirectObject(pageId);
+
+  var dictionary = objectsContext.startDictionary();
+
+  Object.keys(page).forEach(function (key) {
+    dictionary.writeKey(key);
+    if (key !== "Annots") {
+      copyingContext.copyDirectObjectAsIs(page[key]);
+      return;
+    }
+    objectsContext.startArray();
+    keptIds.forEach(function (id) {
+      objectsContext.writeIndirectObjectReference(id);
+    });
+    objectsContext.endArray(muhammara.eTokenSeparatorEndLine);
+  });
+  objectsContext.endDictionary(dictionary);
+  objectsContext.endIndirectObject();
+  copyingContext.end();
+  writer.end();
+}
+
+module.exports = {
+  findAnnotationId: findAnnotationId,
+  editAnnotationContents: editAnnotationContents,
+  removeAnnotation: removeAnnotation,
+};

--- a/packages/native/docs/how-to/add-review-annotations.md
+++ b/packages/native/docs/how-to/add-review-annotations.md
@@ -17,3 +17,6 @@ pdfDoc
 
 Set `richText: true` on a comment to use supported HTML formatting. See
 [`tests/recipe/annotation-comment.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/annotation-comment.js) and [`tests/recipe/annotation-text.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/annotation-text.js).
+
+To change or remove an annotation that is already in a document, see
+[Edit or Remove an Existing Annotation](edit-existing-annotations.md).

--- a/packages/native/docs/how-to/edit-existing-annotations.md
+++ b/packages/native/docs/how-to/edit-existing-annotations.md
@@ -1,0 +1,95 @@
+# Edit Or Remove An Existing Annotation
+
+Recipe creates annotations, but changing one that is already in a document is a
+low-level operation: find the annotation object, then rewrite it through the
+objects context of a modifying writer.
+
+## Find The Annotation
+
+A page dictionary's `Annots` entry is an array of indirect references, one per
+annotation. Resolve it with `queryDictionaryObject` so the lookup also works when
+`Annots` is itself an indirect reference:
+
+```javascript
+var reader = muhammara.createReader("input.pdf");
+var page = reader.parsePage(0).getDictionary();
+var annotationIds = reader
+  .queryDictionaryObject(page, "Annots")
+  .toPDFArray()
+  .toJSArray()
+  .map(function (annotation) {
+    return annotation.toPDFIndirectObjectReference().getObjectID();
+  });
+
+reader.end();
+```
+
+A page without annotations has no `Annots` key, so `queryDictionaryObject`
+returns nothing rather than an empty array. Page indexes here are zero-based.
+
+## Rewrite It Completely
+
+`startModifiedIndirectObject(id)` replaces the whole object. Whatever you do not
+write is gone, so copy every key you are keeping — an annotation that loses
+`Type`, `Subtype`, or `Rect` stops rendering, which is the usual cause of an
+edit that "disappears" from the viewer.
+
+```javascript
+var editAnnotation = require("./edit-annotation");
+
+var annotationId = editAnnotation.findAnnotationId(
+  "input.pdf",
+  0,
+  "Original comment",
+);
+
+editAnnotation.editAnnotationContents(
+  "input.pdf",
+  "output.pdf",
+  annotationId,
+  "Edited comment",
+);
+```
+
+The runnable source is
+[`docs/examples/edit-annotation.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native/docs/examples/edit-annotation.js),
+executed by
+[`docs/tests/modify-pdfs.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/docs/tests/modify-pdfs.js).
+
+It iterates the existing dictionary and copies each entry with
+`copyDirectObjectAsIs`, replacing only `Contents`. Two details matter:
+
+- **Drop `AP` when the text changes.** The appearance stream caches how the
+  annotation was rendered, and a viewer that honours it keeps showing the old
+  text. Removing `AP` asks the viewer to build the appearance from `Contents`
+  and `DA` instead. Viewers that do not generate appearances will show nothing,
+  so write a new `AP` stream yourself when you need one guaranteed.
+- **End the copying context before the writer.** `copyingContext.end()` then
+  `writer.end()`. The WebAssembly package rejects `end()` outright while a
+  copying context is open.
+
+`writeLiteralStringValue` takes the string directly. For text outside the
+printable ASCII range, encode it first with
+`writer.createPDFTextString(text).toBytesArray()`.
+
+## Remove An Annotation
+
+Removal is a change to the page, not to the annotation: rewrite the page
+dictionary with a shortened `Annots` array. `replaceObject` does not help here —
+it swaps references that appear directly in the page dictionary, and an
+annotation reference sits inside the `Annots` array rather than at the top level.
+
+```javascript
+editAnnotation.removeAnnotation("input.pdf", "output.pdf", 0, annotationId);
+```
+
+The same rule applies: copy every page key you are keeping, and write the array
+with `startArray()`, one `writeIndirectObjectReference(id)` per surviving
+annotation, and `endArray()`. The orphaned annotation object stays in the file
+but is no longer referenced by the page.
+
+Modification appends an incremental update, so both the original and the
+rewritten object remain in the output. See
+[Modify PDFs](../low-level/modify-pdfs.md) for the surrounding low-level API and
+[Add Review Annotations](add-review-annotations.md) for creating annotations
+with Recipe.

--- a/packages/native/mkdocs.yml
+++ b/packages/native/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
           - Serve a PDF Response: how-to/serve-a-pdf-response.md
           - Deploy to AWS Lambda: how-to/deploy-to-aws-lambda.md
           - Add Review Annotations: how-to/add-review-annotations.md
+          - Edit or Remove an Existing Annotation: how-to/edit-existing-annotations.md
           - Create Multi-Page Tables: how-to/create-tables.md
           - Flow Text into Columns: how-to/flow-text-into-columns.md
           - Watermark Every Page: how-to/watermark-pdfs.md

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to `@muhammara/wasm` are documented in this file.
   dotted OID keys, to an existing PDF, and the lower-cased read-back, dropped
   custom entries, and stamped provenance that come with it
   [#450](https://github.com/julianhille/MuhammaraJS/issues/450)
+- Document editing and removing an annotation that already exists in a PDF,
+  including ending the copying context before the writer
+  [#385](https://github.com/julianhille/MuhammaraJS/issues/385)
 - Add `PDFReader.extractPageContentItems(pageIndex, limits?)` for detecting
   page-marking content operations, matching the Node reader, along with the
   `ePDFPageContentItemText`, `ePDFPageContentItemPath`,

--- a/packages/wasm/docs/how-to/add-review-annotations.md
+++ b/packages/wasm/docs/how-to/add-review-annotations.md
@@ -40,3 +40,6 @@ is a Worker-safe XML subset, not arbitrary browser HTML.
 Editing a source page can add annotations. Appending or rebuilding a source page
 does not deep-copy its existing `/Annots` graph. The runnable implementation is
 the [Annotations browser example](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/wasm/examples/browser/how-tos.mjs).
+
+To change or remove an annotation that is already in a document, see
+[Edit or Remove an Existing Annotation](edit-existing-annotations.md).

--- a/packages/wasm/docs/how-to/edit-existing-annotations.md
+++ b/packages/wasm/docs/how-to/edit-existing-annotations.md
@@ -1,0 +1,121 @@
+# Edit Or Remove An Existing Annotation
+
+Recipe creates annotations, but changing one that is already in a document is a
+low-level operation: find the annotation object, then rewrite it through the
+objects context of a modifying writer.
+
+## Find The Annotation
+
+A page dictionary's `Annots` entry is an array of indirect references, one per
+annotation. Resolve it with `queryDictionaryObject` so the lookup also works when
+`Annots` is itself an indirect reference:
+
+```javascript
+import { createMuhammaraWasm } from "@muhammara/wasm";
+
+var muhammara = await createMuhammaraWasm();
+var reader = muhammara.createReader(inputBytes);
+var page = reader.parsePage(0).getDictionary().toPDFDictionary();
+var annotationIds = reader
+  .queryDictionaryObject(page, "Annots")
+  .toPDFArray()
+  .toJSArray()
+  .map((annotation) => annotation.toPDFIndirectObjectReference().getObjectID());
+
+reader.end();
+```
+
+A page without annotations has no `Annots` key, so `queryDictionaryObject`
+returns nothing rather than an empty array. Page indexes here are zero-based.
+
+## Rewrite It Completely
+
+`startModifiedIndirectObject(id)` replaces the whole object. Whatever you do not
+write is gone, so copy every key you are keeping — an annotation that loses
+`Type`, `Subtype`, or `Rect` stops rendering, which is the usual cause of an
+edit that "disappears" from the viewer.
+
+```javascript
+var writer = muhammara.createWriterToModify(inputBytes);
+var copyingContext = writer.createPDFCopyingContextForModifiedFile();
+var existing = copyingContext
+  .getSourceDocumentParser()
+  .parseNewObject(annotationId)
+  .toPDFDictionary()
+  .toJSObject();
+var objectsContext = writer.getObjectsContext();
+
+objectsContext.startModifiedIndirectObject(annotationId);
+
+var dictionary = objectsContext.startDictionary();
+
+Object.keys(existing).forEach((key) => {
+  // Contents is rewritten below; AP caches the rendered look of the old text.
+  if (key === "Contents" || key === "AP") return;
+  dictionary.writeKey(key);
+  copyingContext.copyDirectObjectAsIs(existing[key]);
+});
+dictionary.writeKey("Contents").writeLiteralStringValue("Edited comment");
+objectsContext.endDictionary(dictionary);
+objectsContext.endIndirectObject();
+copyingContext.end();
+
+var outputBytes = writer.end();
+```
+
+Two details matter:
+
+- **Drop `AP` when the text changes.** The appearance stream caches how the
+  annotation was rendered, and a viewer that honours it keeps showing the old
+  text. Removing `AP` asks the viewer to build the appearance from `Contents`
+  and `DA` instead. Viewers that do not generate appearances will show nothing,
+  so write a new `AP` stream yourself when you need one guaranteed.
+- **End the copying context before the writer.** `writer.end()` throws
+  `Write the active page before ending the PDF` while a copying context is still
+  open, so call `copyingContext.end()` first.
+
+`writeLiteralStringValue` takes the string directly. For text outside the
+printable ASCII range, encode it first with
+`writer.createPDFTextString(text).toBytesArray()`.
+
+## Remove An Annotation
+
+Removal is a change to the page, not to the annotation: rewrite the page
+dictionary with a shortened `Annots` array. `replaceObject` does not help here —
+it swaps references that appear directly in the page dictionary, and an
+annotation reference sits inside the `Annots` array rather than at the top level.
+
+```javascript
+var parser = copyingContext.getSourceDocumentParser();
+var pageId = parser.getPageObjectID(0);
+var pageEntries = parser.parsePage(0).getDictionary().toJSObject();
+var keptIds = annotationIds.filter((id) => id !== annotationId);
+
+objectsContext.startModifiedIndirectObject(pageId);
+
+var pageDictionary = objectsContext.startDictionary();
+
+Object.keys(pageEntries).forEach((key) => {
+  pageDictionary.writeKey(key);
+  if (key !== "Annots") {
+    copyingContext.copyDirectObjectAsIs(pageEntries[key]);
+    return;
+  }
+  objectsContext.startArray();
+  keptIds.forEach((id) => objectsContext.writeIndirectObjectReference(id));
+  objectsContext.endArray(muhammara.eTokenSeparatorEndLine);
+});
+objectsContext.endDictionary(pageDictionary);
+objectsContext.endIndirectObject();
+```
+
+The orphaned annotation object stays in the file but is no longer referenced by
+the page.
+
+Modification appends an incremental update, so both the original and the
+rewritten object remain in the output. See [Low-Level API](../low-level.md) for
+the surrounding API and [Add Review Annotations](add-review-annotations.md) for
+creating annotations with Recipe.
+
+Appending or rebuilding an existing source page does not deep-copy that page's
+`Annots` graph; see [Differences and Restrictions](../differences.md).

--- a/packages/wasm/mkdocs.yml
+++ b/packages/wasm/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - Overview: how-to/index.md
       - Preview, Download, or Upload a PDF: how-to/serve-a-pdf-response.md
       - Add Review Annotations: how-to/add-review-annotations.md
+      - Edit or Remove an Existing Annotation: how-to/edit-existing-annotations.md
       - Create Multi-Page Tables: how-to/create-tables.md
       - Flow Text into Columns: how-to/flow-text-into-columns.md
       - Watermark Every Page: how-to/watermark-pdfs.md


### PR DESCRIPTION
Closes #385

The reporter's code was close but lost the annotation, and the reason was never
documented: `startModifiedIndirectObject()` replaces the *whole* object, so
writing only `Contents` drops `Type`, `Subtype` and `Rect` and the annotation
stops rendering. The second trap is `AP` — the cached appearance stream keeps
showing the old text even when `Contents` is correct.

Removal has a separate gotcha. `replaceObject()` cannot do it: it swaps
references held directly by the page dictionary, and an annotation reference
sits inside the `Annots` array, so the page dictionary has to be rewritten with
a shortened array.

## Changes

- New how-to `edit-existing-annotations.md` on **both** doc sets, covering find,
  edit, and remove, with nav entries in both `mkdocs.yml` files.
- New runnable example `packages/native/docs/examples/edit-annotation.js`
  (`findAnnotationId`, `editAnnotationContents`, `removeAnnotation`).
- Two cases in `packages/native-with-source/docs/tests/modify-pdfs.js` that
  execute it, asserting the edited annotation keeps its id, `Subtype` and the
  other keys, and that removal leaves exactly the other annotation.
- Cross-links from `add-review-annotations.md` on both ends.
- Changelog entries under `### Added` in both changelogs.

## Verified on both backends

Every snippet was run before it was written up, on the native addon and on the
WebAssembly build, including the removal path.

That turned up a divergence the guides now state on each side: **Wasm requires
`copyingContext.end()` before `writer.end()`**, which otherwise throws
`Write the active page before ending the PDF` because an open copying context
counts as a live child. Native tolerates the call either way, so the guides use
the single shape that works on both.

## Test results

`npx mocha packages/native-with-source/docs/tests/*.js` — the two new cases pass
along with the four existing `modify-pdfs.js` and `create-pdfs.js` ones.

Three `inspect-pdfs.js` cases fail in my checkout, and are **not** related to
this change: I had to symlink a prebuilt `muhammara.node` to run the suite at
all, and that binary predates `extractPageContentItems` from #275, so
`detect-blank-pages` and `find-text-positions` fail against it. CI builds from
source, where those already pass on `develop`.

`npx prettier -c` passes across all touched trees. `mkdocs` is not installed in
my environment (no pip), so the strict docs build was not run locally; the new
internal links (`../low-level/modify-pdfs.md`, `../low-level.md`,
`add-review-annotations.md`, `../differences.md`, `edit-existing-annotations.md`)
and both nav paths were checked by hand.