### PR TITLE
Support native Recipe annotation opacity and comment replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Support native Recipe `annot()` opacity and `comment()` replies, including
+  TypeScript options, matching Wasm annotation dictionaries
+  [#606](https://github.com/julianhille/MuhammaraJS/issues/606)
 - Document watermarking a PDF in place and watermarking a `Buffer`, including
   the overwrite, incremental-update, and buffer-mode caveats
   [#297](https://github.com/julianhille/MuhammaraJS/issues/297)

--- a/packages/native-core/lib/recipe/annotation.js
+++ b/packages/native-core/lib/recipe/annotation.js
@@ -11,6 +11,7 @@
  * @param {string} [options.date] - The date.
  * @param {boolean} [options.open=false] - Open the annotation by default?
  * @param {boolean} [options.richText] - Display with rich text format, text will be transformed automatically, or you may pass in your own rich text starts with "<?xml..."
+ * @param {Array} [options.replies] - Array of annotation replies, each with text and optional title, date, subject, richText, and flag.
  * @param {'invisible'|'hidden'|'print'|'nozoom'|'norotate'|'noview'|'readonly'|'locked'|'togglenoview'} [options.flag] - The flag property
  * @returns {Recipe} The recipe instance.
  */
@@ -19,6 +20,7 @@ exports.comment = function comment(text = "", x, y, options = {}) {
     subtype: "Text",
     pageNumber: this.pageNumber,
     args: { text, x, y, options: Object.assign({ icon: "Comment" }, options) },
+    replies: options.replies,
   });
   return this;
 };
