### PR TITLE
Raise mkdocs-material and serialize-javascript to patched versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Release the file handles `Recipe#appendPage()` opens when the appended PDF
   cannot be read or a page cannot be copied, instead of leaking them for the
   life of the process [#381](https://github.com/julianhille/MuhammaraJS/issues/381)
+- Update `mkdocs-material` to 9.7.7 for the DOM XSS security vulnerability fix
+  in search suggestions, bringing the native documentation build back in line
+  with the Wasm one [#600](https://github.com/julianhille/MuhammaraJS/issues/600)
+- Override `serialize-javascript` to 7.1.1 for the remote code execution and
+  CPU exhaustion security vulnerability fixes, since Mocha still resolves the
+  6.x line [#600](https://github.com/julianhille/MuhammaraJS/issues/600)
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2140,16 +2140,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -2231,27 +2221,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -2265,13 +2234,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.1.tgz",
+      "integrity": "sha512-k3CMsaIvvdSwm8oLB4MXSl0wH2/cwlH7xGcnRd2DaeRmBkbzYmyT8j0tsX60DwD1eRwHTpNpH8ljKu9oUT1MeQ==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "docs:check": "npm run docs:generate && mkdocs build --strict --config-file packages/native/mkdocs.yml",
     "docs:serve": "npm run docs:generate && mkdocs serve --config-file packages/native/mkdocs.yml",
     "test:docs": "npm run test:docs --workspace=@muhammara/native-with-source"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
   }
 }

--- a/packages/native/docs/requirements.txt
+++ b/packages/native/docs/requirements.txt
@@ -1,2 +1,2 @@
 mkdocs==1.6.1
-mkdocs-material==9.6.18
+mkdocs-material==9.7.7


### PR DESCRIPTION
## Summary

- raise `mkdocs-material` 9.6.18 → 9.7.7, fixing
  [GHSA-xvg9-69gf-fjrf](https://github.com/advisories/GHSA-xvg9-69gf-fjrf)
  (moderate, DOM XSS in search suggestions). This also re-syncs the native doc
  toolchain with the Wasm one, which was already on 9.7.7
- add a `serialize-javascript` override of 7.1.1, fixing
  [GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq)
  (high, RCE) and
  [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v)
  (moderate, DoS). Mocha declares `^6.0.2`, so the caret cannot reach a patched
  version without the override — same pattern as the existing `tar` entry

Both are dev/documentation dependencies; neither ships in a published
`@muhammara/*` package. The 7.x line requires Node 20+, which every workspace
already does, and drops `randombytes`, so it and `safe-buffer` leave the
lockfile.

The `serialize-javascript` half ships to the v6 line separately in #602.

## Verification

- `npm run docs:check` — strict native build is clean on 9.7.7
- `npm audit` — the two `serialize-javascript` advisories are gone
- `npm install --package-lock-only` leaves the lockfile unchanged
- `npm run test:codestyle`
- mocha 11.8.0 passes serially and under `--parallel` with
  serialize-javascript 7.1.1. Parallel mode is the only path that loads it, and
  no test script here uses it

Closes #600
