### PR TITLE
Add parallel promise-based PDF recryption

### DIFF
--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -41,6 +41,8 @@ jobs:
           restore-keys: native-source-
       - run: sudo apt-get update && sudo apt-get install -y perl
       - run: npm ci --ignore-scripts
+      - name: Verify native build graph generation
+        run: npm exec -c 'python3 packages/native-with-source/tests/build-overrides/generation.py'
       - run: npm run native:test:types && npm run native-with-source:test:types
       - run: npm exec --workspace=@muhammara/native-with-source -- node-pre-gyp rebuild
       - name: Verify OpenSSL is statically linked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix Windows source and Electron build generation with the native concurrency
+  overrides, without modifying vendored sources
+  [#98](https://github.com/julianhille/MuhammaraJS/issues/98)
 - Release the source PDF file handle that `Recipe` holds, so the source,
   appended, and overlaid files can be deleted right after `endPDF()` instead of
   failing with `EBUSY` on Windows [#381](https://github.com/julianhille/MuhammaraJS/issues/381)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Breaking Changes
 
+- Native logging is thread-local rather than process-wide. A writer on another
+  thread no longer configures a job's log destination; pass `log` to each
+  `recryptAsync()` call or writer instead
+  [#98](https://github.com/julianhille/MuhammaraJS/issues/98)
 - The native `PDFReader` methods that take a page index or object ID —
   `parseNewObject()`, `getPageObjectID()`, `parsePageDictionary()`,
   `parsePage()`, `extractPageText()`, `extractPageContentItems()`, and
@@ -20,6 +24,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- `recryptAsync()`, a promise-returning `recrypt` that runs independent
+  re-encryption jobs in parallel on libuv's thread pool without blocking the
+  event loop during PDF processing, and
+  `Recipe.endPDFAsync()` which uses it
+  [#98](https://github.com/julianhille/MuhammaraJS/issues/98)
 - Document watermarking a PDF in place and watermarking a `Buffer`, including
   the overwrite, incremental-update, and buffer-mode caveats
   [#297](https://github.com/julianhille/MuhammaraJS/issues/297)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Release OpenSSL's per-thread resources after each `recryptAsync()` job so
+  pooled re-encryption does not leak at shutdown
+  [#98](https://github.com/julianhille/MuhammaraJS/issues/98)
 - Fix Windows source and Electron build generation with the native concurrency
   overrides, without modifying vendored sources
   [#98](https://github.com/julianhille/MuhammaraJS/issues/98)

--- a/packages/native-core/lib/Recipe.js
+++ b/packages/native-core/lib/Recipe.js
@@ -255,13 +255,10 @@ class Recipe {
   }
 
   /**
-   * End the pdfDoc
-   * @function
-   * @memberof Recipe
-   * @param {function} [callback] - The callback function.
-   * @returns {*} The callback result, if a callback is provided.
+   * Everything endPDF() and endPDFAsync() do before the document is encrypted.
+   * @private
    */
-  endPDF(callback) {
+  _endPDFPrologue() {
     this._writeInfo();
     this.writer.end();
     // This is a temporary work around for copying context will overwrite the current one
@@ -311,13 +308,47 @@ class Recipe {
         this._insertPages();
       }
     }
-    if (this.needToEncrypt) {
-      if (this.isBufferSrc) {
-        // eslint-disable-next-line no-console
-        console.log("Feature: Encryption is not supported in Buffer Mode yet.");
-      } else {
-        this._encrypt();
-      }
+  }
+
+  /**
+   * Whether endPDF() still has to encrypt the output.
+   * @private
+   */
+  _needsEncryptStep() {
+    if (!this.needToEncrypt) {
+      return false;
+    }
+    if (this.isBufferSrc) {
+      // eslint-disable-next-line no-console
+      console.log("Feature: Encryption is not supported in Buffer Mode yet.");
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * The value endPDF() hands to its callback, and endPDFAsync() resolves with.
+   * @private
+   */
+  _endPDFResult() {
+    if (this.isBufferSrc) {
+      return this.output ? this.output : this.outStream.toBuffer();
+    }
+    return undefined;
+  }
+
+  /**
+   * End the pdfDoc
+   * @function
+   * @memberof Recipe
+   * @param {function} [callback] - The callback function.
+   * @returns {*} The callback result, if a callback is provided.
+   */
+  endPDF(callback) {
+    this._endPDFPrologue();
+
+    if (this._needsEncryptStep()) {
+      this._encrypt();
     }
 
     if (this.isBufferSrc && this.output) {
@@ -325,16 +356,31 @@ class Recipe {
     }
 
     if (callback) {
-      if (this.isBufferSrc) {
-        if (this.output) {
-          return callback(this.output);
-        } else {
-          return callback(this.outStream.toBuffer());
-        }
-      } else {
-        return callback();
-      }
+      return callback(this._endPDFResult());
     }
+  }
+
+  /**
+   * End the pdfDoc without blocking the event loop while it is encrypted.
+   * Only the encryption step runs off the main thread; writing the document
+   * and inserting pages stay synchronous.
+   * @function
+   * @memberof Recipe
+   * @returns {Promise<Buffer|string|undefined>} The output path or buffer in
+   * buffer mode, undefined otherwise.
+   */
+  async endPDFAsync() {
+    this._endPDFPrologue();
+
+    if (this._needsEncryptStep()) {
+      await this._encryptAsync();
+    }
+
+    if (this.isBufferSrc && this.output) {
+      await fs.promises.writeFile(this.output, this.outStream.toBuffer());
+    }
+
+    return this._endPDFResult();
   }
 
   /**

--- a/packages/native-core/lib/recipe/encrypt.js
+++ b/packages/native-core/lib/recipe/encrypt.js
@@ -110,3 +110,18 @@ exports._encrypt = function _encrypt() {
   muhammara.recrypt(tmp, this.output, this.encryption_);
   fs.unlinkSync(tmp);
 };
+
+// Same as _encrypt(), but keeps the event loop free while the document is
+// re-encrypted. Used by endPDFAsync().
+exports._encryptAsync = async function _encryptAsync() {
+  if (!this.encryption_) {
+    return;
+  }
+
+  var tmp = this.output + ".tmp.pdf";
+  await fs.promises.rename(this.output, tmp);
+  // Left in place when recryptAsync rejects, exactly like _encrypt does, so the
+  // untouched original is still recoverable from the .tmp.pdf file.
+  await muhammara.recryptAsync(tmp, this.output, this.encryption_);
+  await fs.promises.unlink(tmp);
+};

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -48,6 +48,23 @@ declare namespace muhammara {
     options?: PDFRecryptOptions,
   ): void;
 
+  /**
+   * Promise-returning recrypt. The re-encryption runs on a background thread.
+   * Independent calls can run in parallel on libuv's shared thread pool.
+   * Use separate output paths/streams per job and pass log settings per call.
+   * Stream buffering and delivery still run on the calling thread.
+   */
+  export function recryptAsync(
+    originalPdfPath: FilePath,
+    newPdfPath: FilePath,
+    options?: PDFRecryptOptions,
+  ): Promise<void>;
+  export function recryptAsync(
+    originalPdfStream: PDFRStreamForFile | PDFRStreamForBuffer,
+    newPdfStream: PDFWStreamForFile | PDFWStreamForBuffer,
+    options?: PDFRecryptOptions,
+  ): Promise<void>;
+
   export interface WriteStream {
     write(inBytesArray: any[]): number;
     getCurrentPosition(): number;
@@ -1359,6 +1376,7 @@ declare namespace muhammara {
 
     endPDF(): void;
     endPDF<T>(callback: (output?: Buffer | string) => T): T;
+    endPDFAsync(): Promise<Buffer | string | undefined>;
   }
 }
 

--- a/packages/native-with-source/binding.gyp
+++ b/packages/native-with-source/binding.gyp
@@ -25,6 +25,9 @@
             "cflags": [ "-std=c++20" ],
             'cflags!': [ '-fno-exceptions' ],
             'cflags_cc!': [ '-fno-exceptions' ],
+            'include_dirs+': [
+                '<(module_root_dir)/openssl-build/<(target_arch)/include'
+            ],
             'include_dirs': [
                 '<(muhammara_source_root)',
                 '<(muhammara_source_root)/deps/PDFWriter',

--- a/packages/native-with-source/binding.gyp
+++ b/packages/native-with-source/binding.gyp
@@ -9,12 +9,13 @@
 			'product_extension': 'node',
             'dependencies': [
                '<(module_root_dir)/openssl.gyp:openssl',
-               '<(muhammara_source_root)/deps/PDFWriter/binding.gyp:pdfwriter'
+               '<(muhammara_source_root)/build-overrides/pdfwriter.gyp:pdfwriter'
             ],
             "defines": [
             'USE_BUNDLED=TRUE'
             ],
             'defines!': [
+            '_HAS_EXCEPTIONS=0',
             'V8_DEPRECATION_WARNINGS=1',
             'V8_DEPRECATION_WARNINGS',
             'V8_IMMINENT_DEPRECATION_WARNINGS',
@@ -22,6 +23,8 @@
             ],
             "cflags_cc": [ "-std=c++20" ],
             "cflags": [ "-std=c++20" ],
+            'cflags!': [ '-fno-exceptions' ],
+            'cflags_cc!': [ '-fno-exceptions' ],
             'include_dirs': [
                 '<(muhammara_source_root)',
                 '<(muhammara_source_root)/deps/PDFWriter',
@@ -31,6 +34,7 @@
 			{
 				'VCCLCompilerTool':
 				{
+					'ExceptionHandling': 1,
 					'AdditionalIncludeDirectories': [
                         '<(module_root_dir)/openssl-build/<(target_arch)/include/'
 					],
@@ -52,6 +56,7 @@
                         '<(module_root_dir)/openssl-build/<(target_arch)/libcrypto.a'
                     ],
                     'xcode_settings': {
+                        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
                         'CLANG_CXX_LIBRARY': 'libc++',
                         "OTHER_CFLAGS": [ "-std=c++20" ]
                     }
@@ -121,6 +126,7 @@
                  '<(muhammara_source_root)/ObjectByteWriterWithPosition.cpp',
                  '<(muhammara_source_root)/PDFObjectParserDriver.cpp',
                  '<(muhammara_source_root)/text-extraction/PDFTextExtractor.cpp',
+                 '<(muhammara_source_root)/RecryptAsync.cpp',
                  '<(muhammara_source_root)/muhammara.cpp'
             ]
 

--- a/packages/native-with-source/docs/tests/recrypt-pdfs.js
+++ b/packages/native-with-source/docs/tests/recrypt-pdfs.js
@@ -1,0 +1,92 @@
+var assert = require("chai").assert;
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+var muhammara = require("@muhammara/native-with-source");
+require.cache[require.resolve("@muhammara/native")] = { exports: muhammara };
+var examples = require("../../../native/docs/examples/recrypt-without-blocking");
+
+var fontPath = path.join(
+  __dirname,
+  "../../tests/TestMaterials/fonts/arial.ttf",
+);
+
+function writeSourcePdf(sourcePath) {
+  var writer = muhammara.createWriter(sourcePath);
+  var page = writer.createPage(0, 0, 200, 200);
+
+  writer
+    .startPageContentContext(page)
+    .BT()
+    .Tf(writer.getFontForFile(fontPath), 12)
+    .Tm(1, 0, 0, 1, 20, 30)
+    .Tj("Secret")
+    .ET();
+  writer.writePage(page);
+  writer.end();
+}
+
+function assertEncrypted(filePath, password) {
+  var reader = muhammara.createReader(filePath, { password: password });
+  try {
+    assert.isTrue(reader.isEncrypted());
+    assert.isAbove(reader.getPagesCount(), 0);
+  } finally {
+    reader.end();
+  }
+}
+
+describe("docs/how-to/change-pdf-passwords", function () {
+  var workingDirectory;
+
+  beforeEach(function () {
+    workingDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), "muhammara-docs-"),
+    );
+  });
+
+  afterEach(function () {
+    fs.rmSync(workingDirectory, { recursive: true, force: true });
+  });
+
+  it("recrypts a file without blocking", async function () {
+    var sourcePath = path.join(workingDirectory, "source.pdf");
+    var outputPath = path.join(workingDirectory, "encrypted.pdf");
+    writeSourcePdf(sourcePath);
+
+    var result = await examples.recryptWithoutBlocking(sourcePath, outputPath, {
+      userPassword: "user",
+      ownerPassword: "owner",
+      userProtectionFlag: 4,
+    });
+
+    assert.equal(result, outputPath);
+    assertEncrypted(outputPath, "user");
+  });
+
+  it("recrypts a Buffer without blocking", async function () {
+    var sourcePath = path.join(workingDirectory, "source.pdf");
+    var outputPath = path.join(workingDirectory, "encrypted-buffer.pdf");
+    writeSourcePdf(sourcePath);
+
+    await examples.recryptBufferWithoutBlocking(
+      fs.readFileSync(sourcePath),
+      outputPath,
+      { userPassword: "user" },
+    );
+
+    assertEncrypted(outputPath, "user");
+  });
+
+  it("ends a Recipe with encryption without blocking", async function () {
+    var outputPath = path.join(workingDirectory, "recipe.pdf");
+
+    await examples.encryptRecipeWithoutBlocking(outputPath, {
+      userPassword: "user",
+      ownerPassword: "owner",
+      userProtectionFlag: 4,
+    });
+
+    assertEncrypted(outputPath, "user");
+  });
+});

--- a/packages/native-with-source/src/RecryptAsync.cpp
+++ b/packages/native-with-source/src/RecryptAsync.cpp
@@ -1,0 +1,412 @@
+/*
+ Source File : RecryptAsync.cpp
+
+
+ Copyright 2026 Julian Hille MuhammaraJS
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+#include "RecryptAsync.h"
+
+#include "ObjectByteReaderWithPosition.h"
+#include "ObjectByteWriterWithPosition.h"
+
+#include "EStatusCode.h"
+#include "IByteReaderWithPosition.h"
+#include "OutputStringBufferStream.h"
+#include "Trace.h"
+
+#include <uv.h>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+using namespace v8;
+using namespace node;
+
+const char* const scRecryptFailureMessage =
+    "Unable to recrypt files, check that input and output files are clear and arguments are coool";
+
+// The native build provides a thread-local Trace. Libuv reuses its threads, so
+// clear each job's settings even when PDF processing throws or fails early.
+struct RecryptTraceScope
+{
+    Trace& trace;
+    RecryptTraceScope() : trace(Trace::DefaultTrace()) {}
+    ~RecryptTraceScope() { trace.SetLogSettings(static_cast<IByteWriter*>(NULL), false); }
+};
+
+// Chunk size for moving bytes between the JS stream objects and memory. The
+// stream proxies build one JS array entry per byte, so the synchronous recrypt
+// already pays this cost; comparable chunks keep the profile the same.
+static const size_t scStreamChunkSize = 64 * 1024;
+
+
+// Reads the buffered input off-thread. A dedicated reader rather than
+// InputStringBufferStream, because the parser seeks relative to the current
+// position and std::stringbuf refuses an ios_base::cur seek while its put area
+// is open.
+class MemoryByteReaderWithPosition : public IByteReaderWithPosition
+{
+public:
+    explicit MemoryByteReaderWithPosition(const std::string& inBytes)
+        : mBytes(inBytes), mPosition(0) {}
+
+    virtual IOBasicTypes::LongBufferSizeType Read(IOBasicTypes::Byte* inBuffer,
+                                                  IOBasicTypes::LongBufferSizeType inBufferSize)
+    {
+        size_t available = mBytes.size() - mPosition;
+        size_t amount = (inBufferSize < available) ? (size_t)inBufferSize : available;
+        if (amount > 0) {
+            memcpy(inBuffer, mBytes.data() + mPosition, amount);
+            mPosition += amount;
+        }
+        return (IOBasicTypes::LongBufferSizeType)amount;
+    }
+
+    virtual bool NotEnded() { return mPosition < mBytes.size(); }
+
+    virtual void Skip(IOBasicTypes::LongBufferSizeType inSkipSize)
+    {
+        mPosition = (mBytes.size() - mPosition < inSkipSize) ? mBytes.size() : mPosition + (size_t)inSkipSize;
+    }
+
+    virtual void SetPosition(IOBasicTypes::LongFilePositionType inOffsetFromStart)
+    {
+        if (inOffsetFromStart < 0)
+            mPosition = 0;
+        else if ((size_t)inOffsetFromStart > mBytes.size())
+            mPosition = mBytes.size();
+        else
+            mPosition = (size_t)inOffsetFromStart;
+    }
+
+    virtual void SetPositionFromEnd(IOBasicTypes::LongFilePositionType inOffsetFromEnd)
+    {
+        if (inOffsetFromEnd < 0 || (size_t)inOffsetFromEnd > mBytes.size())
+            mPosition = 0;
+        else
+            mPosition = mBytes.size() - (size_t)inOffsetFromEnd;
+    }
+
+    virtual IOBasicTypes::LongFilePositionType GetCurrentPosition()
+    {
+        return (IOBasicTypes::LongFilePositionType)mPosition;
+    }
+
+private:
+    const std::string& mBytes;
+    size_t mPosition;
+};
+
+struct RecryptWork
+{
+    uv_work_t request;
+
+    Isolate* isolate;
+    Global<Promise::Resolver> resolver;
+    Global<Context> context;
+    // Keeps async_hooks informed, and gives CallbackScope something to attach
+    // the completion to so microtasks are drained the way Node expects.
+    Global<Object> asyncResource;
+    node::async_context asyncContext;
+    // Only set for the stream overload; the produced bytes are handed to this
+    // JS object once the background work is done.
+    Global<Object> writeStream;
+
+    bool usesStreams;
+    std::string originalPath;
+    std::string newPath;
+    std::string originalPassword;
+    EPDFVersion pdfVersion;
+    PDFCreationSettings creationSettings;
+    LogConfiguration logConfiguration;
+
+    std::string inputBytes;
+    OutputStringBufferStream outputBuffer;
+
+    PDFHummus::EStatusCode status;
+
+    RecryptWork()
+        : isolate(NULL),
+          usesStreams(false),
+          pdfVersion(ePDFVersionUndefined),
+          creationSettings(true, true),
+          logConfiguration(LogConfiguration::DefaultLogConfiguration()),
+          status(PDFHummus::eFailure)
+    {
+        request.data = this;
+        asyncContext.async_id = 0;
+        asyncContext.trigger_async_id = 0;
+    }
+};
+
+bool ParseRecryptArguments(Isolate* isolate,
+                           const ARGS_TYPE& args,
+                           EPDFVersion& outPDFVersion,
+                           PDFCreationSettings& outCreationSettings,
+                           LogConfiguration& outLogConfiguration,
+                           std::string& outOriginalPassword)
+{
+    if (args.Length() < 2 || args.Length() > 3) {
+        THROW_EXCEPTION("Wrong number of arguments, Provide one argument stating the location of the source file, a second one for the destination file, and an optional options object");
+        return false;
+    }
+
+    if (!args[0]->IsString() && !args[0]->IsObject()) {
+        THROW_EXCEPTION("Wrong arguments, please provide a path to a file as the first argument or a stream object");
+        return false;
+    }
+
+    if (!args[1]->IsString() && !args[1]->IsObject()) {
+        THROW_EXCEPTION("Wrong arguments, please provide a path to a file as the second argument or a stream object");
+        return false;
+    }
+
+    if ((args[1]->IsString() && !args[0]->IsString()) || (args[1]->IsObject() && !args[0]->IsObject())) {
+        THROW_EXCEPTION("Wrong arguments, please either provide two paths or two stream objects for the first two arguments");
+        return false;
+    }
+
+    if (args.Length() == 3 && args[2]->IsObject())
+    {
+        Local<Object> anObject = args[2]->TO_OBJECT();
+        if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("version")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("version")).ToLocalChecked()->IsNumber())
+        {
+            long pdfVersionValue = TO_INT32(anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("version")).ToLocalChecked())->Value();
+
+            if(pdfVersionValue != ePDFVersionUndefined && (pdfVersionValue < ePDFVersion10 || ePDFVersionMax < pdfVersionValue))
+            {
+                THROW_EXCEPTION("Wrong argument for PDF version, please provide a valid PDF version");
+                return false;
+            }
+            outPDFVersion = (EPDFVersion)pdfVersionValue;
+        }
+
+        if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("compress")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("compress")).ToLocalChecked()->IsBoolean())
+            outCreationSettings.CompressStreams = anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("compress")).ToLocalChecked()->TO_BOOLEAN()->Value();
+
+        if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("log")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("log")).ToLocalChecked()->IsString())
+        {
+            outLogConfiguration.ShouldLog = true;
+            outLogConfiguration.LogFileLocation = *UTF_8_VALUE(anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("log")).ToLocalChecked()->TO_STRING());
+        }
+
+        if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("password")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->IsString())
+        {
+            outOriginalPassword = *UTF_8_VALUE(anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->TO_STRING());
+        }
+
+        if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("userPassword")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("userPassword")).ToLocalChecked()->IsString())
+        {
+            outCreationSettings.DocumentEncryptionOptions.ShouldEncrypt = true;
+            outCreationSettings.DocumentEncryptionOptions.UserPassword = *UTF_8_VALUE(anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("userPassword")).ToLocalChecked()->TO_STRING());
+        }
+
+        if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("ownerPassword")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("ownerPassword")).ToLocalChecked()->IsString())
+        {
+            outCreationSettings.DocumentEncryptionOptions.OwnerPassword = *UTF_8_VALUE(anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("ownerPassword")).ToLocalChecked()->TO_STRING());
+        }
+
+        if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("userProtectionFlag")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("userProtectionFlag")).ToLocalChecked()->IsNumber())
+        {
+            outCreationSettings.DocumentEncryptionOptions.UserProtectionOptionsFlag = TO_INT32(anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("userProtectionFlag")).ToLocalChecked())->Value();
+        }
+        else // default to print only
+            outCreationSettings.DocumentEncryptionOptions.UserProtectionOptionsFlag = 4;
+    }
+
+    return true;
+}
+
+// Drains the whole JS read stream into memory. Runs on the main thread, because
+// ObjectByteReaderWithPosition calls back into JS on every read.
+static void DrainReadStream(Local<Object> inReadStream, std::string& outBytes)
+{
+    ObjectByteReaderWithPosition reader(inReadStream);
+    std::vector<IOBasicTypes::Byte> chunk(scStreamChunkSize);
+
+    reader.SetPosition(0);
+
+    while (reader.NotEnded()) {
+        IOBasicTypes::LongBufferSizeType read =
+            reader.Read(&chunk[0], (IOBasicTypes::LongBufferSizeType)scStreamChunkSize);
+        if (0 == read)
+            break;
+
+        outBytes.append((const char*)&chunk[0], (size_t)read);
+    }
+}
+
+// Hands the produced bytes to the JS write stream. Runs on the main thread for
+// the same reason DrainReadStream does. ObjectByteWriterWithPosition rethrows a
+// JS exception raised by the stream, so the caller has to check for one.
+static void FlushWriteStream(Local<Object> inWriteStream, const std::string& inBytes)
+{
+    ObjectByteWriterWithPosition writer(inWriteStream);
+
+    size_t position = 0;
+    while (position < inBytes.size()) {
+        size_t amount = inBytes.size() - position;
+        if (amount > scStreamChunkSize)
+            amount = scStreamChunkSize;
+
+        writer.Write((const IOBasicTypes::Byte*)inBytes.data() + position,
+                     (IOBasicTypes::LongBufferSizeType)amount);
+
+        position += amount;
+    }
+}
+
+static void RecryptWorkCallback(uv_work_t* inRequest)
+{
+    RecryptWork* work = static_cast<RecryptWork*>(inRequest->data);
+
+    try {
+        RecryptTraceScope traceScope;
+        // Recrypt parses the source before StartPDF configures logging.
+        traceScope.trace.SetLogSettings(work->logConfiguration.LogFileLocation,
+                                        work->logConfiguration.ShouldLog,
+                                        work->logConfiguration.StartWithBOM);
+
+        if (work->usesStreams) {
+            MemoryByteReaderWithPosition input(work->inputBytes);
+            work->status = PDFWriter::RecryptPDF(&input,
+                                             work->originalPassword,
+                                             &work->outputBuffer,
+                                             work->logConfiguration,
+                                             work->creationSettings,
+                                             work->pdfVersion);
+        }
+        else {
+            work->status = PDFWriter::RecryptPDF(work->originalPath,
+                                             work->originalPassword,
+                                             work->newPath,
+                                             work->logConfiguration,
+                                             work->creationSettings,
+                                             work->pdfVersion);
+        }
+    }
+    catch (...) {
+        // Exceptions must not escape a libuv worker and terminate the server.
+        work->status = PDFHummus::eFailure;
+    }
+}
+
+static void RecryptAfterWorkCallback(uv_work_t* inRequest, int inStatus)
+{
+    RecryptWork* work = static_cast<RecryptWork*>(inRequest->data);
+    Isolate* isolate = work->isolate;
+
+    HandleScope handleScope(isolate);
+    // The current context is empty inside a libuv callback, so the one captured
+    // when the promise was created has to be entered explicitly.
+    Local<Context> context = Local<Context>::New(isolate, work->context);
+    Context::Scope contextScope(context);
+
+    {
+        // Drains microtasks on destruction, so the promise continuations run
+        // before control returns to the loop.
+        node::CallbackScope callbackScope(isolate,
+                                          Local<Object>::New(isolate, work->asyncResource),
+                                          work->asyncContext);
+
+        Local<Promise::Resolver> resolver = Local<Promise::Resolver>::New(isolate, work->resolver);
+        bool rejected = false;
+
+        if (inStatus != 0 || PDFHummus::eSuccess != work->status) {
+            Local<Value> error = Exception::TypeError(
+                String::NewFromUtf8(isolate, scRecryptFailureMessage, v8::NewStringType::kNormal).ToLocalChecked());
+            resolver->Reject(context, error).FromMaybe(false);
+            rejected = true;
+        }
+        else if (work->usesStreams) {
+            TryCatch tryCatch(isolate);
+            FlushWriteStream(Local<Object>::New(isolate, work->writeStream), work->outputBuffer.ToString());
+            if (tryCatch.HasCaught()) {
+                Local<Value> error = tryCatch.Exception();
+                tryCatch.Reset();
+                resolver->Reject(context, error).FromMaybe(false);
+                rejected = true;
+            }
+        }
+
+        if (!rejected)
+            resolver->Resolve(context, Undefined(isolate)).FromMaybe(false);
+    }
+
+    node::EmitAsyncDestroy(isolate, work->asyncContext);
+    delete work;
+}
+
+METHOD_RETURN_TYPE RecryptAsync(const ARGS_TYPE& args)
+{
+    CREATE_ISOLATE_CONTEXT;
+    CREATE_ESCAPABLE_SCOPE;
+
+    EPDFVersion pdfVersion = ePDFVersionUndefined;
+    PDFCreationSettings creationSettings(true, true);
+    LogConfiguration logConfiguration = LogConfiguration::DefaultLogConfiguration();
+    std::string originalPassword;
+
+    if (!ParseRecryptArguments(isolate, args, pdfVersion, creationSettings, logConfiguration, originalPassword)) {
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+
+    Local<Context> context = GET_CURRENT_CONTEXT;
+    Local<Promise::Resolver> resolver;
+    if (!Promise::Resolver::New(context).ToLocal(&resolver)) {
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+
+    RecryptWork* work = new RecryptWork();
+    work->isolate = isolate;
+    work->resolver.Reset(isolate, resolver);
+    work->context.Reset(isolate, context);
+    work->pdfVersion = pdfVersion;
+    work->creationSettings = creationSettings;
+    work->logConfiguration = logConfiguration;
+    work->originalPassword = originalPassword;
+    work->usesStreams = args[0]->IsObject();
+
+    if (work->usesStreams) {
+        work->writeStream.Reset(isolate, args[1]->TO_OBJECT());
+
+        // Reading happens here, on the main thread, so the background work
+        // never touches the JS stream objects.
+        DrainReadStream(args[0]->TO_OBJECT(), work->inputBytes);
+    }
+    else {
+        work->originalPath = std::string(*UTF_8_VALUE(args[0]->TO_STRING()));
+        work->newPath = std::string(*UTF_8_VALUE(args[1]->TO_STRING()));
+    }
+
+    Local<Object> asyncResource = Object::New(isolate);
+    work->asyncResource.Reset(isolate, asyncResource);
+    work->asyncContext = node::EmitAsyncInit(isolate, asyncResource, "muhammara:recryptAsync");
+
+    // The event loop of the current environment, not uv_default_loop(), so the
+    // addon keeps working when loaded inside a worker thread.
+    uv_loop_t* loop = node::GetCurrentEventLoop(isolate);
+    int queued = uv_queue_work(loop, &work->request, RecryptWorkCallback, RecryptAfterWorkCallback);
+    if (0 != queued) {
+        node::EmitAsyncDestroy(isolate, work->asyncContext);
+        delete work;
+        THROW_EXCEPTION("Unable to schedule the recrypt operation");
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
+    }
+
+    SET_FUNCTION_RETURN_VALUE(resolver->GetPromise())
+}

--- a/packages/native-with-source/src/RecryptAsync.cpp
+++ b/packages/native-with-source/src/RecryptAsync.cpp
@@ -28,6 +28,7 @@
 #include "Trace.h"
 
 #include <uv.h>
+#include <openssl/crypto.h>
 
 #include <cstring>
 #include <string>
@@ -303,6 +304,10 @@ static void RecryptWorkCallback(uv_work_t* inRequest)
         // Exceptions must not escape a libuv worker and terminate the server.
         work->status = PDFHummus::eFailure;
     }
+
+    // Pool threads can outlive OpenSSL's shutdown. Release this thread's RNG
+    // and error state now, after all PDF objects have been destroyed, not on JS.
+    OPENSSL_thread_stop();
 }
 
 static void RecryptAfterWorkCallback(uv_work_t* inRequest, int inStatus)

--- a/packages/native-with-source/src/RecryptAsync.h
+++ b/packages/native-with-source/src/RecryptAsync.h
@@ -1,0 +1,43 @@
+/*
+ Source File : RecryptAsync.h
+
+
+ Copyright 2026 Julian Hille MuhammaraJS
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+#pragma once
+
+#include "nodes.h"
+
+#include "EPDFVersion.h"
+#include "PDFWriter.h"
+
+#include <string>
+
+// Shared by the synchronous recrypt() and the asynchronous recryptAsync(), so
+// both accept exactly the same options and reject the same inputs.
+// Returns false when an exception has already been thrown on the isolate.
+bool ParseRecryptArguments(v8::Isolate* isolate,
+                           const v8::FunctionCallbackInfo<v8::Value>& args,
+                           EPDFVersion& outPDFVersion,
+                           PDFCreationSettings& outCreationSettings,
+                           LogConfiguration& outLogConfiguration,
+                           std::string& outOriginalPassword);
+
+// The message both entry points use when PDFWriter reports a failure, so the
+// rejection text of recryptAsync() matches the throw of recrypt().
+extern const char* const scRecryptFailureMessage;
+
+METHOD_RETURN_TYPE RecryptAsync(const ARGS_TYPE& args);

--- a/packages/native-with-source/src/build-overrides/README.md
+++ b/packages/native-with-source/src/build-overrides/README.md
@@ -1,0 +1,90 @@
+# Native Concurrency Build Overrides
+
+These native-only overrides let independent PDFWriter jobs execute concurrently
+without editing `src/deps`. They do not change vendor class declarations, layouts,
+public exports, or the Wasm build. Worker scheduling and per-job trace setup/reset
+remain the responsibility of `RecryptAsync.cpp`.
+
+## Build Design
+
+- `pdfwriter.gyp` and `aes.gyp` include the vendor GYP targets and apply
+  `target_defaults`. GYP rebases included source paths relative to the wrapper;
+  the `sources!` entries must use those rebased paths, not bare filenames.
+- `generate.gyp` runs `generate.cjs` before compilation. Each replacement checks
+  its exact expected occurrence count and fails the build on mismatches. It
+  validates all patches before writing build copies under
+  `build/<configuration>/obj/gen/native-build-overrides`, never under `src/deps`.
+  A vendor update that changes a patch anchor requires reviewing the override.
+- The small AES source/header closure is copied together. Merely adding an
+  include directory would not work: quoted includes search beside the including
+  vendor source/header first. All other PDFWriter sources and headers are used
+  directly from the vendor tree.
+- GYP loads dependencies before applying `dependencies!`. The excluded original
+  AES target can therefore still be generated/built, but is **not linked** into
+  the addon. The replacement uses the distinct `muhammara_aesgm` archive name to
+  avoid output collisions. The `--gyp` regression checks the effective link rule
+  and replacement object paths, then tests the actual GYP-built archives.
+- All helpers live under `src`, which is already included in the source package's
+  shipping allowlist. Generated copies remain build artifacts.
+
+## Concurrency Boundaries
+
+`Trace::DefaultTrace()` is thread-local, and all trace state is initialized.
+Different jobs must not pass a `Trace` instance between threads. The worker must
+disable/reset its trace before and after each job so a reused pool thread cannot
+retain a previous job's settings or a borrowed stream.
+
+One short recursive mutex protects log-file construction and each whole log
+record, including timestamp, message, newline, open, flush, and close. It also
+protects separate `Log` instances sharing one stream. It never surrounds PDF
+parsing, cryptography, or serialization. Logging failures and reentrant log
+callbacks are suppressed while inside this sink operation; a failed file open
+does not dereference a null output stream. Stream ownership remains with callers.
+
+Both log timestamps and PDF dates use caller-owned `tm` storage via
+`localtime_r`/`gmtime_r` on POSIX and `localtime_s`/`gmtime_s` on Windows. Timezone
+semantics are unchanged; changing process-global timezone settings concurrently
+is not supported.
+
+AES-NI's first-detection cache and VIA's repeatedly written probe flags are
+thread-local C storage. MSVC VIA inline assembly writes only stack locals; C
+performs the TLS accesses. This covers negative VIA detections on every call,
+not just a warmup. Existing CPU selection, AES algorithms, random IV generation,
+and RNG fallback behavior are otherwise unchanged.
+
+## Verification
+
+From the repository root, with a POSIX C/C++ toolchain:
+
+```sh
+node packages/native-with-source/tests/build-overrides/run.cjs
+node packages/native-with-source/tests/build-overrides/run.cjs --aes-ni
+node packages/native-with-source/tests/build-overrides/run.cjs --aes-ni --tsan
+node packages/native-with-source/tests/build-overrides/run.cjs --ia32
+```
+
+`--aes-ni` explicitly enables the runtime-dispatched AES-NI build on x64, since
+the default Linux build may not compile that path. `--ia32` needs a multilib
+toolchain and exercises the VIA-enabled build, including recurring negative
+probes on non-VIA CPUs. `--tsan` needs an installed ThreadSanitizer runtime.
+`CC`, `CXX`, and `TMPDIR` are honored. The runner only executes when invoked
+directly, not when Mocha discovers it, and adds no instrumentation to the addon.
+
+The isolated harness checks simultaneous cold AES-128/192/256 known-answer
+encryption/decryption, unique live trace addresses, main/worker log routing,
+both trace formatting overloads with truncation-sized messages, shared stream
+records, shared-file creation/BOM and long records, recursive/unwritable logging,
+and date conversions in UTC and a non-UTC timezone.
+
+From `packages/native-with-source`, configure/build the native archive overrides:
+
+```sh
+../../node_modules/.bin/node-pre-gyp configure
+make -C build -j4 pdfwriter libaesgm
+node tests/build-overrides/run.cjs --gyp
+```
+
+To relink the addon after the main worker changes are ready, run
+`../../node_modules/.bin/node-pre-gyp build --jobs=4` from the same directory.
+Use the normal Windows/macOS native builds to validate those platform branches;
+the isolated runner currently targets POSIX toolchains.

--- a/packages/native-with-source/src/build-overrides/README.md
+++ b/packages/native-with-source/src/build-overrides/README.md
@@ -7,9 +7,20 @@ remain the responsibility of `RecryptAsync.cpp`.
 
 ## Build Design
 
-- `pdfwriter.gyp` and `aes.gyp` include the vendor GYP targets and apply
-  `target_defaults`. GYP rebases included source paths relative to the wrapper;
-  the `sources!` entries must use those rebased paths, not bare filenames.
+- `pdfwriter.gyp` and `aes.gyp` declare static targets with the vendor settings
+  and apply `target_defaults`. Their source lists are read from the vendor GYP
+  files using node-gyp's configured Python interpreter and `ast.literal_eval`.
+  Paths are relative to the wrapper; `sources!` uses those same paths.
+  The generation regression checks the explicit settings against the vendor
+  targets so an upstream settings change requires reviewing these wrappers.
+- Do not directly include a vendor `.gyp`: the MSVS generator emits a solution
+  for every loaded `.gyp`, even an include whose targets belong to the wrapper.
+  That orphan solution has no project-created output directory and fails during
+  configure ([#98](https://github.com/julianhille/MuhammaraJS/issues/98)). Includes
+  are processed before command expansion, so generating an included `.gypi`
+  inside the same wrapper would not work. Reading only the source lists avoids
+  extra configure entrypoints, generated GYP copies, and vendor-tree writes.
+  Rerun configure after changing a vendor source list.
 - `generate.gyp` runs `generate.cjs` before compilation. Each replacement checks
   its exact expected occurrence count and fails the build on mismatches. It
   validates all patches before writing build copies under
@@ -19,11 +30,11 @@ remain the responsibility of `RecryptAsync.cpp`.
   include directory would not work: quoted includes search beside the including
   vendor source/header first. All other PDFWriter sources and headers are used
   directly from the vendor tree.
-- GYP loads dependencies before applying `dependencies!`. The excluded original
-  AES target can therefore still be generated/built, but is **not linked** into
-  the addon. The replacement uses the distinct `muhammara_aesgm` archive name to
-  avoid output collisions. The `--gyp` regression checks the effective link rule
-  and replacement object paths, then tests the actual GYP-built archives.
+- The PDFWriter wrapper depends directly on the replacement AES target. The
+  original AES target is neither loaded nor linked. The replacement retains the
+  distinct `muhammara_aesgm` archive name. The `--gyp` regression checks the
+  effective link rule and replacement object paths, then tests the actual
+  GYP-built archives.
 - All helpers live under `src`, which is already included in the source package's
   shipping allowlist. Generated copies remain build artifacts.
 
@@ -33,6 +44,12 @@ remain the responsibility of `RecryptAsync.cpp`.
 Different jobs must not pass a `Trace` instance between threads. The worker must
 disable/reset its trace before and after each job so a reused pool thread cannot
 retain a previous job's settings or a borrowed stream.
+
+After PDF processing and trace cleanup, `RecryptAsync.cpp` calls
+`OPENSSL_thread_stop()` on the pool thread itself. OpenSSL's per-thread RNG and
+error state must be released before library shutdown, because libuv's threads
+can outlive it. This is not global `OPENSSL_cleanup()`; subsequent jobs and
+Node's own crypto operations can continue using OpenSSL.
 
 One short recursive mutex protects log-file construction and each whole log
 record, including timestamp, message, newline, open, flush, and close. It also
@@ -53,6 +70,29 @@ not just a warmup. Existing CPU selection, AES algorithms, random IV generation,
 and RNG fallback behavior are otherwise unchanged.
 
 ## Verification
+
+For build generation only, use npm's node-gyp, or pass the directory containing
+node-gyp's `gyp/` explicitly:
+
+```sh
+npm exec -c 'python3 packages/native-with-source/tests/build-overrides/generation.py'
+python3 packages/native-with-source/tests/build-overrides/generation.py /path/to/node-gyp
+```
+
+Native CI runs this regression before building the packed source package.
+
+This standalone regression runs the real MSVS generator for x64 and ia32, plus
+Make generation, against the package's `binding.gyp`. It uses fresh
+temporary output directories (including spaces) and does not compile, run build
+actions, download headers, or alter the normal build directory. MSVS uses a
+virtual VS2022/Windows SDK configuration; a non-UTF-8 subprocess locale works
+around GYP's MSVS XML writer on POSIX. The test sets `module_root_dir` to GYP's
+per-file `DEPTH` rather than an absolute path, keeping dependency projects inside
+the temporary output directory, and asserts that vendor files are untouched.
+The test checks solution/project references,
+compiler include paths and exception settings, replacement source selection,
+the absence of original AES link dependencies, and preserved vendor metadata.
+It does not replace Windows/Electron compilation or macOS runtime testing.
 
 From the repository root, with a POSIX C/C++ toolchain:
 

--- a/packages/native-with-source/src/build-overrides/ThreadSafety.h
+++ b/packages/native-with-source/src/build-overrides/ThreadSafety.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <ctime>
+#include <mutex>
+
+namespace MuhammaraBuild {
+
+inline bool LocalTime(const time_t& value, tm& result) {
+#ifdef _WIN32
+  return localtime_s(&result, &value) == 0;
+#else
+  return localtime_r(&value, &result) != nullptr;
+#endif
+}
+
+inline bool GmTime(const time_t& value, tm& result) {
+#ifdef _WIN32
+  return gmtime_s(&result, &value) == 0;
+#else
+  return gmtime_r(&value, &result) != nullptr;
+#endif
+}
+
+inline unsigned& LogDepth() {
+  static thread_local unsigned depth = 0;
+  return depth;
+}
+
+// One sink lock across all Log instances, including separate instances opening
+// the same path. Never held during PDF parsing, encryption, or serialization.
+class LogGuard {
+ public:
+  LogGuard() : lock(Mutex()) { ++LogDepth(); }
+  ~LogGuard() { --LogDepth(); }
+  bool IsOuter() const { return LogDepth() == 1; }
+
+ private:
+  static std::recursive_mutex& Mutex() {
+    static std::recursive_mutex mutex;
+    return mutex;
+  }
+  std::lock_guard<std::recursive_mutex> lock;
+};
+
+}  // namespace MuhammaraBuild

--- a/packages/native-with-source/src/build-overrides/aes-thread-local.h
+++ b/packages/native-with-source/src/build-overrides/aes-thread-local.h
@@ -1,0 +1,12 @@
+#ifndef MUHAMMARA_AES_THREAD_LOCAL_H
+#define MUHAMMARA_AES_THREAD_LOCAL_H
+
+#if defined(_MSC_VER)
+#define MUHAMMARA_THREAD_LOCAL __declspec(thread)
+#elif defined(__GNUC__) || defined(__clang__)
+#define MUHAMMARA_THREAD_LOCAL __thread
+#else
+#define MUHAMMARA_THREAD_LOCAL _Thread_local
+#endif
+
+#endif

--- a/packages/native-with-source/src/build-overrides/aes.gyp
+++ b/packages/native-with-source/src/build-overrides/aes.gyp
@@ -1,0 +1,22 @@
+{
+    'includes': [ '../deps/LibAesgm/binding.gyp' ],
+    'target_defaults': {
+        'product_name': 'muhammara_aesgm',
+        'dependencies': [ 'generate.gyp:native_build_overrides' ],
+        'include_dirs': [ '.' ],
+        'sources!': [
+            '../deps/LibAesgm/aescrypt.c',
+            '../deps/LibAesgm/aeskey.c',
+            '../deps/LibAesgm/aes_ni.c',
+            '../deps/LibAesgm/aes_modes.c',
+            '../deps/LibAesgm/aestab.c'
+        ],
+        'sources': [
+            '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aescrypt.c',
+            '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aeskey.c',
+            '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aes_ni.c',
+            '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aes_modes.c',
+            '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aestab.c'
+        ]
+    }
+}

--- a/packages/native-with-source/src/build-overrides/aes.gyp
+++ b/packages/native-with-source/src/build-overrides/aes.gyp
@@ -1,5 +1,15 @@
 {
-    'includes': [ '../deps/LibAesgm/binding.gyp' ],
+    'targets': [ {
+        'target_name': 'libaesgm',
+        'type': 'static_library',
+        'defines': [ 'USE_BUNDLED=TRUE' ],
+        'msvs_settings': {
+            'VCCLCompilerTool': { 'AdditionalOptions': [ '/std:c++17' ] }
+        },
+        'sources': [
+            '<!@("<(python)" -c "import ast, shlex; print(shlex.join(\'../deps/LibAesgm/\' + p for p in ast.literal_eval(open(\'../deps/LibAesgm/binding.gyp\', encoding=\'utf-8\').read())[\'targets\'][0][\'sources\']))")'
+        ]
+    } ],
     'target_defaults': {
         'product_name': 'muhammara_aesgm',
         'dependencies': [ 'generate.gyp:native_build_overrides' ],

--- a/packages/native-with-source/src/build-overrides/generate.cjs
+++ b/packages/native-with-source/src/build-overrides/generate.cjs
@@ -1,0 +1,203 @@
+var fs = require("node:fs");
+var path = require("node:path");
+
+var aesFiles = [
+  "aescrypt.c",
+  "aeskey.c",
+  "aes_ni.c",
+  "aes_modes.c",
+  "aestab.c",
+  "aesopt.h",
+  "brg_endian.h",
+  "aes.h",
+  "aestab.h",
+  "brg_types.h",
+  "aes_via_ace.h",
+  "aes_ni.h",
+  "aescpp.h",
+];
+
+function generate(output, deps = path.resolve(__dirname, "../deps")) {
+  var files = {};
+  function load(name) {
+    return fs
+      .readFileSync(path.join(deps, name), "utf8")
+      .replace(/\r\n/g, "\n");
+  }
+  function replace(source, before, after, count = 1) {
+    var parts = source.split(before);
+    if (parts.length !== count + 1) {
+      throw new Error(
+        `Native build override mismatch (${count} expected): ${before}`,
+      );
+    }
+    return parts.join(after);
+  }
+
+  var trace = load("PDFWriter/Trace.cpp");
+  trace = replace(
+    trace,
+    '#include "Trace.h"',
+    '#include "Trace.h"\n#include "ThreadSafety.h"',
+  );
+  trace = replace(
+    trace,
+    "static Trace default_trace;",
+    "static thread_local Trace default_trace;",
+  );
+  trace = replace(
+    trace,
+    "mShouldLog = false;",
+    "mShouldLog = false;\n\tmLogStream = NULL;\n\tmPlaceUTF8Bom = false;\n\tmBuffer[0] = '\\0';",
+  );
+  // OutputFile failures and stream callbacks must not recursively log themselves.
+  trace = replace(
+    trace,
+    "\n\tif(mShouldLog)\n",
+    "\n\tif(MuhammaraBuild::LogDepth() != 0) return;\n\tif(mShouldLog)\n",
+    2,
+  );
+  files["Trace.cpp"] = trace;
+
+  var log = load("PDFWriter/Log.cpp");
+  log = replace(
+    log,
+    '#include "Log.h"',
+    '#include "Log.h"\n#include "ThreadSafety.h"',
+  );
+  log = replace(
+    log,
+    "Log::Log(const std::string& inLogFilePath,bool inPlaceUTF8Bom)\n{",
+    "Log::Log(const std::string& inLogFilePath,bool inPlaceUTF8Bom)\n{\n    MuhammaraBuild::LogGuard guard;",
+  );
+  for (var method of ["LogEntryToFile", "LogEntryToStream"]) {
+    var signature = `void Log::${method}(const Byte* inMessage, LongBufferSizeType inMessageSize)\n{`;
+    log = replace(
+      log,
+      signature,
+      signature +
+        "\n    MuhammaraBuild::LogGuard guard;\n    if(!guard.IsOuter()) return;",
+    );
+  }
+  log = replace(
+    log,
+    "mLogFile.OpenFile(inLogFilePath);",
+    "if(mLogFile.OpenFile(inLogFilePath) != PDFHummus::eSuccess)\n            {\n                mLogStream = NULL;\n                mLogMethod = STATIC_LogEntryToFile;\n                return;\n            }",
+  );
+  log = replace(
+    log,
+    "mLogFile.OpenFile(mFilePath,true);",
+    "if(mLogFile.OpenFile(mFilePath,true) != PDFHummus::eSuccess) return;",
+  );
+  log = replace(
+    log,
+    "SAFE_LOCAL_TIME(structuredLocalTime,currentTime);",
+    'if(!MuhammaraBuild::LocalTime(currentTime, structuredLocalTime)) return "";',
+  );
+  files["Log.cpp"] = log;
+
+  var date = load("PDFWriter/PDFDate.cpp");
+  date = replace(
+    date,
+    '#include "PDFDate.h"',
+    '#include "PDFDate.h"\n#include "ThreadSafety.h"',
+  );
+  date = replace(
+    date,
+    "SAFE_LOCAL_TIME(structuredLocalTime,currentTime);",
+    "if(!MuhammaraBuild::LocalTime(currentTime, structuredLocalTime))\n    {\n        SetTime(-1);\n        return;\n    }",
+  );
+  date = replace(
+    date,
+    "struct tm *gmTime;",
+    "struct tm gmStorage;\n    struct tm *gmTime = &gmStorage;",
+  );
+  date = replace(
+    date,
+    "gmTime = gmtime(&localEpoch);",
+    "if(!MuhammaraBuild::GmTime(localEpoch, gmStorage))\n    {\n        UTC = eUndefined;\n        return;\n    }",
+  );
+  files["PDFDate.cpp"] = date;
+
+  // Copy the small AES source/header closure together: quoted includes otherwise
+  // resolve beside the vendor source first, bypassing an include_dir override.
+  for (var name of aesFiles) files[name] = load("LibAesgm/" + name);
+  files["aes_ni.c"] = replace(
+    files["aes_ni.c"],
+    '#include "aes_ni.h"',
+    '#include "aes_ni.h"\n#include "aes-thread-local.h"',
+  );
+  files["aes_ni.c"] = replace(
+    files["aes_ni.c"],
+    "static int test = -1;",
+    "static MUHAMMARA_THREAD_LOCAL int test = -1;",
+    2,
+  );
+  var via = files["aes_via_ace.h"];
+  via = replace(
+    via,
+    "static unsigned char via_flags = 0;",
+    '#include "aes-thread-local.h"\nstatic MUHAMMARA_THREAD_LOCAL unsigned char via_flags = 0;',
+  );
+  // MSVC inline assembly cannot directly address TLS. Keep probe assembly local
+  // and let C generate TLS addressing, including the recurring negative probe.
+  via = replace(
+    via,
+    "        mov     [via_flags],dl  /* set VIA detected flag    */\n",
+    "",
+  );
+  via = replace(
+    via,
+    "        mov     ret_value,al    /*     able to change it    */\n        pop     ebx\n    }\n    return (int)ret_value;",
+    "        mov     ret_value,al    /*     able to change it    */\n        pop     ebx\n    }\n    via_flags = (unsigned char)(ret_value | NEH_CPU_READ);\n    return (int)ret_value;",
+  );
+  via = replace(
+    via,
+    "        or      [via_flags],al  /* present & enabled flags  */\n",
+    "",
+  );
+  via = replace(
+    via,
+    "no_rng:\n    }\n    return (int)ret_value;",
+    "no_rng:\n    }\n    via_flags |= (unsigned char)ret_value;\n    return (int)ret_value;",
+  );
+  files["aes_via_ace.h"] = via;
+
+  // Verify everything before writing anything. Never accept a vendor destination.
+  output = path.resolve(output);
+  var parent = output;
+  while (!fs.existsSync(parent)) parent = path.dirname(parent);
+  output = path.resolve(fs.realpathSync(parent), path.relative(parent, output));
+  var relative = path.relative(fs.realpathSync(deps), output);
+  if (
+    !relative ||
+    (!relative.startsWith(".." + path.sep) &&
+      relative !== ".." &&
+      !path.isAbsolute(relative))
+  ) {
+    throw new Error(
+      "Native build overrides must be generated outside src/deps",
+    );
+  }
+  fs.mkdirSync(output, { recursive: true });
+  for (var name of Object.keys(files)) {
+    var destination = path.join(output, name);
+    if (
+      fs.lstatSync(destination, { throwIfNoEntry: false })?.isSymbolicLink()
+    ) {
+      throw new Error(
+        "Native build override output must not be a symbolic link",
+      );
+    }
+  }
+  for (var [name, source] of Object.entries(files)) {
+    fs.writeFileSync(path.join(output, name), source);
+  }
+}
+
+module.exports = { generate, aesFiles };
+if (require.main === module) {
+  if (process.argv.length !== 3)
+    throw new Error("Usage: node generate.cjs OUTPUT_DIRECTORY");
+  generate(process.argv[2]);
+}

--- a/packages/native-with-source/src/build-overrides/generate.gyp
+++ b/packages/native-with-source/src/build-overrides/generate.gyp
@@ -1,0 +1,50 @@
+{
+    'targets': [ {
+        'target_name': 'native_build_overrides',
+        'type': 'none',
+        'actions': [ {
+            'action_name': 'generate_native_build_overrides',
+            'msvs_cygwin_shell': 0,
+            'inputs': [
+                'generate.cjs',
+                'ThreadSafety.h',
+                'aes-thread-local.h',
+                '../deps/PDFWriter/Trace.cpp',
+                '../deps/PDFWriter/Log.cpp',
+                '../deps/PDFWriter/PDFDate.cpp',
+                '../deps/LibAesgm/aescrypt.c',
+                '../deps/LibAesgm/aeskey.c',
+                '../deps/LibAesgm/aes_ni.c',
+                '../deps/LibAesgm/aes_modes.c',
+                '../deps/LibAesgm/aestab.c',
+                '../deps/LibAesgm/aesopt.h',
+                '../deps/LibAesgm/brg_endian.h',
+                '../deps/LibAesgm/aes.h',
+                '../deps/LibAesgm/aestab.h',
+                '../deps/LibAesgm/brg_types.h',
+                '../deps/LibAesgm/aes_via_ace.h',
+                '../deps/LibAesgm/aes_ni.h',
+                '../deps/LibAesgm/aescpp.h'
+            ],
+            'outputs': [
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/Trace.cpp',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/Log.cpp',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/PDFDate.cpp',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aescrypt.c',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aeskey.c',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aes_ni.c',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aes_modes.c',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aestab.c',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aesopt.h',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/brg_endian.h',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aes.h',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aestab.h',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/brg_types.h',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aes_via_ace.h',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aes_ni.h',
+                '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/aescpp.h'
+            ],
+            'action': [ 'node', 'generate.cjs', '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides' ]
+        } ]
+    } ]
+}

--- a/packages/native-with-source/src/build-overrides/pdfwriter.gyp
+++ b/packages/native-with-source/src/build-overrides/pdfwriter.gyp
@@ -1,0 +1,20 @@
+{
+    'includes': [ '../deps/PDFWriter/binding.gyp' ],
+    'target_defaults': {
+        'defines!': [ '_HAS_EXCEPTIONS=0' ],
+        'msvs_settings': { 'VCCLCompilerTool': { 'ExceptionHandling': 1 } },
+        'dependencies!': [ '<(module_root_dir)/src/deps/LibAesgm/binding.gyp:libaesgm' ],
+        'dependencies': [ 'aes.gyp:libaesgm', 'generate.gyp:native_build_overrides' ],
+        'include_dirs': [ '../deps/PDFWriter', '.' ],
+        'sources!': [
+            '../deps/PDFWriter/Trace.cpp',
+            '../deps/PDFWriter/Log.cpp',
+            '../deps/PDFWriter/PDFDate.cpp'
+        ],
+        'sources': [
+            '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/Trace.cpp',
+            '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/Log.cpp',
+            '<(SHARED_INTERMEDIATE_DIR)/native-build-overrides/PDFDate.cpp'
+        ]
+    }
+}

--- a/packages/native-with-source/src/build-overrides/pdfwriter.gyp
+++ b/packages/native-with-source/src/build-overrides/pdfwriter.gyp
@@ -1,9 +1,43 @@
 {
-    'includes': [ '../deps/PDFWriter/binding.gyp' ],
+    # Do not include a .gyp as a .gypi: MSVS emits a solution for every loaded .gyp.
+    'targets': [ {
+        'target_name': 'pdfwriter',
+        'type': 'static_library',
+        'cflags!': [ '-fno-exceptions' ],
+        'cflags_cc!': [ '-fno-exceptions' ],
+        'defines': [ 'USE_BUNDLED=TRUE' ],
+        'conditions': [
+            ['OS=="mac"', {
+                'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES' }
+            }]
+        ],
+        'msvs_settings': {
+            'VCCLCompilerTool': { 'AdditionalOptions': [ '/std:c++20' ] }
+        },
+        'dependencies': [
+            '<(module_root_dir)/openssl.gyp:openssl',
+            '<(module_root_dir)/src/deps/FreeType/binding.gyp:freetype',
+            '<(module_root_dir)/src/deps/LibJpeg/binding.gyp:libjpeg',
+            '<(module_root_dir)/src/deps/Zlib/binding.gyp:zlib',
+            '<(module_root_dir)/src/deps/LibTiff/binding.gyp:libtiff',
+            '<(module_root_dir)/src/deps/LibPng/binding.gyp:libpng'
+        ],
+        'include_dirs': [
+            '<(module_root_dir)/openssl-build/<(target_arch)/include',
+            '<(module_root_dir)/src/deps/LibAesgm',
+            '<(module_root_dir)/src/deps/FreeType/include',
+            '<(module_root_dir)/src/deps/LibTiff',
+            '<(module_root_dir)/src/deps/Zlib',
+            '<(module_root_dir)/src/deps/LibJpeg',
+            '<(module_root_dir)/src/deps/LibPng'
+        ],
+        'sources': [
+            '<!@("<(python)" -c "import ast, shlex; print(shlex.join(\'../deps/PDFWriter/\' + p for p in ast.literal_eval(open(\'../deps/PDFWriter/binding.gyp\', encoding=\'utf-8\').read())[\'targets\'][0][\'sources\']))")'
+        ]
+    } ],
     'target_defaults': {
         'defines!': [ '_HAS_EXCEPTIONS=0' ],
         'msvs_settings': { 'VCCLCompilerTool': { 'ExceptionHandling': 1 } },
-        'dependencies!': [ '<(module_root_dir)/src/deps/LibAesgm/binding.gyp:libaesgm' ],
         'dependencies': [ 'aes.gyp:libaesgm', 'generate.gyp:native_build_overrides' ],
         'include_dirs': [ '../deps/PDFWriter', '.' ],
         'sources!': [

--- a/packages/native-with-source/src/muhammara.cpp
+++ b/packages/native-with-source/src/muhammara.cpp
@@ -68,6 +68,7 @@
 #include "PDFObjectParserDriver.h"
 #include "text-extraction/PDFTextExtractor.h"
 #include "ConstructorsHolder.h"
+#include "RecryptAsync.h"
 
 using namespace v8;
 using namespace node;
@@ -181,80 +182,15 @@ METHOD_RETURN_TYPE Recrypt(const ARGS_TYPE& args)
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
 
-	if (args.Length() < 2 || args.Length() > 3) {
-		THROW_EXCEPTION("Wrong number of arguments, Provide one argument stating the location of the source file, a second one for the destination file, and an optional options object");
-		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
-	}
-    
-	if (!args[0]->IsString() && !args[0]->IsObject()) {
-		THROW_EXCEPTION("Wrong arguments, please provide a path to a file as the first argument or a stream object");
-		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
-	}
-
-	if (!args[1]->IsString() && !args[1]->IsObject()) {
-		THROW_EXCEPTION("Wrong arguments, please provide a path to a file as the second argument or a stream object");
-		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
-	}
-
-    if((args[1]->IsString() && !args[0]->IsString()) || (args[1]->IsObject() && !args[0]->IsObject())) {
-		THROW_EXCEPTION("Wrong arguments, please either provide two paths or two stream objects for the first two arguments");
-		SET_FUNCTION_RETURN_VALUE(UNDEFINED)        
-    }
-    
-
     EPDFVersion pdfVersion = ePDFVersionUndefined;
     PDFCreationSettings pdfCreationSettings(true,true);
     LogConfiguration logConfig = LogConfiguration::DefaultLogConfiguration();
     std::string originalPassword;
-    
-    if(args.Length() == 3 && args[2]->IsObject())
-    {
-        Local<Object> anObject = args[2]->TO_OBJECT();
-        if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("version")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("version")).ToLocalChecked()->IsNumber())
-        {
-            long pdfVersionValue = TO_INT32(anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("version")).ToLocalChecked())->Value();
-            
-            if(pdfVersionValue != ePDFVersionUndefined && (pdfVersionValue < ePDFVersion10 || ePDFVersionMax < pdfVersionValue))
-            {
-                THROW_EXCEPTION("Wrong argument for PDF version, please provide a valid PDF version");
-                SET_FUNCTION_RETURN_VALUE(UNDEFINED)
-            }
-            pdfVersion = (EPDFVersion)pdfVersionValue;
-        }
-            
-        if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("compress")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("compress")).ToLocalChecked()->IsBoolean())
-            pdfCreationSettings.CompressStreams = anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("compress")).ToLocalChecked()->TO_BOOLEAN()->Value();
 
-        if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("log")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("log")).ToLocalChecked()->IsString())
-        {
-            logConfig.ShouldLog = true;
-            logConfig.LogFileLocation = *UTF_8_VALUE(anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("log")).ToLocalChecked()->TO_STRING());
-        }
-
-        if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("password")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->IsString())
-        {
-            originalPassword = *UTF_8_VALUE(anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->TO_STRING());
-        }
-
-        if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("userPassword")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("userPassword")).ToLocalChecked()->IsString())
-        {
-            pdfCreationSettings.DocumentEncryptionOptions.ShouldEncrypt = true;
-            pdfCreationSettings.DocumentEncryptionOptions.UserPassword = *UTF_8_VALUE(anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("userPassword")).ToLocalChecked()->TO_STRING());
-        }
-
-        if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("ownerPassword")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("ownerPassword")).ToLocalChecked()->IsString())
-        {
-            pdfCreationSettings.DocumentEncryptionOptions.OwnerPassword = *UTF_8_VALUE(anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("ownerPassword")).ToLocalChecked()->TO_STRING());
-        }
-
-        if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("userProtectionFlag")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("userProtectionFlag")).ToLocalChecked()->IsNumber())
-        {
-            pdfCreationSettings.DocumentEncryptionOptions.UserProtectionOptionsFlag = TO_INT32(anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("userProtectionFlag")).ToLocalChecked())->Value();
-        }
-        else // default to print only
-            pdfCreationSettings.DocumentEncryptionOptions.UserProtectionOptionsFlag = 4;
+    if (!ParseRecryptArguments(isolate, args, pdfVersion, pdfCreationSettings, logConfig, originalPassword)) {
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     EStatusCode status;
     
     if(args[0]->IsObject())
@@ -280,7 +216,7 @@ METHOD_RETURN_TYPE Recrypt(const ARGS_TYPE& args)
     
     if(status != PDFHummus::eSuccess)
     {
-		THROW_EXCEPTION("Unable to recrypt files, check that input and output files are clear and arguments are coool");
+		THROW_EXCEPTION(scRecryptFailureMessage);
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
     SET_FUNCTION_RETURN_VALUE(UNDEFINED)
@@ -584,6 +520,7 @@ DEF_INIT(MuhammaraInit) {
 	EXPORTS_SET(exports,NEW_SYMBOL("createWriterToModify"), NEW_FUNCTION_TEMPLATE_EXTERNAL(CreateWriterToModify)->GetFunction(GET_CURRENT_CONTEXT).ToLocalChecked())
 	EXPORTS_SET(exports,NEW_SYMBOL("createReader"), NEW_FUNCTION_TEMPLATE_EXTERNAL(CreateReader)->GetFunction(GET_CURRENT_CONTEXT).ToLocalChecked())
     EXPORTS_SET(exports,NEW_SYMBOL("recrypt"), NEW_FUNCTION_TEMPLATE(Recrypt)->GetFunction(GET_CURRENT_CONTEXT).ToLocalChecked())
+    EXPORTS_SET(exports,NEW_SYMBOL("recryptAsync"), NEW_FUNCTION_TEMPLATE(RecryptAsync)->GetFunction(GET_CURRENT_CONTEXT).ToLocalChecked())
     
     // define pdf versions enum
     EXPORTS_SET(exports,NEW_SYMBOL("ePDFVersion10"),NEW_NUMBER(ePDFVersion10))

--- a/packages/native-with-source/tests/Xcryption.js
+++ b/packages/native-with-source/tests/Xcryption.js
@@ -574,12 +574,44 @@ describe("Xcryption", function () {
       });
     });
 
+    it("reuses OpenSSL on pooled threads after successful and failed jobs", async function () {
+      this.timeout(60000);
+      var randomBytes = require("crypto").randomBytes;
+      // PDF 2.0 initializes OpenSSL's per-thread RNG. Repeated batches exercise
+      // cleanup and reinitialization; the sanitizer run checks process exit.
+      for (var round = 0; round < 3; round++) {
+        await Promise.all(
+          Array.from({ length: 8 }, async function (_, index) {
+            var target = __dirname + "/output/RecryptOpenSSL-" + index + ".pdf";
+            var password = "round-" + round + "-" + index;
+            await muhammara.recryptAsync(
+              __dirname + "/TestMaterials/Original.pdf",
+              target,
+              {
+                version: muhammara.ePDFVersion20,
+                userPassword: password,
+              },
+            );
+            assertRecryptedPdf(target, password, true);
+            await assert.rejects(
+              muhammara.recryptAsync(target, target + ".rejected.pdf", {
+                password: "wrong-password",
+              }),
+              /Unable to recrypt files/,
+            );
+            assert.equal(randomBytes(32).length, 32);
+          }),
+        );
+      }
+    });
+
     it("leaves the event loop free while the synchronous call blocks it", async function () {
+      this.timeout(60000);
       // A single small fixture recrypts too fast to observe, so build a bigger
       // one first. Appending the same document repeatedly is enough.
       var big = __dirname + "/output/RecryptAsyncLargeSource.pdf";
       var writer = muhammara.createWriter(big);
-      for (var i = 0; i < 12; i++) {
+      for (var i = 0; i < 3; i++) {
         writer.appendPDFPagesFromPDF(
           __dirname + "/TestMaterials/BasicTIFFImagesTest.PDF",
         );

--- a/packages/native-with-source/tests/Xcryption.js
+++ b/packages/native-with-source/tests/Xcryption.js
@@ -269,4 +269,406 @@ describe("Xcryption", function () {
       );
     });
   });
+
+  describe("recryptAsync", function () {
+    var fs = require("fs");
+
+    it("strips a password from a path and resolves", async function () {
+      await muhammara.recryptAsync(
+        __dirname + "/TestMaterials/PDFWithPassword.PDF",
+        __dirname + "/output/RecryptAsyncToNothing.PDF",
+        {
+          password: "user",
+        },
+      );
+      assertRecryptedPdf(
+        __dirname + "/output/RecryptAsyncToNothing.PDF",
+        undefined,
+        false,
+      );
+    });
+
+    it("encrypts a path with a different password", async function () {
+      await muhammara.recryptAsync(
+        __dirname + "/TestMaterials/PDFWithPassword.PDF",
+        __dirname + "/output/RecryptAsyncDifferentPassword.PDF",
+        {
+          password: "user",
+          userPassword: "newPassword",
+          ownerPassword: "newOwner",
+          userProtectionFlag: 4,
+        },
+      );
+      assertRecryptedPdf(
+        __dirname + "/output/RecryptAsyncDifferentPassword.PDF",
+        "newPassword",
+        true,
+      );
+    });
+
+    it("encrypts a previously unencrypted PDF", async function () {
+      await muhammara.recryptAsync(
+        __dirname + "/TestMaterials/Original.pdf",
+        __dirname + "/output/RecryptAsyncEncrypted.pdf",
+        {
+          userPassword: "user",
+          ownerPassword: "owner",
+          userProtectionFlag: 4,
+        },
+      );
+      assertRecryptedPdf(
+        __dirname + "/output/RecryptAsyncEncrypted.pdf",
+        "user",
+        true,
+      );
+    });
+
+    it("encrypts from a Buffer source through stream objects", async function () {
+      var source = fs.readFileSync(
+        __dirname + "/TestMaterials/PDFWithPassword.PDF",
+      );
+      var target = new muhammara.PDFWStreamForFile(
+        __dirname + "/output/RecryptAsyncFromBuffer.PDF",
+      );
+
+      await muhammara.recryptAsync(
+        new muhammara.PDFRStreamForBuffer(source),
+        target,
+        {
+          password: "user",
+          userPassword: "user",
+          ownerPassword: "owner",
+          userProtectionFlag: 4,
+        },
+      );
+      await new Promise(function (resolve) {
+        target.close(resolve);
+      });
+
+      assertRecryptedPdf(
+        __dirname + "/output/RecryptAsyncFromBuffer.PDF",
+        "user",
+        true,
+      );
+    });
+
+    it("produces the same document as the synchronous recrypt", async function () {
+      var options = { password: "user" };
+      muhammara.recrypt(
+        __dirname + "/TestMaterials/PDFWithPassword.PDF",
+        __dirname + "/output/RecryptParitySync.PDF",
+        options,
+      );
+      await muhammara.recryptAsync(
+        __dirname + "/TestMaterials/PDFWithPassword.PDF",
+        __dirname + "/output/RecryptParityAsync.PDF",
+        options,
+      );
+
+      var syncReader = muhammara.createReader(
+        __dirname + "/output/RecryptParitySync.PDF",
+      );
+      var asyncReader = muhammara.createReader(
+        __dirname + "/output/RecryptParityAsync.PDF",
+      );
+      try {
+        assert.equal(
+          asyncReader.getPagesCount(),
+          syncReader.getPagesCount(),
+          "page count should match the synchronous result",
+        );
+        assert.equal(asyncReader.isEncrypted(), syncReader.isEncrypted());
+      } finally {
+        syncReader.end();
+        asyncReader.end();
+      }
+    });
+
+    it("rejects instead of throwing when the source cannot be read", async function () {
+      await assert.rejects(
+        muhammara.recryptAsync(
+          __dirname + "/TestMaterials/DoesNotExist.pdf",
+          __dirname + "/output/RecryptAsyncMissingSource.pdf",
+        ),
+        /Unable to recrypt files/,
+      );
+    });
+
+    it("rejects when the input password is wrong", async function () {
+      await assert.rejects(
+        muhammara.recryptAsync(
+          __dirname + "/TestMaterials/PDFWithPassword.PDF",
+          __dirname + "/output/RecryptAsyncWrongPassword.pdf",
+          { password: "definitely-not-the-password" },
+        ),
+        /Unable to recrypt files/,
+      );
+    });
+
+    it("throws synchronously on bad arguments, like recrypt does", function () {
+      assert.throws(function () {
+        muhammara.recryptAsync(__dirname + "/TestMaterials/Original.pdf");
+      }, /Wrong number of arguments/);
+
+      assert.throws(function () {
+        muhammara.recryptAsync(
+          __dirname + "/TestMaterials/Original.pdf",
+          new muhammara.PDFWStreamForFile(
+            __dirname + "/output/RecryptAsyncMixed.pdf",
+          ),
+        );
+      }, /please either provide two paths or two stream objects/);
+    });
+
+    it("runs concurrent calls to completion", async function () {
+      var targets = [
+        __dirname + "/output/RecryptAsyncConcurrentA.pdf",
+        __dirname + "/output/RecryptAsyncConcurrentB.pdf",
+        __dirname + "/output/RecryptAsyncConcurrentC.pdf",
+      ];
+
+      await Promise.all(
+        targets.map(function (target) {
+          return muhammara.recryptAsync(
+            __dirname + "/TestMaterials/PDFWithPassword.PDF",
+            target,
+            { password: "user", userPassword: "user" },
+          );
+        }),
+      );
+
+      targets.forEach(function (target) {
+        assertRecryptedPdf(target, "user", true);
+      });
+    });
+
+    it("finishes another job while one native recrypt is blocked on input", async function () {
+      if (
+        process.platform !== "linux" ||
+        Number(process.env.UV_THREADPOOL_SIZE || 4) < 2
+      ) {
+        this.skip();
+      }
+      var path = require("path");
+      var directory = fs.mkdtempSync(
+        path.join(__dirname, "output/recrypt-overlap-"),
+      );
+      var fifo = path.join(directory, "source.fifo");
+      require("child_process").execFileSync("mkfifo", [fifo]);
+      var blocked = assert.rejects(
+        muhammara.recryptAsync(fifo, path.join(directory, "blocked.pdf")),
+        /Unable to recrypt files/,
+      );
+      var fd;
+      var timer;
+      try {
+        // ENXIO means the native reader has not opened the FIFO yet. Keeping
+        // the writer open after this handshake blocks its first read, not JS.
+        var deadline = Date.now() + 5000;
+        while (fd === undefined) {
+          try {
+            fd = fs.openSync(
+              fifo,
+              fs.constants.O_WRONLY | fs.constants.O_NONBLOCK,
+            );
+          } catch (error) {
+            if (error.code !== "ENXIO" || Date.now() > deadline) throw error;
+            await new Promise(function (resolve) {
+              setTimeout(resolve, 5);
+            });
+          }
+        }
+        var target = path.join(directory, "independent.pdf");
+        await Promise.race([
+          muhammara.recryptAsync(
+            __dirname + "/TestMaterials/Original.pdf",
+            target,
+          ),
+          new Promise(function (_, reject) {
+            timer = setTimeout(function () {
+              reject(
+                new Error("A blocked recrypt serialized an independent job"),
+              );
+            }, 5000);
+          }),
+        ]);
+        assertRecryptedPdf(target, undefined, false);
+      } finally {
+        clearTimeout(timer);
+        if (fd === undefined)
+          fd = fs.openSync(fifo, fs.constants.O_RDWR | fs.constants.O_NONBLOCK);
+        fs.closeSync(fd);
+        await blocked;
+        fs.rmSync(directory, { recursive: true, force: true });
+      }
+    });
+
+    it("keeps parallel passwords and main-thread writing independent", async function () {
+      var jobs = Array.from({ length: 16 }, function (_, index) {
+        var target = __dirname + "/output/RecryptParallel-" + index + ".pdf";
+        var password = "parallel-password-" + index;
+        return muhammara
+          .recryptAsync(__dirname + "/TestMaterials/Original.pdf", target, {
+            userPassword: password,
+            ownerPassword: "owner-" + index,
+            version: [
+              muhammara.ePDFVersion14,
+              muhammara.ePDFVersion17,
+              muhammara.ePDFVersion20,
+            ][index % 3],
+            compress: index % 2 === 0,
+            log: __dirname + "/output/RecryptParallel-" + index + ".log",
+          })
+          .then(function () {
+            assertRecryptedPdf(target, password, true);
+          });
+      });
+      var mainOutput = __dirname + "/output/RecryptParallelMain.pdf";
+      var writer = muhammara.createWriter(mainOutput, {
+        log: __dirname + "/output/RecryptParallelMain.log",
+      });
+      writer.writePage(writer.createPage(0, 0, 200, 200));
+      writer.end();
+      await Promise.all(jobs);
+      assertRecryptedPdf(mainOutput, undefined, false);
+    });
+
+    it("routes early errors to each job's log and clears reused thread settings", async function () {
+      var logs = Array.from({ length: 16 }, function (_, index) {
+        return __dirname + "/output/RecryptError-" + index + ".log";
+      });
+      logs.forEach(function (log) {
+        fs.rmSync(log, { force: true });
+      });
+      await Promise.all(
+        logs.map(function (log, index) {
+          return assert.rejects(
+            muhammara.recryptAsync(
+              __dirname + "/output/MissingRecryptJob-" + index + ".pdf",
+              __dirname + "/output/RecryptError-" + index + ".pdf",
+              { log: log },
+            ),
+            /Unable to recrypt files/,
+          );
+        }),
+      );
+      var contents = logs.map(function (log, index) {
+        var text = fs.readFileSync(log, "utf8");
+        assert.ok(text.includes("MissingRecryptJob-" + index + ".pdf"));
+        assert.equal((text.match(/MissingRecryptJob-/g) || []).length, 1);
+        return text;
+      });
+      await Promise.all(
+        logs.map(function (_, index) {
+          return assert.rejects(
+            muhammara.recryptAsync(
+              __dirname + "/output/MissingUnloggedJob-" + index + ".pdf",
+              __dirname + "/output/RecryptUnlogged-" + index + ".pdf",
+            ),
+            /Unable to recrypt files/,
+          );
+        }),
+      );
+      logs.forEach(function (log, index) {
+        assert.equal(fs.readFileSync(log, "utf8"), contents[index]);
+      });
+    });
+
+    it("leaves the event loop free while the synchronous call blocks it", async function () {
+      // A single small fixture recrypts too fast to observe, so build a bigger
+      // one first. Appending the same document repeatedly is enough.
+      var big = __dirname + "/output/RecryptAsyncLargeSource.pdf";
+      var writer = muhammara.createWriter(big);
+      for (var i = 0; i < 12; i++) {
+        writer.appendPDFPagesFromPDF(
+          __dirname + "/TestMaterials/BasicTIFFImagesTest.PDF",
+        );
+      }
+      writer.end();
+
+      async function countTicksDuring(run) {
+        var ticks = 0;
+        var timer = setInterval(function () {
+          ticks += 1;
+        }, 2);
+        try {
+          await run();
+          return ticks;
+        } finally {
+          clearInterval(timer);
+        }
+      }
+
+      var syncTicks = await countTicksDuring(function () {
+        muhammara.recrypt(big, __dirname + "/output/RecryptAsyncLoopSync.pdf", {
+          userPassword: "user",
+        });
+      });
+
+      var asyncTicks = await countTicksDuring(function () {
+        return muhammara.recryptAsync(
+          big,
+          __dirname + "/output/RecryptAsyncLoopAsync.pdf",
+          {
+            userPassword: "user",
+          },
+        );
+      });
+
+      assert.equal(
+        syncTicks,
+        0,
+        "the synchronous recrypt is expected to block the event loop entirely",
+      );
+      assert.ok(
+        asyncTicks > 0,
+        "recryptAsync should let timers run while it works, got " +
+          asyncTicks +
+          " ticks",
+      );
+    });
+  });
+
+  describe("Recipe.endPDFAsync", function () {
+    it("finalizes independent encrypted Recipes concurrently", async function () {
+      await Promise.all(
+        Array.from({ length: 8 }, async function (_, index) {
+          var output = __dirname + "/output/RecipeParallel-" + index + ".pdf";
+          var password = "recipe-" + index;
+          var recipe = new muhammara.Recipe("new", output);
+          recipe.createPage(200, 200).text(password, 20, 20).endPage();
+          recipe.encrypt({ userPassword: password });
+          await recipe.endPDFAsync();
+          assertRecryptedPdf(output, password, true);
+        }),
+      );
+    });
+
+    it("encrypts without blocking and resolves", async function () {
+      var output = __dirname + "/output/RecipeEndPDFAsync.pdf";
+      var recipe = new muhammara.Recipe("new", output);
+      recipe
+        .createPage(595, 842)
+        .text("encrypted asynchronously", 50, 50)
+        .endPage();
+      recipe.encrypt({
+        userPassword: "user",
+        ownerPassword: "owner",
+        userProtectionFlag: 4,
+      });
+
+      var result = await recipe.endPDFAsync();
+      assert.equal(result, undefined);
+      assertRecryptedPdf(output, "user", true);
+    });
+
+    it("ends a document that needs no encryption", async function () {
+      var output = __dirname + "/output/RecipeEndPDFAsyncPlain.pdf";
+      var recipe = new muhammara.Recipe("new", output);
+      recipe.createPage(595, 842).text("no encryption", 50, 50).endPage();
+
+      await recipe.endPDFAsync();
+      assertRecryptedPdf(output, undefined, false);
+    });
+  });
 });