@@ -29,7 +31,6 @@ exports.comment = function comment(text = "", x, y, options = {}) {
  * @function
  * @memberof Recipe#
  * @todo support for rich text RC
- * @todo support for opacity CA
  * @param {number} x - The coordinate x
  * @param {number} y - The coordinate y
  * @param {string} subtype - The markup annotation type 'Text'|'Link'|'FreeText'|'Line'|'Square'|'Circle'|'Polygon'|'PolyLine'|'Highlight'|'Underline'|'Squiggly'|'StrikeOut'|'Caret'|'Stamp'|'Ink'|'Popup'|'FileAttachment'|'Sound'|'Movie'|'Screen'|'Widget'|'PrinterMark'|'TrapNet'|'Watermark'|'3D'|'Redact'|'Projection'|'RichMedia'
@@ -47,6 +48,7 @@ exports.comment = function comment(text = "", x, y, options = {}) {
  * @param {Array} [options.replies] - Array of annotation replies
  * @param {number} [options.border] - The border width.
  * @param {string|number[]} [options.color] - The annotation color.
+ * @param {number} [options.opacity=1] - Annotation opacity from 0 (transparent) to 1 (opaque).
  * @param {boolean} [options.followOriginalPageRotation=false] - Preserve the original page rotation when positioning the annotation.
  * @returns {Recipe} The recipe instance.
  */
@@ -145,6 +147,11 @@ exports._annot = function _annot(subtype, args = {}, pageNumber, ref) {
     .writeBooleanValue(params.open)
     .writeKey("F")
     .writeNumberValue(getFlagBitNumberByName(params.flag));
+
+  var opacity = (reply || options).opacity ?? 1;
+  if (opacity !== 1) {
+    this.dictionaryContext.writeKey("CA").writeNumberValue(opacity);
+  }
 
   /**
    * Rich Text Strings

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -993,6 +993,8 @@ declare namespace muhammara {
       open?: boolean;
       richText?: boolean;
       flag?: CommentOptionsFlag;
+      /** Replies linked to this comment annotation. */
+      replies?: Array<AnnotReply>;
     }
 
     interface AnnotOptions {
@@ -1003,6 +1005,8 @@ declare namespace muhammara {
       icon?: AnnotOptionsIcon;
       width?: number;
       height?: number;
+      /** Annotation opacity from 0 (transparent) to 1 (opaque). Defaults to 1. */
+      opacity?: number;
       date?: string;
       subject?: string;
       replies?: Array<AnnotReply>;

--- a/packages/native-with-source/tests/recipe/annotation-parity.js
+++ b/packages/native-with-source/tests/recipe/annotation-parity.js
@@ -1,0 +1,113 @@
+var assert = require("node:assert/strict");
+var fs = require("node:fs");
+var os = require("node:os");
+var path = require("node:path");
+var muhammara = require("@muhammara/native-with-source");
+
+function readAnnotations(reader) {
+  var page = reader.parsePage(0).getDictionary();
+  return reader
+    .queryDictionaryObject(page, "Annots")
+    .toPDFArray()
+    .toJSArray()
+    .map(function (reference) {
+      var id = reference.toPDFIndirectObjectReference().getObjectID();
+      return {
+        id: id,
+        dictionary: reader.parseNewObject(id).toPDFDictionary().toJSObject(),
+      };
+    });
+}
+
+describe("Recipe annotation parity", function () {
+  var directory;
+  var output;
+  var reader;
+
+  beforeEach(function () {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), "annotation-parity-"));
+    output = path.join(directory, "annotations.pdf");
+  });
+
+  afterEach(function () {
+    if (reader) reader.end();
+    reader = undefined;
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  async function finish(recipe) {
+    await new Promise(function (resolve) {
+      recipe.endPage().endPDF(resolve);
+    });
+    reader = muhammara.createReader(output);
+    return readAnnotations(reader);
+  }
+
+  it("writes fractional and zero opacity while keeping the opaque default", async function () {
+    var recipe = new muhammara.Recipe("new", output).createPage(595, 842);
+    var opacities = [0.45, 0, 1, undefined];
+    opacities.forEach(function (opacity, index) {
+      recipe.annot(100, 200 + index * 30, "Highlight", {
+        width: 200,
+        height: 14,
+        color: "#ffff00",
+        opacity: opacity,
+      });
+    });
+    var annotations = await finish(recipe);
+    assert.equal(annotations.length, opacities.length);
+    annotations.forEach(function (annotation, index) {
+      var dictionary = annotation.dictionary;
+      assert.equal(dictionary.Subtype.toString(), "Highlight");
+      assert.equal(
+        dictionary.CA ? dictionary.CA.toNumber() : 1,
+        opacities[index] ?? 1,
+      );
+      assert.deepEqual(
+        dictionary.C.toPDFArray()
+          .toJSArray()
+          .map(function (value) {
+            return value.toNumber();
+          }),
+        [1, 1, 0],
+      );
+    });
+  });
+
+  it("links every comment and annot reply to its own parent dictionary", async function () {
+    var recipe = new muhammara.Recipe("new", output).createPage(595, 842);
+    var options = {
+      title: "Review",
+      replies: [
+        { text: "Confirmed.", title: "Reviewer" },
+        { text: "Ready to publish.", title: "Editor" },
+      ],
+    };
+    recipe.comment("Please review.", 300, 100, options);
+    recipe.annot(300, 200, "Text", { ...options, text: "Please review." });
+    recipe.comment("No replies.", 300, 300);
+    recipe.comment("Empty replies.", 300, 400, { replies: [] });
+    var annotations = await finish(recipe);
+    assert.equal(annotations.length, 8);
+    [0, 3].forEach(function (index) {
+      var parent = annotations[index];
+      assert.equal(parent.dictionary.Contents.toText(), "Please review.");
+      assert.equal(parent.dictionary.T.toText(), "Review");
+      assert.equal(parent.dictionary.IRT, undefined);
+      options.replies.forEach(function (reply, replyIndex) {
+        var dictionary = annotations[index + replyIndex + 1].dictionary;
+        assert.equal(dictionary.Subtype.toString(), "Text");
+        assert.equal(dictionary.Contents.toText(), reply.text);
+        assert.equal(dictionary.T.toText(), reply.title);
+        assert.equal(
+          dictionary.IRT.toPDFIndirectObjectReference().getObjectID(),
+          parent.id,
+        );
+        assert.equal(dictionary.RT.toString(), "R");
+      });
+    });
+    assert.equal(annotations[0].dictionary.Name.toString(), "Comment");
+    assert.equal(annotations[6].dictionary.Contents.toText(), "No replies.");
+    assert.equal(annotations[7].dictionary.Contents.toText(), "Empty replies.");
+  });
+});

--- a/packages/native-with-source/tests/types/types.test.ts
+++ b/packages/native-with-source/tests/types/types.test.ts
@@ -4,3 +4,12 @@ declare const writer: muhammara.PDFWriter;
 
 var page: muhammara.PDFPage = writer.createPage(0, 0, 595, 842);
 writer.startPageContentContext(page).c(0, 0, 1, 1, 2, 2).S();
+
+declare const recipe: muhammara.Recipe;
+recipe
+  .comment("Please review.", 300, 100, {
+    title: "Review",
+    replies: [{ text: "Confirmed.", title: "Reviewer" }],
+  })
+  .annot(100, 200, "Highlight", { width: 200, height: 14, opacity: 0.45 })
+  .annot(100, 230, "Highlight", { width: 200, height: 14, opacity: 0 });

--- a/packages/native/docs/how-to/add-review-annotations.md
+++ b/packages/native/docs/how-to/add-review-annotations.md
@@ -9,11 +9,27 @@ var pdfDoc = new Recipe("input.pdf", "output.pdf");
 
 pdfDoc
   .editPage(1)
-  .comment("Please review this section.", 300, 100, { title: "Review" })
-  .annot(100, 200, "Highlight", { width: 200, height: 14 })
+  .comment("Please review this section.", 300, 100, {
+    title: "Review",
+    replies: [{ text: "Confirmed.", title: "Reviewer" }],
+  })
+  .annot(100, 200, "Highlight", {
+    width: 200,
+    height: 14,
+    color: "#ffff00",
+    opacity: 0.45,
+  })
   .endPage()
   .endPDF();
 ```
+
+Set `opacity` from `0` (transparent) to `1` (opaque, the default). Recipe writes
+the annotation's `/CA` value; the `color` option sets its RGB color separately.
+Both `comment()` and `annot()` accept `replies`, an array of objects with `text`
+and optional `title`, `date`, `subject`, `richText`, and `flag`. Each reply is a
+separate annotation linked to its parent through `/IRT` and `/RT /R`.
+The dictionary behavior is covered by
+[`tests/recipe/annotation-parity.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/annotation-parity.js).
 
 Set `richText: true` on a comment to use supported HTML formatting. See
 [`tests/recipe/annotation-comment.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/annotation-comment.js) and [`tests/recipe/annotation-text.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/annotation-text.js).

--- a/packages/native/tests/types/types.test.ts
+++ b/packages/native/tests/types/types.test.ts
@@ -28,6 +28,13 @@ api.eXrefEntryUndefined;
 context.J(api.LineCapStyle.LINECAP_BUTT).j(2);
 objects.endArray(api.ETokenSeparator.eTokenSeparatorEndLine);
 recipe.read();
+recipe
+  .comment("Please review.", 300, 100, {
+    title: "Review",
+    replies: [{ text: "Confirmed.", title: "Reviewer" }],
+  })
+  .annot(100, 200, "Highlight", { width: 200, height: 14, opacity: 0.45 })
+  .annot(100, 230, "Highlight", { width: 200, height: 14, opacity: 0 });
 recipe.register("example", function () {});
 recipe.createPage(595, 842, { left: 36 }).margins({ top: 36 });
 var margins: Required<muhammara.Recipe.RecipeMargins> = recipe.margins();

--- a/packages/wasm/docs/how-to/add-review-annotations.md
+++ b/packages/wasm/docs/how-to/add-review-annotations.md
@@ -33,6 +33,12 @@ var outputBytes = pdf
   .endPDF();
 ```
 
+Set `opacity` from `0` (transparent) to `1` (opaque, the default). Recipe writes
+the annotation's `/CA` value; the `color` option sets its RGB color separately.
+On new pages, both `comment()` and `annot()` accept `replies`, an array of objects
+with `text` and optional `title`, `date`, `subject`, `richText`, and `flag`. Each
+reply is a separate annotation linked to its parent through `/IRT` and `/RT /R`.
+
 Annotations are queued until `endPage()`. Supported markup subtypes include
 `Highlight`, `Underline`, `StrikeOut`, and `Squiggly`. Recipe's rich-text form
 is a Worker-safe XML subset, not arbitrary browser HTML.

--- a/packages/wasm/tests/recipe/annotation-parity.test.mjs
+++ b/packages/wasm/tests/recipe/annotation-parity.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { createMuhammaraWasm, createRecipe } from "../../index.js";
+
+function readAnnotations(reader) {
+  var page = reader.parsePage(0).getDictionary();
+  return reader
+    .queryDictionaryObject(page, "Annots")
+    .toPDFArray()
+    .toJSArray()
+    .map(function (reference) {
+      var id = reference.toPDFIndirectObjectReference().getObjectID();
+      return {
+        id: id,
+        dictionary: reader.parseNewObject(id).toPDFDictionary().toJSObject(),
+      };
+    });
+}
+
+describe("Recipe annotation parity", function () {
+  var Recipe;
+  var muhammara;
+  var reader;
+
+  before(async function () {
+    Recipe = await createRecipe();
+    muhammara = await createMuhammaraWasm();
+  });
+
+  afterEach(function () {
+    if (reader) reader.end();
+    reader = undefined;
+  });
+
+  function finish(recipe) {
+    reader = muhammara.createReader(recipe.endPage().endPDF());
+    return readAnnotations(reader);
+  }
+
+  it("writes fractional and zero opacity while keeping the opaque default", function () {
+    var recipe = new Recipe().createPage(595, 842);
+    var opacities = [0.45, 0, 1, undefined];
+    opacities.forEach(function (opacity, index) {
+      recipe.annot(100, 200 + index * 30, "Highlight", {
+        width: 200,
+        height: 14,
+        color: "#ffff00",
+        opacity: opacity,
+      });
+    });
+    var annotations = finish(recipe);
+    assert.equal(annotations.length, opacities.length);
+    annotations.forEach(function (annotation, index) {
+      var dictionary = annotation.dictionary;
+      assert.equal(dictionary.Subtype.toString(), "Highlight");
+      assert.equal(
+        dictionary.CA ? dictionary.CA.toNumber() : 1,
+        opacities[index] ?? 1,
+      );
+      assert.deepEqual(
+        dictionary.C.toPDFArray()
+          .toJSArray()
+          .map(function (value) {
+            return value.toNumber();
+          }),
+        [1, 1, 0],
+      );
+    });
+  });
+
+  it("links every comment and annot reply to its own parent dictionary", function () {
+    var recipe = new Recipe().createPage(595, 842);
+    var options = {
+      title: "Review",
+      replies: [
+        { text: "Confirmed.", title: "Reviewer" },
+        { text: "Ready to publish.", title: "Editor" },
+      ],
+    };
+    recipe.comment("Please review.", 300, 100, options);
+    recipe.annot(300, 200, "Text", { ...options, text: "Please review." });
+    recipe.comment("No replies.", 300, 300);
+    recipe.comment("Empty replies.", 300, 400, { replies: [] });
+    var annotations = finish(recipe);
+    assert.equal(annotations.length, 8);
+    [0, 3].forEach(function (index) {
+      var parent = annotations[index];
+      assert.equal(parent.dictionary.Contents.toText(), "Please review.");
+      assert.equal(parent.dictionary.T.toText(), "Review");
+      assert.equal(parent.dictionary.IRT, undefined);
+      options.replies.forEach(function (reply, replyIndex) {
+        var dictionary = annotations[index + replyIndex + 1].dictionary;
+        assert.equal(dictionary.Subtype.toString(), "Text");
+        assert.equal(dictionary.Contents.toText(), reply.text);
+        assert.equal(dictionary.T.toText(), reply.title);
+        assert.equal(
+          dictionary.IRT.toPDFIndirectObjectReference().getObjectID(),
+          parent.id,
+        );
+        assert.equal(dictionary.RT.toString(), "R");
+      });
+    });
+    assert.equal(annotations[0].dictionary.Name.toString(), "Comment");
+    assert.equal(annotations[6].dictionary.Contents.toText(), "No replies.");
+    assert.equal(annotations[7].dictionary.Contents.toText(), "Empty replies.");
+  });
+});

--- a/packages/wasm/tests/types/types.test.ts
+++ b/packages/wasm/tests/types/types.test.ts
@@ -351,6 +351,8 @@ async function usesLowLevelSurface() {
       replies: [{ text: "reply" }],
     })
     .annot(0, 0, "Square", { width: 10, height: 10, flag: "print" })
+    .annot(100, 200, "Highlight", { width: 200, height: 14, opacity: 0.45 })
+    .annot(100, 230, "Highlight", { width: 200, height: 14, opacity: 0 })
     .info({ author: "author" })
     .custom("custom", "value")
     .insertPage(0, "pdf", 1);


### PR DESCRIPTION
## Summary
- Write native Recipe annotation opacity to `/CA`, preserving zero and the opaque default.
- Queue `comment()` replies through the existing annotation reply writer, including `/IRT` parent references and `/RT /R`.
- Add native TypeScript options and strict usage coverage, mirrored native/Wasm PDF-dictionary regression tests, review-annotation documentation, and the native changelog entry.

## Parity and scope
This completes native support for the two options already implemented by Wasm. Both regression tests fail on the original native implementation and pass on Wasm. The tests inspect fractional/zero/default opacity, RGB color, reply contents and titles, parent references, multiple replies, and absent/empty reply arrays.

The implementation stays in Recipe and uses the existing low-level dictionary API. The existing Wasm Annotations browser example already demonstrates opacity and comment replies, so its focused tab set needs no addition. Wasm changes are documentation and test coverage for existing behavior.

## Validation
- `npm test` — 207 passing.
- `npm run wasm:build` — fresh worktree build succeeds.
- `node packages/wasm/scripts/run-mocha.mjs 'tests/recipe/*.test.mjs' tests/integration/BrowserExamples.test.mjs` — 60 passing, including the browser examples executed in Node.
- `npm run native:test:types`, `npm run native-with-source:test:types`, and `npm run wasm:test:types` — pass.
- `npm run docs:check` and `npm run docs:check --workspace=@muhammara/wasm` — pass with the pinned documentation dependencies.
- `npm run test:codestyle` and `git diff --check` — pass.

Closes #606