### PR TITLE
Preserve custom Recipe info keys on native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Preserve custom Info dictionary keys passed to native `Recipe.info(options)`,
+  matching Wasm, instead of silently discarding them; `custom(key, value)` remains
+  the explicit spelling [#607](https://github.com/julianhille/MuhammaraJS/issues/607)
 - Release the source PDF file handle that `Recipe` holds, so the source,
   appended, and overlaid files can be deleted right after `endPDF()` instead of
   failing with `EBUSY` on Windows [#381](https://github.com/julianhille/MuhammaraJS/issues/381)

--- a/packages/native-core/lib/Recipe.js
+++ b/packages/native-core/lib/Recipe.js
@@ -2,6 +2,7 @@ const muhammara = require("./muhammara");
 const path = require("path");
 const fs = require("fs");
 const streams = require("memory-streams");
+var { standardInfoKeys } = require("./recipe-info");
 
 /**
  * @name Recipe
@@ -117,7 +118,11 @@ class Recipe {
       }
     }
 
-    this.info(this.options);
+    var info = {};
+    standardInfoKeys.forEach((key) => {
+      if (this.options[key] !== undefined) info[key] = this.options[key];
+    });
+    this.info(info);
   }
 
   _getVersion(version) {

--- a/packages/native-core/lib/recipe-info.js
+++ b/packages/native-core/lib/recipe-info.js
@@ -1,0 +1,10 @@
+// Metadata fields accepted by Recipe constructor options and info().
+var recipeInfoKeys = Object.freeze({
+  author: "author",
+  title: "title",
+  subject: "subject",
+  keywords: "keywords",
+});
+var standardInfoKeys = Object.freeze(Object.values(recipeInfoKeys));
+
+module.exports = { recipeInfoKeys, standardInfoKeys };

--- a/packages/native-core/lib/recipe/info.js
+++ b/packages/native-core/lib/recipe/info.js
@@ -1,8 +1,9 @@
 const fs = require("fs");
 const muhammara = require("../muhammara");
+var { recipeInfoKeys, standardInfoKeys } = require("../recipe-info");
 /**
  * @name info
- * @desc Add new PDF information, or retrieve existing PDF information.
+ * @desc Add standard and custom PDF information, or retrieve existing PDF information. Custom keys retain their spelling when written; array values are joined with a comma and space.
  * @memberof Recipe#
  * @function
  * @param {Object} [options] - The options (when missing obtains existing PDF information)
@@ -21,6 +22,14 @@ exports.info = function info(options) {
   } else {
     this.toWriteInfo_ = this.toWriteInfo_ || {};
     Object.assign(this.toWriteInfo_, options);
+    Object.entries(options).forEach(([key, value]) => {
+      if (!standardInfoKeys.includes(key)) {
+        this.custom(
+          key,
+          Array.isArray(value) ? value.join(", ") : String(value),
+        );
+      }
+    });
     result = this;
   }
 
@@ -105,24 +114,10 @@ exports._writeInfo = function _writeInfo() {
     */
 
   const infoDictionary = this.writer.getDocumentContext().getInfoDictionary();
-  const fields = [
-    {
-      key: "author",
-      type: "string",
-    },
-    {
-      key: "title",
-      type: "string",
-    },
-    {
-      key: "subject",
-      type: "string",
-    },
-    {
-      key: "keywords",
-      type: "array",
-    },
-  ];
+  var fields = standardInfoKeys.map((key) => ({
+    key,
+    type: key === recipeInfoKeys.keywords ? "array" : "string",
+  }));
   // const ignores = [
   //     'CreationDate', 'Creator', 'ModDate', 'Producer'
   // ];

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -1039,6 +1039,8 @@ declare namespace muhammara {
     }
 
     interface InfoOptions {
+      /** Additional Info dictionary entries; arrays are joined with a comma and space. */
+      [key: string]: string | string[] | undefined;
       version?: string;
       author?: string;
       title?: string;

--- a/packages/native-with-source/tests/recipe/info-custom-keys.js
+++ b/packages/native-with-source/tests/recipe/info-custom-keys.js
@@ -1,0 +1,102 @@
+var assert = require("node:assert/strict");
+var fs = require("node:fs");
+var path = require("node:path");
+var muhammara = require("@muhammara/native-with-source");
+var Recipe = muhammara.Recipe;
+
+describe("Recipe info custom keys", function () {
+  ["new", "existing"].forEach(function (mode) {
+    function createRecipe(options) {
+      var source =
+        mode === "new"
+          ? Buffer.from("new")
+          : fs.readFileSync(
+              path.join(__dirname, "../TestMaterials/recipe/blank.pdf"),
+            );
+      var recipe = new Recipe(source, undefined, options);
+      if (mode === "new") recipe.createPage(100, 100).endPage();
+      return recipe;
+    }
+
+    function readInfo(recipe) {
+      var bytes = recipe.endPDF(function (output) {
+        return output;
+      });
+      var reader = muhammara.createReader(
+        new muhammara.PDFRStreamForBuffer(bytes),
+      );
+      try {
+        var dictionary = reader
+          .queryDictionaryObject(reader.getTrailer(), "Info")
+          .toJSObject();
+        return Object.fromEntries(
+          Object.entries(dictionary).map(function ([key, value]) {
+            return [key, value.toText ? value.toText() : value.value];
+          }),
+        );
+      } finally {
+        reader.end();
+      }
+    }
+
+    it(`writes standard and custom Info entries in ${mode} PDFs`, function () {
+      var recipe = createRecipe();
+      assert.equal(
+        recipe.info({
+          author: "A",
+          title: "Report",
+          subject: "Metadata parity",
+          keywords: ["one", "two"],
+          ReportId: "X-123",
+          "2.16.76.1.4.2.2.1": "oid-professional",
+          Labels: ["one", "two"],
+          Empty: "",
+          Unicode: "Résumé 日本語",
+        }),
+        recipe,
+      );
+      recipe.info({ Extra: "another call" }).custom("Explicit", "X-123");
+      var info = readInfo(recipe);
+      assert.equal(info.Author, "A");
+      assert.equal(info.Title, "Report");
+      assert.equal(info.Subject, "Metadata parity");
+      assert.deepEqual(info.Keywords.split(/,\s*/), ["one", "two"]);
+      assert.equal(info.ReportId, "X-123");
+      assert.equal(info.ReportId, info.Explicit);
+      assert.equal(info["2.16.76.1.4.2.2.1"], "oid-professional");
+      assert.equal(info.Labels, "one, two");
+      assert.equal(info.Empty, "");
+      assert.equal(info.Unicode, "Résumé 日本語");
+      assert.equal(info.Extra, "another call");
+      assert.equal(info.reportid, undefined);
+    });
+
+    it(`uses the last custom-key call in ${mode} PDFs`, function () {
+      var recipe = createRecipe();
+      recipe
+        .info({ InfoThenCustom: "old", Repeated: "old" })
+        .custom("InfoThenCustom", "new")
+        .custom("CustomThenInfo", "old")
+        .info({ CustomThenInfo: "new", Repeated: "new" });
+      var info = readInfo(recipe);
+      assert.equal(info.InfoThenCustom, "new");
+      assert.equal(info.CustomThenInfo, "new");
+      assert.equal(info.Repeated, "new");
+    });
+
+    it(`keeps constructor settings out of ${mode} PDF metadata`, function () {
+      var info = readInfo(
+        createRecipe({
+          author: "Constructor author",
+          version: 1.7,
+          compress: false,
+          ReportId: "not constructor metadata",
+        }),
+      );
+      assert.equal(info.Author, "Constructor author");
+      ["version", "compress", "ReportId"].forEach(function (key) {
+        assert.equal(Object.hasOwn(info, key), false);
+      });
+    });
+  });
+});

--- a/packages/native-with-source/tests/types/types.test.ts
+++ b/packages/native-with-source/tests/types/types.test.ts
@@ -20,3 +20,12 @@ recipe
 var textWidth: number = recipe.textDimensions("text").width;
 recipe.textDimensions("text", { size: 12 }).width;
 void textWidth;
+
+var info: muhammara.Recipe.InfoOptions = {
+  author: "A",
+  keywords: ["one", "two"],
+  ReportId: "X-123",
+  "2.16.76.1.4.2.2.1": "oid-professional",
+  Labels: ["one", "two"],
+};
+recipe.info(info).custom("ReportId", "X-456").info({ ReportId: "X-789" });

--- a/packages/native/docs/how-to/add-metadata-to-existing-pdfs.md
+++ b/packages/native/docs/how-to/add-metadata-to-existing-pdfs.md
@@ -1,8 +1,8 @@
 # Add Metadata To An Existing PDF
 
-Open the document with Recipe, set standard fields with `info(options)`, and add
-your own Info dictionary keys with `custom(key, value)`. Both queue values that
-are written when the document is finalized.
+Open the document with Recipe and set standard fields and custom Info dictionary
+keys with `info(options)`, or use `custom(key, value)` for an explicit custom
+entry. Both queue values that are written when the document is finalized.
 
 ```javascript
 var Recipe = require("@muhammara/native").Recipe;
@@ -14,6 +14,7 @@ pdfDoc
     title: "Prescription",
     subject: "Issued 2026-03-01",
     keywords: ["prescription", "signed"],
+    ReportId: "X-123",
   })
   .custom("2.16.76.1.4.2.2.1", "oid-professional")
   .custom("2.16.76.1.4.2.2.2", "oid-uf-professional")
@@ -30,11 +31,15 @@ var metadata = new Recipe("output.pdf").info();
 console.log(metadata["2.16.76.1.4.2.2.1"]); // "oid-professional"
 ```
 
-`info` covers `author`, `title`, `subject`, and `keywords`; `keywords` accepts an
-array and a single value alike. Every other key belongs to `custom`, whose key
-and value are both coerced with `toString()`. Any name the PDF Info dictionary
-accepts works, including dotted OID strings, so identifiers such as
-`2.16.76.1.4.2.2.1` need no escaping.
+`info` handles `author`, `title`, `subject`, and `keywords` as standard fields;
+`keywords` accepts an array and a single value alike. Other keys are written as
+custom Info entries, matching Wasm: `info({ ReportId: "X-123" })` and
+`custom("ReportId", "X-123")` write the same entry. Custom array values passed to
+`info` are joined with `", "`; other values are converted to strings. When both
+methods set the same custom key, the last call wins. Constructor options still
+only initialize standard metadata; pass custom keys to `info` or `custom`.
+Any name the PDF Info dictionary accepts works, including dotted OID strings, so
+identifiers such as `2.16.76.1.4.2.2.1` need no escaping.
 
 ## What The Round Trip Changes
 
@@ -47,8 +52,8 @@ lower-cased name, or use keys that are already lower-case.
 
 **Custom entries do not survive the next modification.** Recipe carries the
 standard fields of a source document into its output, but not custom Info
-entries, so a second editing pass drops them. Re-apply every `custom` call each
-time you rewrite a document that must keep them.
+entries, so a second editing pass drops them. Re-apply custom entries with `info`
+or `custom` each time you rewrite a document that must keep them.
 
 **Recipe stamps its own provenance.** `Producer` and `Creator` are always set to
 MuhammaraJS values, and the source document's originals are preserved as
@@ -58,7 +63,7 @@ the time of the edit.
 These entries live in the document Info dictionary. Writing XMP metadata is a
 separate mechanism and is not exposed by Recipe.
 
-See [`tests/recipe/info.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/info.js)
+See [`tests/recipe/info-custom-keys.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/info-custom-keys.js)
 for the verified workflow, and
 [Metadata And Custom Data](../recipe/metadata-and-custom-data.md) for metadata on
 newly created documents.

--- a/packages/native/docs/recipe/metadata-and-custom-data.md
+++ b/packages/native/docs/recipe/metadata-and-custom-data.md
@@ -1,7 +1,10 @@
 # Metadata And Custom Data
 
 Set standard metadata in the constructor or with `info`, and add custom Info
-dictionary values with `custom`.
+dictionary values with `info({ ReportId: "Q1-2026" })` or
+`custom("ReportId", "Q1-2026")`. Both custom-entry spellings match Wasm; the last
+call for a given custom key wins. Custom keys belong in method calls, not
+constructor options.
 
 ```javascript
 var pdfDoc = new Recipe("new", "output.pdf", {

--- a/packages/native/tests/types/types.test.ts
+++ b/packages/native/tests/types/types.test.ts
@@ -35,6 +35,14 @@ recipe
   })
   .annot(100, 200, "Highlight", { width: 200, height: 14, opacity: 0.45 })
   .annot(100, 230, "Highlight", { width: 200, height: 14, opacity: 0 });
+var info: muhammara.Recipe.InfoOptions = {
+  author: "A",
+  keywords: ["one", "two"],
+  ReportId: "X-123",
+  "2.16.76.1.4.2.2.1": "oid-professional",
+  Labels: ["one", "two"],
+};
+recipe.info(info).custom("ReportId", "X-456").info({ ReportId: "X-789" });
 recipe.register("example", function () {});
 recipe.createPage(595, 842, { left: 36 }).margins({ top: 36 });
 var margins: Required<muhammara.Recipe.RecipeMargins> = recipe.margins();

--- a/packages/wasm/docs/how-to/add-metadata-to-existing-pdfs.md
+++ b/packages/wasm/docs/how-to/add-metadata-to-existing-pdfs.md
@@ -1,8 +1,8 @@
 # Add Metadata To An Existing PDF
 
-Open the document bytes with Recipe, set standard fields with `info(options)`,
-and add your own Info dictionary keys with `custom(key, value)`. Both are written
-when `endPDF()` returns the finished document.
+Open the document bytes with Recipe and set standard fields and custom Info
+dictionary keys with `info(options)`, or use `custom(key, value)` for an explicit
+custom entry. Both are written when `endPDF()` returns the finished document.
 
 ```javascript
 import { createRecipe } from "@muhammara/wasm";
@@ -16,6 +16,7 @@ var outputBytes = pdf
     title: "Prescription",
     subject: "Issued 2026-03-01",
     keywords: ["prescription", "signed"],
+    ReportId: "X-123",
   })
   .custom("2.16.76.1.4.2.2.1", "oid-professional")
   .custom("2.16.76.1.4.2.2.2", "oid-uf-professional")
@@ -34,8 +35,13 @@ console.log(metadata["2.16.76.1.4.2.2.1"]); // "oid-professional"
 
 `info` covers `author`, `title`, `subject`, and `keywords`; an array of keywords
 is joined into a single Info value. Every other key is added as a custom Info
-entry, so `custom(key, value)` is shorthand for `info({ [key]: value })`. Any
-name the PDF Info dictionary accepts works, including dotted OID strings, so
+entry, so `custom(key, value)` is shorthand for `info({ [key]: value })`.
+As on native, `info({ ReportId: "X-123" })` and `custom("ReportId", "X-123")`
+write the same entry. Custom array values passed to `info` are joined with
+`", "`; other values are converted to strings. When both methods set the same
+custom key, the last call wins. Constructor options still only initialize
+standard metadata; pass custom keys to `info` or `custom`. Any name the PDF Info
+dictionary accepts works, including dotted OID strings, so
 identifiers such as `2.16.76.1.4.2.2.1` need no escaping.
 
 ## What The Round Trip Changes
@@ -49,8 +55,8 @@ unaffected because they contain no letters.
 
 **Custom entries do not survive the next modification.** Recipe carries the
 standard fields of a source document into its output, but not custom Info
-entries, so a second editing pass drops them. Re-apply every `custom` call each
-time you rewrite a document that must keep them.
+entries, so a second editing pass drops them. Re-apply custom entries with `info`
+or `custom` each time you rewrite a document that must keep them.
 
 **Recipe stamps its own provenance.** `Producer` and `Creator` are always set to
 MuhammaraJS values, and the source document's originals are preserved as
@@ -60,5 +66,5 @@ the time of the edit.
 These entries live in the document Info dictionary. Writing XMP metadata is a
 separate mechanism and is not exposed by Recipe.
 
-See [`tests/recipe/info-composition.test.mjs`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/wasm/tests/recipe/info-composition.test.mjs)
+See [`tests/recipe/info-custom-keys.test.mjs`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/wasm/tests/recipe/info-custom-keys.test.mjs)
 for the verified workflow.

--- a/packages/wasm/lib/recipe-info.js
+++ b/packages/wasm/lib/recipe-info.js
@@ -1,0 +1,15 @@
+// Metadata fields accepted by Recipe constructor options and info().
+export var recipeInfoKeys = Object.freeze({
+  author: "author",
+  title: "title",
+  subject: "subject",
+  keywords: "keywords",
+});
+export var standardInfoKeys = Object.freeze(Object.values(recipeInfoKeys));
+
+// The source writer also exposes these provenance fields as properties.
+export var writableInfoKeys = Object.freeze([
+  ...standardInfoKeys,
+  "creator",
+  "producer",
+]);

--- a/packages/wasm/lib/recipe.js
+++ b/packages/wasm/lib/recipe.js
@@ -24,6 +24,7 @@ import { createInfoMethods } from "./recipe/info.js";
 import { createInspectPdf } from "./recipe/inspection.js";
 import { createRegistrationMethods } from "./recipe/registration.js";
 import { createSecurityMethods, permission } from "./recipe/security.js";
+import { standardInfoKeys } from "./recipe-info.js";
 
 /** Creates the high-level Recipe PDF composition factory. */
 export function createRecipeFactory({
@@ -93,7 +94,7 @@ export function createRecipeFactory({
         ]),
       );
       var info = {};
-      ["author", "title", "subject", "keywords"].forEach((key) => {
+      standardInfoKeys.forEach((key) => {
         if (options[key] !== undefined) info[key] = options[key];
       });
       if (hasSource) this._openSource(sourceOrOptions);

--- a/packages/wasm/lib/recipe/info.js
+++ b/packages/wasm/lib/recipe/info.js
@@ -1,3 +1,5 @@
+import { writableInfoKeys } from "../recipe-info.js";
+
 /** Creates Recipe document-information methods. */
 export function createInfoMethods({ call, withString }) {
   function pdfDate(date) {
@@ -14,16 +16,7 @@ export function createInfoMethods({ call, withString }) {
         var text = Array.isArray(value) ? value.join(", ") : String(value);
         if (this._sourceMode) {
           var info = this.writer.getDocumentContext().getInfoDictionary();
-          if (
-            [
-              "title",
-              "author",
-              "subject",
-              "keywords",
-              "creator",
-              "producer",
-            ].includes(key)
-          ) {
+          if (writableInfoKeys.includes(key)) {
             info[key] = text;
           } else {
             info.addAdditionalInfoEntry(key, text);

--- a/packages/wasm/tests/recipe/info-custom-keys.test.mjs
+++ b/packages/wasm/tests/recipe/info-custom-keys.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createMuhammaraWasm, createRecipe } from "../../index.js";
+
+describe("Recipe info custom keys", function () {
+  var muhammara;
+  var Recipe;
+
+  before(async function () {
+    muhammara = await createMuhammaraWasm();
+    Recipe = await createRecipe();
+  });
+
+  ["new", "existing"].forEach(function (mode) {
+    function makeRecipe(options = {}) {
+      var recipe =
+        mode === "new"
+          ? new Recipe(options)
+          : new Recipe(
+              readFileSync(
+                new URL(
+                  "../../../native-with-source/tests/TestMaterials/recipe/blank.pdf",
+                  import.meta.url,
+                ),
+              ),
+              options,
+            );
+      if (mode === "new") recipe.createPage(100, 100).endPage();
+      return recipe;
+    }
+
+    function readInfo(recipe) {
+      var reader = muhammara.createReader(recipe.endPDF());
+      try {
+        var dictionary = reader
+          .queryDictionaryObject(reader.getTrailer(), "Info")
+          .toJSObject();
+        return Object.fromEntries(
+          Object.entries(dictionary).map(function ([key, value]) {
+            return [key, value.toText ? value.toText() : value.value];
+          }),
+        );
+      } finally {
+        reader.end();
+      }
+    }
+
+    it(`writes standard and custom Info entries in ${mode} PDFs`, function () {
+      var recipe = makeRecipe();
+      assert.equal(
+        recipe.info({
+          author: "A",
+          title: "Report",
+          subject: "Metadata parity",
+          keywords: ["one", "two"],
+          ReportId: "X-123",
+          "2.16.76.1.4.2.2.1": "oid-professional",
+          Labels: ["one", "two"],
+          Empty: "",
+          Unicode: "Résumé 日本語",
+        }),
+        recipe,
+      );
+      recipe.info({ Extra: "another call" }).custom("Explicit", "X-123");
+      var info = readInfo(recipe);
+      assert.equal(info.Author, "A");
+      assert.equal(info.Title, "Report");
+      assert.equal(info.Subject, "Metadata parity");
+      assert.deepEqual(info.Keywords.split(/,\s*/), ["one", "two"]);
+      assert.equal(info.ReportId, "X-123");
+      assert.equal(info.ReportId, info.Explicit);
+      assert.equal(info["2.16.76.1.4.2.2.1"], "oid-professional");
+      assert.equal(info.Labels, "one, two");
+      assert.equal(info.Empty, "");
+      assert.equal(info.Unicode, "Résumé 日本語");
+      assert.equal(info.Extra, "another call");
+      assert.equal(info.reportid, undefined);
+    });
+
+    it(`uses the last custom-key call in ${mode} PDFs`, function () {
+      var recipe = makeRecipe();
+      recipe
+        .info({ InfoThenCustom: "old", Repeated: "old" })
+        .custom("InfoThenCustom", "new")
+        .custom("CustomThenInfo", "old")
+        .info({ CustomThenInfo: "new", Repeated: "new" });
+      var info = readInfo(recipe);
+      assert.equal(info.InfoThenCustom, "new");
+      assert.equal(info.CustomThenInfo, "new");
+      assert.equal(info.Repeated, "new");
+    });
+
+    it(`keeps constructor settings out of ${mode} PDF metadata`, function () {
+      var info = readInfo(
+        makeRecipe({
+          author: "Constructor author",
+          version: 1.7,
+          compress: false,
+          ReportId: "not constructor metadata",
+        }),
+      );
+      assert.equal(info.Author, "Constructor author");
+      ["version", "compress", "ReportId"].forEach(function (key) {
+        assert.equal(Object.hasOwn(info, key), false);
+      });
+    });
+  });
+});

--- a/packages/wasm/tests/types/types.test.ts
+++ b/packages/wasm/tests/types/types.test.ts
@@ -356,7 +356,15 @@ async function usesLowLevelSurface() {
     .annot(0, 0, "Square", { width: 10, height: 10, flag: "print" })
     .annot(100, 200, "Highlight", { width: 200, height: 14, opacity: 0.45 })
     .annot(100, 230, "Highlight", { width: 200, height: 14, opacity: 0 })
-    .info({ author: "author" })
+    .info({
+      author: "author",
+      keywords: ["one", "two"],
+      ReportId: "X-123",
+      "2.16.76.1.4.2.2.1": "oid-professional",
+      Labels: ["one", "two"],
+    })
+    .custom("ReportId", "X-456")
+    .info({ ReportId: "X-789" })
     .custom("custom", "value")
     .insertPage(0, "pdf", 1);
   recipe.knownColors.rgb.blue;


### PR DESCRIPTION
## Summary
- Route non-standard native `Recipe.info(options)` keys through the existing `custom()` writer path, matching Wasm and preserving last-call-wins ordering between both methods.
- Filter the internal constructor call to standard metadata so writer settings, font paths, and encryption options cannot become custom Info entries.
- Extend native `Recipe.InfoOptions`, exercise custom keys in all three package type checks, and add mirrored PDF dictionary regression tests for new and existing documents.
- Update both metadata how-to pages, the native Recipe reference source, and the native changelog. Keep the documented lower-cased read-back and second-edit caveats explicit.

## Parity and scope
This is an additive native Recipe bug fix using the existing low-level metadata primitive. Wasm already supports these custom keys; its behavior and type surface are covered by matching tests. No Wasm runtime change or new browser example is needed: the existing browser metadata capability is unchanged.

## Verification
- Native Recipe suite: 111 passing (`npx mocha "packages/native-with-source/tests/recipe/*.js" --timeout 15000`).
- Wasm Recipe suite: 54 passing (`node packages/wasm/scripts/run-mocha.mjs "tests/recipe/*.test.mjs"`) after a fresh `npm run wasm:build`.
- `npm run native:test:types`
- `npm run native-with-source:test:types`
- `npm run wasm:test:types`
- `npm run docs:check`
- `npm run docs:check --workspace=@muhammara/wasm`
- `npm run test:codestyle`
- `git diff --check`

Closes #607