--- a/packages/native-with-source/tests/build-overrides/concurrency.cpp
+++ b/packages/native-with-source/tests/build-overrides/concurrency.cpp
@@ -1,0 +1,202 @@
+#include "IByteWriter.h"
+#include "Log.h"
+#include "PDFDate.h"
+#include "ThreadSafety.h"
+#include "Trace.h"
+#include "aes.h"
+
+#include <atomic>
+#include <cassert>
+#include <cstdarg>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace IOBasicTypes;
+
+class Sink : public IByteWriter {
+ public:
+  std::string bytes;
+  bool recurse = false;
+  bool fail = false;
+  LongBufferSizeType Write(const Byte* data, LongBufferSizeType size) override {
+    if (fail) throw std::runtime_error("log sink failure");
+    if (recurse) Trace::DefaultTrace().TraceToLog("recursive write failure");
+    // Intentionally not synchronized: Log must protect the whole record, not
+    // merely each Write, even when different Log instances share this sink.
+    std::this_thread::yield();
+    bytes.append(reinterpret_cast<const char*>(data), size);
+    return size;
+  }
+};
+
+static void traceList(Trace& trace, const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  trace.TraceToLog(format, args);
+  va_end(args);
+}
+
+static std::set<std::string> records(const std::string& bytes, int count) {
+  std::set<std::string> result;
+  size_t begin = 0;
+  while (begin != bytes.size()) {
+    size_t end = bytes.find("\r\n", begin);
+    assert(end != std::string::npos && end >= begin + 24);
+    assert(bytes.compare(begin, 2, "[ ") == 0);
+    assert(bytes.compare(begin + 21, 3, " ] ") == 0);
+    assert(result.insert(bytes.substr(begin + 24, end - begin - 24)).second);
+    begin = end + 2;
+  }
+  assert(result.size() == static_cast<size_t>(count));
+  return result;
+}
+
+int main(int argc, char** argv) {
+  assert(argc == 2);
+  const int workers = 12;
+  const int iterations = 200;
+  std::atomic<int> ready{0};
+  std::atomic<bool> start{false};
+  std::vector<Trace*> addresses(workers);
+  std::vector<Sink> privateSinks(workers);
+  Sink shared;
+  std::vector<std::thread> threads;
+  Trace* mainTrace = &Trace::DefaultTrace();
+  Sink mainSink;
+  mainTrace->SetLogSettings(&mainSink, true);
+  const std::string filePath = std::string(argv[1]) + "/shared.log";
+
+  for (int id = 0; id != workers; ++id) {
+    threads.emplace_back([&, id] {
+      Trace& trace = Trace::DefaultTrace();
+      addresses[id] = &trace;
+      trace.TraceToLog("default disabled");
+      trace.SetLogSettings(&privateSinks[id], true);
+      ++ready;
+      while (!start.load()) std::this_thread::yield();
+
+      // No AES call occurs before this barrier, including on the main thread.
+      const unsigned char plain[16] = {
+          0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+          0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+      const unsigned char expected[3][16] = {
+          {0x69, 0xc4, 0xe0, 0xd8, 0x6a, 0x7b, 0x04, 0x30,
+           0xd8, 0xcd, 0xb7, 0x80, 0x70, 0xb4, 0xc5, 0x5a},
+          {0xdd, 0xa9, 0x7c, 0xa4, 0x86, 0x4c, 0xdf, 0xe0,
+           0x6e, 0xaf, 0x70, 0xa0, 0xec, 0x0d, 0x71, 0x91},
+          {0x8e, 0xa2, 0xb7, 0xca, 0x51, 0x67, 0x45, 0xbf,
+           0xea, 0xfc, 0x49, 0x90, 0x4b, 0x49, 0x60, 0x89}};
+      unsigned char key[32];
+      for (unsigned char i = 0; i != 32; ++i) key[i] = i;
+      for (int n = 0; n != iterations; ++n) {
+        for (int width = 0; width != 3; ++width) {
+          alignas(16) aes_encrypt_ctx enc;
+          alignas(16) aes_decrypt_ctx dec;
+          unsigned char cipher[16], restored[16];
+          assert(aes_encrypt_key(key, 16 + width * 8, &enc) == 0);
+          assert(aes_decrypt_key(key, 16 + width * 8, &dec) == 0);
+          assert(aes_encrypt(plain, cipher, &enc) == 0);
+          assert(std::memcmp(cipher, expected[width], 16) == 0);
+          assert(aes_decrypt(cipher, restored, &dec) == 0);
+          assert(std::memcmp(restored, plain, 16) == 0);
+        }
+        PDFDate date;
+        date.SetToCurrentTime();
+        assert(date.Year >= 2026 && date.Month >= 1 && date.Month <= 12);
+        assert(date.Day >= 1 && date.Day <= 31 && date.Second >= 0 && date.Second <= 60);
+        assert(date.ToString().compare(0, 2, "D:") == 0);
+        // Distinct epochs expose accidentally shared localtime/gmtime storage.
+        for (int j = 0; j != 10; ++j) {
+          time_t epoch = 946684800 + id * 86400;
+          tm local{}, utc{};
+          assert(MuhammaraBuild::LocalTime(epoch, local));
+          assert(MuhammaraBuild::GmTime(epoch, utc));
+          std::this_thread::yield();
+          assert(utc.tm_year == 100 && utc.tm_mon == 0 && utc.tm_mday == id + 1);
+          tm again{};
+          assert(MuhammaraBuild::LocalTime(epoch, again));
+          assert(local.tm_year == again.tm_year && local.tm_mday == again.tm_mday);
+        }
+        trace.TraceToLog("private-%d-%d", id, n);
+        Log log(&shared);
+        log.LogEntry("shared-" + std::to_string(id) + "-" + std::to_string(n));
+      }
+      const std::string longMessage(MAX_TRACE_SIZE + 100, 'A' + id);
+      trace.TraceToLog("%s", longMessage.c_str());
+      traceList(trace, "%s", (std::string("list-") + longMessage).c_str());
+      trace.SetLogSettings(static_cast<IByteWriter*>(nullptr), false);
+      trace.TraceToLog("disabled after reset");
+
+      // Race lazy file creation/BOM and writes larger than OutputBufferedStream.
+      Log fileLog(filePath, true);
+      for (int n = 0; n != 20; ++n) {
+        fileLog.LogEntry(std::to_string(id) + ":" + std::to_string(n) + ":" +
+                         std::string(8192, 'A' + id));
+      }
+    });
+  }
+  while (ready.load() != workers) std::this_thread::yield();
+  start = true;
+  mainTrace->TraceToLog("main-only");
+  for (auto& thread : threads) thread.join();
+  assert(std::set<Trace*>(addresses.begin(), addresses.end()).size() == workers);
+  for (auto address : addresses) assert(address != mainTrace);
+  assert(records(mainSink.bytes, 1).count("main-only") == 1);
+  auto sharedRecords = records(shared.bytes, workers * iterations);
+  for (int id = 0; id != workers; ++id) {
+    auto own = records(privateSinks[id].bytes, iterations + 2);
+    for (int n = 0; n != iterations; ++n) {
+      assert(own.count("private-" + std::to_string(id) + "-" + std::to_string(n)) == 1);
+      assert(sharedRecords.count("shared-" + std::to_string(id) + "-" + std::to_string(n)) == 1);
+    }
+    assert(own.count(std::string(MAX_TRACE_SIZE - 1, 'A' + id)) == 1);
+    assert(own.count("list-" + std::string(MAX_TRACE_SIZE - 6, 'A' + id)) == 1);
+  }
+  std::ifstream input(filePath, std::ios::binary);
+  std::string bytes{std::istreambuf_iterator<char>(input), {}};
+  assert(bytes.compare(0, 3, "\xef\xbb\xbf") == 0);
+  auto fileRecords = records(bytes.substr(3), workers * 20);
+  for (int id = 0; id != workers; ++id) {
+    for (int n = 0; n != 20; ++n) {
+      assert(fileRecords.count(std::to_string(id) + ":" + std::to_string(n) + ":" +
+                               std::string(8192, 'A' + id)) == 1);
+    }
+  }
+
+  Sink recursive;
+  recursive.recurse = true;
+  mainTrace->SetLogSettings(&recursive, true);
+  mainTrace->TraceToLog("outer-only");
+  assert(records(recursive.bytes, 1).count("outer-only") == 1);
+  Sink throwing;
+  throwing.fail = true;
+  mainTrace->SetLogSettings(&throwing, true);
+  bool caught = false;
+  try {
+    mainTrace->TraceToLog("throws under the sink lock");
+  } catch (const std::runtime_error&) {
+    caught = true;
+  }
+  assert(caught && MuhammaraBuild::LogDepth() == 0);
+  std::thread afterFailure([&] {
+    Log log(&shared);
+    log.LogEntry("lock released after exception");
+  });
+  afterFailure.join();
+  assert(shared.bytes.find("lock released after exception") != std::string::npos);
+  mainTrace->SetLogSettings(std::string(argv[1]) + "/missing/log", true, true);
+  mainTrace->TraceToLog("unwritable construction");
+  // Existing path, then removal: failure in OpenFile must not recurse or write
+  // through a null stream. Point to a directory for a portable open failure.
+  mainTrace->SetLogSettings(std::string(argv[1]), true, false);
+  mainTrace->TraceToLog("unwritable append");
+  mainTrace->SetLogSettings(static_cast<IByteWriter*>(nullptr), false);
+  std::cout << "Trace routing/buffers, whole log records, dates, cold AES: passed\n";
+}

--- a/packages/native-with-source/tests/build-overrides/generation.py
+++ b/packages/native-with-source/tests/build-overrides/generation.py
@@ -1,0 +1,274 @@
+"""Generate native build graphs without a compiler or downloaded Node headers."""
+
+import ast
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+
+
+def main():
+    if len(sys.argv) == 2:
+        node_gyp = Path(sys.argv[1]).resolve()
+    elif len(sys.argv) == 1 and os.environ.get("npm_config_node_gyp"):
+        node_gyp = Path(os.environ["npm_config_node_gyp"]).resolve().parents[1]
+    else:
+        raise SystemExit("Usage: python3 generation.py PATH_TO_NODE_GYP")
+    root = Path(__file__).resolve().parents[2]
+    ns = {"ms": "http://schemas.microsoft.com/developer/msbuild/2003"}
+    vendor_files = {
+        path: path.stat().st_mtime_ns
+        for path in (root / "src/deps").rglob("*")
+        if path.is_file()
+    }
+    targets = {}
+    for wrapper, vendor in [("pdfwriter", "PDFWriter"), ("aes", "LibAesgm")]:
+        original = ast.literal_eval(
+            (root / "src/deps" / vendor / "binding.gyp").read_text(encoding="utf-8")
+        )
+        assert list(original) == ["targets"] and len(original["targets"]) == 1
+        target = original["targets"][0]
+        targets[vendor] = target
+        metadata = {key: value for key, value in target.items() if key != "sources"}
+        if vendor == "PDFWriter":
+            metadata["dependencies"] = [
+                item
+                for item in metadata["dependencies"]
+                if item != "<(module_root_dir)/src/deps/LibAesgm/binding.gyp:libaesgm"
+            ]
+        actual = ast.literal_eval(
+            (root / "src/build-overrides" / (wrapper + ".gyp")).read_text()
+        )["targets"][0]
+        # Fail on vendor settings drift rather than silently losing new options.
+        assert {
+            key: value for key, value in actual.items() if key != "sources"
+        } == metadata
+
+    with tempfile.TemporaryDirectory(prefix="muhammara gyp ") as temporary:
+        output = Path(temporary)
+        python = Path(sys.executable)
+        if os.name != "nt":
+            # Exercise the quoted interpreter path common on Windows installations.
+            (output / "python path").symlink_to(python.parent, target_is_directory=True)
+            python = output / "python path" / python.name
+        config = output / "config.gypi"
+        for generator, platform, arch in [
+            ("msvs", "win", "x64"),
+            ("msvs", "win", "ia32"),
+            ("make", "linux", "x64"),
+        ]:
+            build = output / (generator + "-" + arch)
+            config.write_text(
+                repr(
+                    {
+                        "target_defaults": {
+                            "product_prefix": "",
+                            "defines": ["_HAS_EXCEPTIONS=0"],
+                            "default_configuration": "Release",
+                            "configurations": {
+                                name: {
+                                    "msvs_configuration_platform": (
+                                        "Win32" if arch == "ia32" else "x64"
+                                    ),
+                                    "msvs_windows_target_platform_version": "10.0.22621.0",
+                                }
+                                for name in ["Debug", "Release"]
+                            },
+                        },
+                    }
+                )
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(node_gyp / "gyp/gyp_main.py"),
+                    "binding.gyp",
+                    "-I",
+                    str(config),
+                    "-f",
+                    generator,
+                    "--depth=.",
+                    "--no-parallel",
+                    "--generator-output",
+                    str(build),
+                    "-Goutput_dir=.",
+                    "-Gmsvs_version=2022",
+                    "-DOS=" + platform,
+                    "-Dtarget_arch=" + arch,
+                    # Relative dependency filenames keep all generated projects
+                    # under generator-output, including on a non-Windows host.
+                    "-Dmodule_root_dir=<(DEPTH)",
+                    "-Dmodule_name=muhammara",
+                    "-Dmodule_path=" + str(output / "binding"),
+                    "-Dpython=" + str(python),
+                ],
+                cwd=root,
+                env={
+                    **os.environ,
+                    "GYP_MSVS_VERSION": "2022",
+                    "GYP_MSVS_OVERRIDE_PATH": str(output / "virtual-vs"),
+                    # GYP's MSVS XML writer needs a non-UTF-8 locale on POSIX.
+                    "LC_ALL": "en_US.ISO8859-1",
+                    "PYTHONCOERCECLOCALE": "0",
+                    "PYTHONUTF8": "0",
+                    "GYP_DEFINES": "",
+                    "GYP_GENERATOR_FLAGS": "",
+                    "GYP_GENERATORS": generator,
+                },
+                capture_output=True,
+                text=True,
+                timeout=90,
+            )
+            assert result.returncode == 0, result.stdout + result.stderr
+            if generator == "msvs":
+                solution = (build / "binding.sln").read_text()
+                for project in [
+                    "muhammara",
+                    "pdfwriter",
+                    "libaesgm",
+                    "native_build_overrides",
+                    "freetype",
+                    "libjpeg",
+                    "zlib",
+                    "libtiff",
+                    "libpng",
+                    "openssl",
+                ]:
+                    assert project + ".vcxproj" in solution, project
+                assert not (build / "src/deps/PDFWriter/binding.sln").exists()
+                assert not (build / "src/deps/LibAesgm").exists()
+                for wrapper, vendor, replacements in [
+                    ("pdfwriter", "PDFWriter", ["Trace.cpp", "Log.cpp", "PDFDate.cpp"]),
+                    (
+                        "libaesgm",
+                        "LibAesgm",
+                        [
+                            "aescrypt.c",
+                            "aeskey.c",
+                            "aes_ni.c",
+                            "aes_modes.c",
+                            "aestab.c",
+                        ],
+                    ),
+                ]:
+                    project = build / ("src/build-overrides/" + wrapper + ".vcxproj")
+                    tree = ET.parse(project)
+                    for item in tree.findall(".//ms:ClCompile[@Include]", ns):
+                        exclusions = item.findall("ms:ExcludedFromBuild", ns)
+                        if exclusions:
+                            # The original must be excluded in every configuration.
+                            assert len(exclusions) == 1
+                            assert exclusions[0].text == "true"
+                            assert "Condition" not in exclusions[0].attrib
+                    sources = [
+                        item.attrib["Include"].replace("\\", "/")
+                        for item in tree.findall(".//ms:ClCompile[@Include]", ns)
+                        if item.find("ms:ExcludedFromBuild", ns) is None
+                    ]
+                    target = targets[vendor]
+                    expected = [
+                        name
+                        for name in target["sources"]
+                        if name.endswith((".c", ".cpp"))
+                    ]
+                    assert sorted(Path(name).name for name in sources) == sorted(
+                        expected
+                    ), sources
+                    for name in replacements:
+                        source = next(
+                            source for source in sources if source.endswith("/" + name)
+                        )
+                        assert "/native-build-overrides/" in source, source
+                    for source in sources:
+                        if "/native-build-overrides/" not in source:
+                            assert (project.parent / source).is_file(), source
+                    for compile in tree.findall(
+                        ".//ms:ItemDefinitionGroup/ms:ClCompile", ns
+                    ):
+                        includes = {
+                            (project.parent / directory).resolve()
+                            for directory in compile.find(
+                                "ms:AdditionalIncludeDirectories", ns
+                            )
+                            .text.replace("\\", "/")
+                            .split(";")
+                        }
+                        assert root / "src/build-overrides" in includes
+                        if wrapper == "pdfwriter":
+                            assert root / "src/deps/PDFWriter" in includes
+                            assert (
+                                compile.find("ms:ExceptionHandling", ns).text == "Sync"
+                            )
+                            assert (
+                                "_HAS_EXCEPTIONS=0"
+                                not in compile.find(
+                                    "ms:PreprocessorDefinitions", ns
+                                ).text
+                            )
+                    references = tree.findall(".//ms:ProjectReference", ns)
+                    assert any(
+                        "native_build_overrides.vcxproj" in item.attrib["Include"]
+                        for item in references
+                    )
+                # Follow actual link dependencies, not merely projects present in a solution.
+                visited = set()
+
+                def visit(project):
+                    project = project.resolve()
+                    project.relative_to(build)  # No projects beside vendor sources.
+                    if project in visited:
+                        return
+                    visited.add(project)
+                    assert "src/deps/LibAesgm" not in project.as_posix(), project
+                    for reference in ET.parse(project).findall(
+                        ".//ms:ProjectReference", ns
+                    ):
+                        visit(
+                            project.parent
+                            / reference.attrib["Include"].replace("\\", "/")
+                        )
+
+                visit(build / "muhammara.vcxproj")
+                assert (
+                    build / "src/build-overrides/libaesgm.vcxproj"
+                ).resolve() in visited
+                aes = ET.parse(build / "src/build-overrides/libaesgm.vcxproj")
+                assert aes.find(".//ms:TargetName", ns).text == "muhammara_aesgm"
+                assert aes.find(".//ms:ConfigurationType", ns).text == "StaticLibrary"
+            else:
+                rule = next(
+                    line
+                    for line in (build / "muhammara.target.mk").read_text().splitlines()
+                    if line.startswith("$(obj).target/muhammara.node: $(OBJS)")
+                )
+                assert "src/build-overrides/muhammara_aesgm.a" in rule, rule
+                assert "src/deps/LibAesgm" not in rule, rule
+                for target, names in [
+                    ("pdfwriter", ["Trace", "Log", "PDFDate"]),
+                    (
+                        "libaesgm",
+                        ["aescrypt", "aeskey", "aes_ni", "aes_modes", "aestab"],
+                    ),
+                ]:
+                    rule = (
+                        build / "src/build-overrides" / (target + ".target.mk")
+                    ).read_text()
+                    for name in names:
+                        assert "gen/native-build-overrides/" + name + ".o" in rule
+                        assert "/PDFWriter/" + name + ".o" not in rule
+                        assert "/LibAesgm/" + name + ".o" not in rule
+            print(
+                generator + " " + arch + " generation and graph checks passed",
+                flush=True,
+            )
+    assert {
+        path: path.stat().st_mtime_ns
+        for path in (root / "src/deps").rglob("*")
+        if path.is_file()
+    } == vendor_files, "Build generation must not write into src/deps"
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/native-with-source/tests/build-overrides/run.cjs
+++ b/packages/native-with-source/tests/build-overrides/run.cjs
@@ -1,0 +1,126 @@
+var assert = require("node:assert/strict");
+var fs = require("node:fs");
+var os = require("node:os");
+var path = require("node:path");
+var { spawnSync } = require("node:child_process");
+var { generate, aesFiles } = require("../../src/build-overrides/generate.cjs");
+
+function main() {
+  var root = path.resolve(__dirname, "../..");
+  var temp = fs.mkdtempSync(path.join(os.tmpdir(), "muhammara-concurrency-"));
+  var overrides = path.join(root, "src/build-overrides");
+  var pdf = path.join(root, "src/deps/PDFWriter");
+  var generated = path.join(temp, "generated");
+  var useGyp = process.argv.includes("--gyp");
+  var flags = ["-O1", "-g", "-pthread"];
+  if (process.argv.includes("--tsan")) flags.push("-fsanitize=thread");
+  if (process.argv.includes("--aes-ni")) flags.push("-DINTEL_AES_POSSIBLE");
+  if (process.argv.includes("--ia32")) flags.push("-m32");
+  function run(command, args, options = {}) {
+    var result = spawnSync(command, args, {
+      stdio: "inherit",
+      timeout: 90000,
+      ...options,
+    });
+    if (result.error) throw result.error;
+    assert.equal(
+      result.status,
+      0,
+      `${command} failed (${result.signal || result.status})`,
+    );
+  }
+
+  try {
+    generate(generated);
+    var linked = path.join(temp, "linked-deps");
+    fs.symlinkSync(path.join(root, "src/deps"), linked, "dir");
+    assert.throws(() => generate(linked), /outside src\/deps/);
+    assert.throws(
+      () => generate(path.join(root, "src/deps/forbidden")),
+      /outside src\/deps/,
+    );
+    // A changed patch anchor must fail before producing any partial build copies.
+    var changed = path.join(temp, "changed-deps");
+    fs.mkdirSync(path.join(changed, "PDFWriter"), { recursive: true });
+    fs.writeFileSync(
+      path.join(changed, "PDFWriter/Trace.cpp"),
+      "changed vendor source",
+    );
+    assert.throws(
+      () => generate(path.join(temp, "rejected"), changed),
+      /override mismatch/,
+    );
+    assert.equal(fs.existsSync(path.join(temp, "rejected")), false);
+
+    var objects = [];
+    for (var name of useGyp
+      ? []
+      : aesFiles.filter((name) => name.endsWith(".c"))) {
+      var object = path.join(temp, name + ".o");
+      run(process.env.CC || "cc", [
+        ...flags,
+        "-I" + overrides,
+        "-c",
+        path.join(generated, name),
+        "-o",
+        object,
+      ]);
+      objects.push(object);
+    }
+    var sources = [
+      ...["Trace.cpp", "Log.cpp", "PDFDate.cpp"].map((name) =>
+        path.join(generated, name),
+      ),
+      ...[
+        "OutputFile.cpp",
+        "OutputFileStream.cpp",
+        "OutputBufferedStream.cpp",
+      ].map((name) => path.join(pdf, name)),
+      ...objects,
+    ];
+    if (useGyp) {
+      var build = path.join(root, "build");
+      var linkRule = fs
+        .readFileSync(path.join(build, "muhammara.target.mk"), "utf8")
+        .split("\n")
+        .find((line) =>
+          line.startsWith("$(obj).target/muhammara.node: $(OBJS)"),
+        );
+      assert.ok(linkRule.includes("src/build-overrides/muhammara_aesgm.a"));
+      assert.ok(!linkRule.includes("src/deps/LibAesgm"));
+      var pdfRule = fs.readFileSync(
+        path.join(build, "src/build-overrides/pdfwriter.target.mk"),
+        "utf8",
+      );
+      for (var name of ["Trace", "Log", "PDFDate"]) {
+        assert.ok(pdfRule.includes(`gen/native-build-overrides/${name}.o`));
+        assert.ok(!pdfRule.includes(`src/deps/PDFWriter/${name}.o`));
+      }
+      sources = ["pdfwriter.a", "muhammara_aesgm.a"].map((name) =>
+        path.join(build, "Release/obj.target/src/build-overrides", name),
+      );
+    }
+    var binary = path.join(temp, "concurrency");
+    run(process.env.CXX || "c++", [
+      ...flags,
+      "-std=c++17",
+      "-I" + overrides,
+      "-I" + generated,
+      "-I" + pdf,
+      path.join(__dirname, "concurrency.cpp"),
+      ...sources,
+      "-o",
+      binary,
+    ]);
+    for (var zone of ["UTC", "America/New_York"]) {
+      var output = path.join(temp, zone.replaceAll("/", "-"));
+      fs.mkdirSync(output);
+      run(binary, [output], { env: { ...process.env, TZ: zone } });
+    }
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+// Mocha also discovers .cjs files recursively; compiling this harness is opt-in.
+if (require.main === module) main();

--- a/packages/native-with-source/tests/types/types.test.ts
+++ b/packages/native-with-source/tests/types/types.test.ts
@@ -4,3 +4,8 @@ declare const writer: muhammara.PDFWriter;
 
 var page: muhammara.PDFPage = writer.createPage(0, 0, 595, 842);
 writer.startPageContentContext(page).c(0, 0, 1, 1, 2, 2).S();
+
+var recrypted: Promise<void> = muhammara.recryptAsync("in.pdf", "out.pdf", {
+  userPassword: "user",
+});
+void recrypted;

--- a/packages/native/docs/breaking-changes.md
+++ b/packages/native/docs/breaking-changes.md
@@ -5,6 +5,11 @@ For release-by-release changes, see the [Changelog](https://github.com/julianhil
 
 ## Version 7.x
 
+- Native logging is thread-local rather than process-wide. Configuring a writer
+  on one thread no longer redirects logs from another thread. Pass `log` to
+  each writer or `recryptAsync()` call; async jobs clear their settings after
+  completion. See [concurrent recrypt](how-to/change-pdf-passwords.md#concurrency-and-limitations)
+  [#98](https://github.com/julianhille/MuhammaraJS/issues/98).
 - `PDFReader` methods that take a page index or object ID — `parseNewObject()`,
   `getPageObjectID()`, `parsePageDictionary()`, `parsePage()`,
   `extractPageText()`, `extractPageContentItems()`, and `getXrefEntry()` —

--- a/packages/native/docs/examples/recrypt-without-blocking.js
+++ b/packages/native/docs/examples/recrypt-without-blocking.js
@@ -1,0 +1,43 @@
+var muhammara = require("@muhammara/native");
+
+// Re-encrypts a document without blocking the event loop. The returned promise
+// resolves once the new file has been written.
+async function recryptWithoutBlocking(inputPath, outputPath, options) {
+  await muhammara.recryptAsync(inputPath, outputPath, options);
+  return outputPath;
+}
+
+// The same, for callers that already hold the document in memory.
+async function recryptBufferWithoutBlocking(sourceBuffer, outputPath, options) {
+  var target = new muhammara.PDFWStreamForFile(outputPath);
+
+  await muhammara.recryptAsync(
+    new muhammara.PDFRStreamForBuffer(sourceBuffer),
+    target,
+    options,
+  );
+  await new Promise(function (resolve) {
+    target.close(resolve);
+  });
+
+  return outputPath;
+}
+
+// Recipe's asynchronous ending, which uses recryptAsync for the encryption step.
+async function encryptRecipeWithoutBlocking(outputPath, encryption) {
+  var recipe = new muhammara.Recipe("new", outputPath);
+  recipe
+    .createPage(595, 842)
+    .text("encrypted asynchronously", 50, 50)
+    .endPage();
+  recipe.encrypt(encryption);
+
+  await recipe.endPDFAsync();
+  return outputPath;
+}
+
+module.exports = {
+  recryptWithoutBlocking,
+  recryptBufferWithoutBlocking,
+  encryptRecipeWithoutBlocking,
+};

--- a/packages/native/docs/how-to/change-pdf-passwords.md
+++ b/packages/native/docs/how-to/change-pdf-passwords.md
@@ -16,6 +16,80 @@ muhammara.recrypt("input.pdf", "output.pdf", {
 To remove encryption, provide the input `password` without new output password
 options. File and stream scenarios are exercised in [`tests/Xcryption.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/Xcryption.js).
 
+## Without Blocking the Event Loop
+
+`recrypt` does all of its work on the main thread, so a server serves no other
+request while a document is re-encrypted. `recryptAsync` takes the same
+arguments and the same options, runs the re-encryption on a background thread,
+and returns a promise.
+
+```javascript
+await muhammara.recryptAsync("input.pdf", "output.pdf", {
+  password: "current-password",
+  userPassword: "new-open-password",
+});
+```
+
+Stream objects work the same way as with `recrypt`:
+
+```javascript
+var target = new muhammara.PDFWStreamForFile("output.pdf");
+
+await muhammara.recryptAsync(
+  new muhammara.PDFRStreamForBuffer(sourceBuffer),
+  target,
+  { userPassword: "new-open-password" },
+);
+
+await new Promise((resolve) => target.close(resolve));
+```
+
+Argument errors — a missing second argument, or mixing a path with a stream —
+still throw synchronously, exactly as `recrypt` does. Everything that happens
+once the work has started, including a wrong input password or an unreadable
+source, comes back as a rejection with the same message `recrypt` throws.
+
+Recipe has a matching `endPDFAsync()`:
+
+```javascript
+var recipe = new muhammara.Recipe("new", "output.pdf");
+recipe.createPage(595, 842).text("hello", 50, 50).endPage();
+recipe.encrypt({ userPassword: "user" });
+
+await recipe.endPDFAsync();
+```
+
+### Concurrency and Limitations
+
+!!! warning "What `recryptAsync` does and does not promise"
+
+    - **Independent calls can run in parallel.** `Promise.all()` submits jobs to
+      Node's shared libuv thread pool; PDF processing no longer takes a global
+      recrypt lock. Available pool threads bound execution, not queue size.
+      Limit outstanding jobs in a server to control memory and I/O pressure.
+    - **Keep job resources independent.** Use distinct output paths and stream
+      instances, and do not overwrite inputs another job is reading. Normal
+      synchronous writers can run on the main thread while recrypt jobs execute;
+      this does not make individual writer/reader objects safe to share across
+      threads. Main-thread work still blocks the event loop while it runs.
+    - **Logging is thread-local.** Pass `log` for each recrypt job rather than
+      relying on another writer's configuration. It covers early input failures
+      and is cleared before a pool thread is reused. Shared log files serialize
+      complete log records only, not PDF processing.
+    - **Stream input is held in memory.** The source is read into a buffer
+      before the work starts and the result is buffered until it finishes, so
+      peak memory is roughly input plus output. Use the path form for very
+      large documents.
+    - **`endPDFAsync()` only moves the encryption step off-thread.** Writing the
+      document and inserting pages remain synchronous, and encryption in buffer
+      mode is still unsupported, exactly as with `endPDF()`.
+
+Native builds apply checked concurrency overrides to generated build copies of
+PDFWriter and AES sources. Vendored files in `src/deps` remain unchanged. These
+overrides isolate tracing and AES capability caches and use reentrant date/time
+conversion. The Wasm build does not use the native libuv pool and does not support
+encryption/recrypt, so these native-only overrides do not apply there.
+
 The tested workflows cover the library's current password and PDF-version
 options. The encryption algorithm is selected automatically from the PDF
 `version`; there is no separate algorithm option.

--- a/packages/native/tests/types/types.test.ts
+++ b/packages/native/tests/types/types.test.ts
@@ -52,6 +52,27 @@ var callbackResult: string = recipe.endPDF(function () {
   return "result";
 });
 
+var endedAsync: Promise<Buffer | string | undefined> = recipe.endPDFAsync();
+
+var recryptedPaths: Promise<void> = muhammara.recryptAsync(
+  "in.pdf",
+  "out.pdf",
+  {
+    password: "user",
+    userPassword: "user",
+    ownerPassword: "owner",
+    userProtectionFlag: 4,
+  },
+);
+var recryptedStreams: Promise<void> = muhammara.recryptAsync(
+  new muhammara.PDFRStreamForBuffer(Buffer.from([])),
+  new muhammara.PDFWStreamForFile("out.pdf"),
+  { version: muhammara.ePDFVersion16 },
+);
+
+void endedAsync;
+void recryptedPaths;
+void recryptedStreams;
 void callbackResult;
 void margins;
 void title;

--- a/packages/wasm/DIFFERENCES.md
+++ b/packages/wasm/DIFFERENCES.md
@@ -16,6 +16,13 @@ they never load Node modules, filesystem paths, or Recipe plugins.
 | Existing PDFs           | Construct with `new Recipe(bytes, options)` to edit in place; `read(bytes)` and `readAsync(blob)` inspect metadata only and do not replace Recipe output state. `editPage(pageNumber)` uses the byte-backed modifier; links, registered images, and text-box clipping use that active modifier context. Polygon-derived shapes are supported while editing. `createPage()` and registered-PDF `appendPage()` continue through that modifier after source construction. Page geometry, including 90/270-degree rotation and non-zero MediaBox origins, uses Recipe coordinates for all high-level drawing and annotations. `pauseContext()`/`resumeContext()` split an edit into appended content contexts. Paths, streams, and password-protected input are unavailable. |
 | Metadata and encryption | New and modified PDFs receive canonical Recipe dates and Producer/Creator fields; source modifications retain prior ModDate/Creator/Producer as `source-*` Info entries. `getPageInfo()` follows Node Recipe and returns document Info metadata. Use `pageInfo(pageNumber)` or `getCurrentPageInfo()` for page geometry. `info()` exposes Recipe-written metadata and `structure("json")` provides a browser-safe summary. Encryption/recrypt explicitly throw because OpenSSL is not part of the Wasm build.                                                                                                                                                                                                                                                            |
 
+Native `recryptAsync()` and the encryption stage of native `Recipe.endPDFAsync()`
+run in libuv's thread pool with native-only concurrency build overrides. Wasm
+does not expose these APIs because encryption/recrypt is unsupported; existing
+encryption/recrypt entry points throw explicitly. Each Wasm runtime has its own
+module state, and these native thread-local logging changes do not alter Wasm
+logging. No browser example applies to native re-encryption.
+
 The current PDFWriter `AppendPDFPagesFromPDF` byte path does not deep-copy an
 existing page's `/Annots` graph. Recipe-created annotations are preserved in
 their own output, but appended or rebuilt source pages lose existing


### PR DESCRIPTION
Add parallel `recryptAsync()` and `Recipe.endPDFAsync()` without editing vendored sources.

Includes concurrency tests, types, tested examples, how-to docs, changelog, and logging migration notes. Native-only; Wasm divergence is documented, so no browser example applies.

Verified: 221 native tests, concurrency harness, type checks, strict docs builds, and formatting. Windows/macOS and TSan remain unverified.

Closes #98