### PR TITLE
Release 6.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.0.7] - 2026-09-08
+
+### Fixed
+
+- Add a serialize-javascript override of 7.1.1 for security vulnerability fixes.
+
 ## [6.0.6] - 2026-08-22
 
 ### Fixed
@@ -561,7 +567,8 @@ with the following changes.
 
 - Initial release
 
-[unreleased]: https://github.com/julianhille/MuhammaraJS/compare/6.0.6...HEAD
+[unreleased]: https://github.com/julianhille/MuhammaraJS/compare/6.0.7...HEAD
+[6.0.7]: https://github.com/julianhille/MuhammaraJS/compare/6.0.6...6.0.7
 [6.0.6]: https://github.com/julianhille/MuhammaraJS/compare/6.0.5...6.0.6
 [6.0.5]: https://github.com/julianhille/MuhammaraJS/compare/6.0.4...6.0.5
 [6.0.4]: https://github.com/julianhille/MuhammaraJS/compare/6.0.3...6.0.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muhammara",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muhammara",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "bundleDependencies": [
         "@mapbox/node-pre-gyp"
       ],
@@ -1389,16 +1389,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -1444,27 +1434,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -1479,13 +1448,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.1.tgz",
+      "integrity": "sha512-k3CMsaIvvdSwm8oLB4MXSl0wH2/cwlH7xGcnRd2DaeRmBkbzYmyT8j0tsX60DwD1eRwHTpNpH8ljKu9oUT1MeQ==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muhammara",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "description": "Create, read and modify PDF files and streams. A drop in replacement for hummusjs PDF library",
   "homepage": "https://github.com/julianhille/Muhammarajs",
   "license": "Apache-2.0",
@@ -52,7 +52,8 @@
     "jsdoc": "^4.0.3"
   },
   "overrides": {
-    "tar": "7.5.22"
+    "tar": "7.5.22",
+    "serialize-javascript": "^7.0.5"
   },
   "binary": {
     "module_name": "muhammara",


### PR DESCRIPTION
## Summary

- add a `serialize-javascript` override of 7.1.1, fixing
  [GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq)
  (high, RCE) and
  [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v)
  (moderate, DoS). Mocha declares `^6.0.2`, so the caret cannot reach a patched
  version without the override — same pattern as the existing `tar` entry
- bump the version to 6.0.7 and add the 6.0.7 release information

`mkdocs-material` is the other half of #600 but does not apply here: the v6 tree
predates the mkdocs documentation setup and carries no `requirements.txt`.

## Verification

- `npm audit` — the two `serialize-javascript` advisories are gone
- `npm install --package-lock-only` leaves the lockfile unchanged
- `npm run test:codestyle`
- mocha 10.7.3, the version this branch locks, passes serially and under
  `--parallel` with serialize-javascript 7.1.1. Parallel mode is the only path
  that loads it, and no test script here uses it

Not run locally: `npm test`, which needs a native build — left to CI.

Closes #600
