### PR TITLE
Remove obsolete Node.js compatibility branches from nodes.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `Muhammara-Recipe (https://github.com/julianhille/MuhammaraJS)`, replacing the
   inherited `Hummus-Recipe` value. PDFs edited with `Recipe` still record the
   source document's own creator as `source-Creator`.
+- Drop the Node.js compatibility fallbacks in `src/nodes.h` for versions below
+  the supported floor: the io.js 2.5 instance creation and numeric
+  conversions, the pre-Node-10 non-context-aware conversions, and the
+  non-context-aware module and `ConstructorsHolder` singleton path. The Node 20
+  accessor branch and the `HolderV2()` property-holder branch stay
+  [#553](https://github.com/julianhille/MuhammaraJS/issues/553)
 
 ## [7.0.0-beta.1] - 2026-09-05
 

--- a/packages/native-with-source/src/nodes.h
+++ b/packages/native-with-source/src/nodes.h
@@ -10,18 +10,7 @@
 #include <node_object_wrap.h>
 
 
-#define NODE_2_5_0_MODULE_VERSION 44
-#define NODE_10_0_0_MODULE_VERSION 64
-#define NODE_11_0_0_MODULE_VERSION 67
 #define NODE_21_0_0_MODULE_VERSION  120
-#define NODE_26_0_0_MODULE_VERSION 147
-#define NODE_CONTEXT_AWARE_VERSION NODE_10_0_0_MODULE_VERSION
-#define IS_CONTEXT_AWARE NODE_MODULE_VERSION >= NODE_CONTEXT_AWARE_VERSION
-#ifdef NODE_MODULE_INIT
-    #define IS_CONTEXT_AWARE_MODULE 1
-#else 
-    #define IS_CONTEXT_AWARE_MODULE 0
-#endif
 
 
 #define ARGS_TYPE v8::FunctionCallbackInfo<v8::Value>
@@ -78,8 +67,6 @@
 #endif
 
 // some conversions
-#if NODE_MODULE_VERSION > NODE_2_5_0_MODULE_VERSION
-
 #define SET_CONSTRUCTOR(c,t) c.Reset(isolate, t->GetFunction(GET_CURRENT_CONTEXT).ToLocalChecked())
 #define NEW_INSTANCE(c,i) Local<Function> c1 = Local<Function>::New(isolate, c); Local<Object> i = Local<Function>::New(isolate, c1)->NewInstance(GET_CURRENT_CONTEXT).ToLocalChecked()
 #define NEW_INSTANCE_ARGS(c,i,argc,argv) Local<Function> c1 = Local<Function>::New(isolate, c); Local<Object> i = Local<Function>::New(isolate, c1)->NewInstance(GET_CURRENT_CONTEXT,argc,argv).ToLocalChecked()
@@ -88,87 +75,40 @@
 #define TO_INT32(x) x->ToInt32(GET_CURRENT_CONTEXT).ToLocalChecked()
 #define TO_UINT32Value() ToUint32(GET_CURRENT_CONTEXT).ToLocalChecked()->Value()
 
-#else 
-
-#define SET_CONSTRUCTOR(c,t) c.Reset(isolate, t->GetFunction(GET_CURRENT_CONTEXT).ToLocalChecked())
-#define NEW_INSTANCE(c,i) Local<Object> i = Local<Function>::New(isolate, c)->NewInstance()
-#define NEW_INSTANCE_ARGS(c,i,argc,argv) Local<Object> i = Local<Function>::New(isolate, c)->NewInstance(argc,argv)
-#define TO_NUMBER(x) x->ToNumber()
-#define TO_UINT32(x) x->ToUint32()
-#define TO_INT32(x) x->ToInt32()
-#define TO_UINT32Value() ToUint32()->Value()
-
-#endif
-
 // Some more conversions
-#if IS_CONTEXT_AWARE
-    #define TO_STRING() ToString(GET_CURRENT_CONTEXT).FromMaybe(Local<String>())
-    #define TO_OBJECT() ToObject(GET_CURRENT_CONTEXT).FromMaybe(Local<Object>())
-    #define TO_BOOLEAN() ToBoolean(isolate)
-    #define UTF_8_VALUE(x) String::Utf8Value(isolate, x)
-
-#else 
-    #define TO_STRING() ToString()
-    #define TO_OBJECT() ToObject()
-    #define TO_BOOLEAN() ToBoolean()
-    #define UTF_8_VALUE(x) String::Utf8Value(x)
-
-#endif
+#define TO_STRING() ToString(GET_CURRENT_CONTEXT).FromMaybe(Local<String>())
+#define TO_OBJECT() ToObject(GET_CURRENT_CONTEXT).FromMaybe(Local<Object>())
+#define TO_BOOLEAN() ToBoolean(isolate)
+#define UTF_8_VALUE(x) String::Utf8Value(isolate, x)
 
 // Strict context aware definitions, to support node threadening
-#if IS_CONTEXT_AWARE_MODULE
-	#define NODES_MODULE(m,f) NODE_MODULE_INIT() {f(exports, context);}
-    #define EXPORTS_SET(e,k,v) e->Set(context, k,v);
-    #define CALL_INIT_WITH_EXPORTS(f) f(exports, context, external);
-    #define DEF_INIT(f) void f(Local<Object> exports, Local<Context> context)
-    #define DEF_SUBORDINATE_INIT(f) void f(Local<Object> exports, Local<Context> context, Local<External> external)
-    #define DEC_SUBORDINATE_INIT(f) static void f(v8::Local<v8::Object> exports, v8::Local<v8::Context> context, v8::Local<v8::External> external);
-    #define NEW_FUNCTION_TEMPLATE_EXTERNAL(X) FunctionTemplate::New(isolate, X, external)
+#define NODES_MODULE(m,f) NODE_MODULE_INIT() {f(exports, context);}
+#define EXPORTS_SET(e,k,v) e->Set(context, k,v);
+#define CALL_INIT_WITH_EXPORTS(f) f(exports, context, external);
+#define DEF_INIT(f) void f(Local<Object> exports, Local<Context> context)
+#define DEF_SUBORDINATE_INIT(f) void f(Local<Object> exports, Local<Context> context, Local<External> external)
+#define DEC_SUBORDINATE_INIT(f) static void f(v8::Local<v8::Object> exports, v8::Local<v8::Context> context, v8::Local<v8::External> external);
+#define NEW_FUNCTION_TEMPLATE_EXTERNAL(X) FunctionTemplate::New(isolate, X, external)
 
-    #define EXPOSE_EXTERNAL(C, c, e) C* c = reinterpret_cast<C*>(EXTERNAL_VALUE(e));
-    #define EXPOSE_EXTERNAL_FOR_INIT(C, c) EXPOSE_EXTERNAL(C, c, external)
-    #define EXPOSE_EXTERNAL_ARGS(C, c) EXPOSE_EXTERNAL(C, c, args.Data().As<External>())
-    #define DECLARE_EXTERNAL_DE_CON_STRUCTORS(C) v8::Persistent<v8::Object> mExports; \
-                                            C(v8::Isolate* isolate, v8::Local<v8::Object> exports); \
-                                            static void DeleteMe(const v8::WeakCallbackInfo<C>& info); \
-                                            virtual ~C();
-    #define DEFINE_EXTERNAL_DE_CON_STRUCTORS(C) \
-        C::C(Isolate* isolate, Local<Object> exports) { \
-            mExports.Reset(isolate, exports); \
+#define EXPOSE_EXTERNAL(C, c, e) C* c = reinterpret_cast<C*>(EXTERNAL_VALUE(e));
+#define EXPOSE_EXTERNAL_FOR_INIT(C, c) EXPOSE_EXTERNAL(C, c, external)
+#define EXPOSE_EXTERNAL_ARGS(C, c) EXPOSE_EXTERNAL(C, c, args.Data().As<External>())
+#define DECLARE_EXTERNAL_DE_CON_STRUCTORS(C) v8::Persistent<v8::Object> mExports; \
+                                        C(v8::Isolate* isolate, v8::Local<v8::Object> exports); \
+                                        static void DeleteMe(const v8::WeakCallbackInfo<C>& info); \
+                                        virtual ~C();
+#define DEFINE_EXTERNAL_DE_CON_STRUCTORS(C) \
+    C::C(Isolate* isolate, Local<Object> exports) { \
+        mExports.Reset(isolate, exports); \
+    } \
+    C::~C() { \
+        if (!mExports.IsEmpty()) { \
+            mExports.Reset(); \
         } \
-        C::~C() { \
-            if (!mExports.IsEmpty()) { \
-                mExports.Reset(); \
-            } \
-        } \
-        void C::DeleteMe(const WeakCallbackInfo<C>& info) { \
-            delete info.GetParameter(); \
-        }
+    } \
+    void C::DeleteMe(const WeakCallbackInfo<C>& info) { \
+        delete info.GetParameter(); \
+    }
 
-    // creates external instance on exports, when using externals
-    #define DECLARE_EXTERNAL(C) C* c1 = new C(isolate, exports); Local<External> external = NEW_EXTERNAL(c1);
-#else 
-	#define NODES_MODULE(m,f) NODE_MODULE(m, f)
-    #define EXPORTS_SET(e,k,v) e->Set(k,v);
-    #define CALL_INIT_WITH_EXPORTS(f) f(exports);
-    #define DEF_INIT(f) void f(Local<Object> exports)
-    #define DEF_SUBORDINATE_INIT(f) void f(Local<Object> exports)
-    #define DEC_SUBORDINATE_INIT(f) static void f(v8::Local<v8::Object> exports);
-    #define NEW_FUNCTION_TEMPLATE_EXTERNAL(X) NEW_FUNCTION_TEMPLATE(X)
-
-    #define EXPOSE_EXTERNAL(C, c) C* c = C::GetInstance();
-    #define EXPOSE_EXTERNAL_FOR_INIT(C, c) EXPOSE_EXTERNAL(C, c)
-    #define EXPOSE_EXTERNAL_ARGS(C, c) EXPOSE_EXTERNAL(C, c)
-    #define DECLARE_EXTERNAL_DE_CON_STRUCTORS(C) C(); \
-                                            virtual ~C(); \
-                                            static C* GetInstance();        
-    #define DEFINE_EXTERNAL_DE_CON_STRUCTORS(C) \
-        C::C(){} \
-        C::~C(){} \
-        C _instance; \
-        C* C::GetInstance(){return &_instance;} 
-
-    // the following is empty because external is defined as a shared static instance, when external is not used
-    #define DECLARE_EXTERNAL(C) 
- 
-#endif
+// creates external instance on exports, when using externals
+#define DECLARE_EXTERNAL(C) C* c1 = new C(isolate, exports); Local<External> external = NEW_EXTERNAL(c1);


### PR DESCRIPTION
Removes the Node.js compatibility fallbacks in `src/nodes.h` for versions below
the supported floor of Node 20:

- the io.js 2.5 instance creation and numeric conversions
- the pre-Node-10 non-context-aware conversions
- the non-context-aware module and `ConstructorsHolder` singleton path

The Node 20 accessor branch and the `HolderV2()` property holder branch stay.
Also drops the version constants left unused by the removal.

Verified with a full source build, including the bundled OpenSSL, and
`npm test` (205/205).

Closes #553
