### PR TITLE
Align Recipe default text size across native and Wasm

### DIFF
--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -1096,6 +1096,7 @@ declare namespace muhammara {
       rotation?: number;
       rotationOrigin?: [number, number];
       font?: string;
+      /** Font size in points for text() and textDimensions(); defaults to 14. */
       size?: number;
       align?: string;
       highlight?: boolean;

--- a/packages/native-with-source/tests/recipe/text-defaults.js
+++ b/packages/native-with-source/tests/recipe/text-defaults.js
@@ -1,0 +1,129 @@
+var assert = require("node:assert/strict");
+var path = require("path");
+var muhammara = require("@muhammara/native-with-source");
+var Recipe = muhammara.Recipe;
+
+describe("Recipe text default-size parity", function () {
+  [false, true].forEach(function (editing) {
+    it(`uses 14pt by default and preserves explicit sizes when ${editing ? "editing" : "creating"}`, function () {
+      var recipe = new Recipe(Buffer.from("new"));
+      if (editing) {
+        var source = recipe
+          .createPage("letter")
+          .endPage()
+          .endPDF((bytes) => bytes);
+        recipe = new Recipe(source).editPage(1);
+      } else {
+        recipe.createPage("letter");
+      }
+      recipe.registerFont(
+        "arial",
+        path.join(__dirname, "../TestMaterials/fonts/arial.ttf"),
+      );
+      assert.deepEqual(
+        recipe.textDimensions("Hello", { font: "arial" }),
+        recipe.textDimensions("Hello", { font: "arial", size: 14 }),
+      );
+      assert.notDeepEqual(
+        recipe.textDimensions("Hello", { font: "arial" }),
+        recipe.textDimensions("Hello", { font: "arial", size: 12 }),
+      );
+      [{}, { size: 12 }, { fontSize: 18 }, {}].forEach(
+        function (options, index) {
+          recipe.text("Hello", 72, 72 + index * 30, {
+            font: "arial",
+            ...options,
+          });
+        },
+      );
+      var bytes = recipe.endPage().endPDF((output) => output);
+      var reader = muhammara.createReader(
+        new muhammara.PDFRStreamForBuffer(bytes),
+      );
+      try {
+        var sizes;
+        if (editing) {
+          // Native edits put text in Form XObjects, outside extractPageText's scope.
+          var page = reader.parsePage(0).getDictionary();
+          var resources = reader
+            .queryDictionaryObject(page, "Resources")
+            .toPDFDictionary();
+          var forms = reader
+            .queryDictionaryObject(resources, "XObject")
+            .toPDFDictionary();
+          sizes = Object.keys(forms.toJSObject()).flatMap(function (name) {
+            var stream = reader.startReadingFromStream(
+              reader.queryDictionaryObject(forms, name).toPDFStream(),
+            );
+            var chunks = [];
+            while (stream.notEnded())
+              chunks.push(Buffer.from(stream.read(4096)));
+            return Array.from(
+              Buffer.concat(chunks)
+                .toString("latin1")
+                .matchAll(/\/\S+\s+([\d.]+)\s+Tf\b/g),
+              (match) => Number(match[1]),
+            );
+          });
+        } else {
+          sizes = reader.extractPageText(0).map((item) => item.fontSize);
+        }
+        assert.deepEqual(sizes, [14, 12, 18, 14]);
+      } finally {
+        reader.end();
+      }
+    });
+  });
+
+  it("lays out wrapped text and table rows like explicit 14pt", function () {
+    var recipe = new Recipe(Buffer.from("new"));
+    recipe.registerFont(
+      "arial",
+      path.join(__dirname, "../TestMaterials/fonts/arial.ttf"),
+    );
+    [{}, { size: 14 }].forEach(function (options) {
+      recipe
+        .createPage("letter")
+        .text("Hello world wraps across several lines", 150, 72, {
+          font: "arial",
+          ...options,
+          align: "center",
+          textBox: { width: 90, wrap: "auto" },
+        })
+        .text("Centered", 150, 160, {
+          font: "arial",
+          ...options,
+          align: "center",
+        })
+        .table(
+          72,
+          200,
+          [
+            { value: "Hello world wraps across several lines" },
+            { value: "Next row" },
+          ],
+          {
+            font: "arial",
+            ...options,
+            columns: [{ name: "value", width: 90 }],
+          },
+        )
+        .endPage();
+    });
+    var bytes = recipe.endPDF((output) => output);
+    var reader = muhammara.createReader(
+      new muhammara.PDFRStreamForBuffer(bytes),
+    );
+    try {
+      var output = reader.extractPageText(0);
+      assert.ok(
+        output.length > 3,
+        "text and table cells wrap into multiple lines",
+      );
+      assert.ok(output.every((item) => item.fontSize === 14));
+      assert.deepEqual(output, reader.extractPageText(1));
+    } finally {
+      reader.end();
+    }
+  });
+});

--- a/packages/native-with-source/tests/types/types.test.ts
+++ b/packages/native-with-source/tests/types/types.test.ts
@@ -13,3 +13,10 @@ recipe
   })
   .annot(100, 200, "Highlight", { width: 200, height: 14, opacity: 0.45 })
   .annot(100, 230, "Highlight", { width: 200, height: 14, opacity: 0 });
+
+recipe
+  .text("Default size", 72, 72)
+  .text("Explicit size", 72, 100, { size: 12 });
+var textWidth: number = recipe.textDimensions("text").width;
+recipe.textDimensions("text", { size: 12 }).width;
+void textWidth;

--- a/packages/native/docs/recipe/text-and-fonts.md
+++ b/packages/native/docs/recipe/text-and-fonts.md
@@ -4,6 +4,9 @@ Register fonts under a family name, then select the appropriate variant through
 text options. Recipe coordinates use a top-left origin and accept `center` for
 either coordinate.
 
+Recipe `text()` and `textDimensions()` default to 14 points when `size` is
+omitted. Pass `{ size: 12 }` to render and measure at 12 points instead.
+
 ```javascript
 var pdfDoc = new Recipe("new", "output.pdf", { fontSrcPath: ["./fonts"] });
 

--- a/packages/native/tests/types/types.test.ts
+++ b/packages/native/tests/types/types.test.ts
@@ -40,6 +40,10 @@ recipe.createPage(595, 842, { left: 36 }).margins({ top: 36 });
 var margins: Required<muhammara.Recipe.RecipeMargins> = recipe.margins();
 var title: string = recipe.getPageInfo().title;
 var textWidth: number = recipe.textDimensions("text").width;
+recipe.textDimensions("text", { size: 12 }).width;
+recipe
+  .text("Default size", 72, 72)
+  .text("Explicit size", 72, 100, { size: 12 });
 var coordinates: muhammara.Recipe | number[] = recipe.movedown(1, Boolean(1));
 recipe.structure("structure.json").endPDF();
 recipe

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -29,6 +29,12 @@ All notable changes to `@muhammara/wasm` are documented in this file.
 - Show `extractPageContentItems()` in the low-level browser example
   [#275](https://github.com/julianhille/MuhammaraJS/issues/275)
 
+### Fixed
+
+- Align Recipe text, measurement, and layout defaults on 14 points to match
+  native, correcting the 12-point default in the alpha and beta releases
+  [#605](https://github.com/julianhille/MuhammaraJS/issues/605)
+
 ### Changed
 
 - Reject invalid page indices and object IDs in the reader's `getPageObjectID()`

--- a/packages/wasm/docs/recipe.md
+++ b/packages/wasm/docs/recipe.md
@@ -25,6 +25,11 @@ Recipe provides pages, text, shapes, images, tables, composition, annotations,
 metadata, and byte-safe splitting. `setPageBox()` uses PDF bottom-left
 coordinates even though the high-level drawing API uses top-left coordinates.
 
+Recipe `text()` and `textDimensions()` default to 14 points when both `size`
+and `fontSize` are omitted, matching native Recipe. Pass `{ size: 12 }` (or
+`{ fontSize: 12 }`) to render and measure at 12 points instead; explicit sizes
+remain unchanged.
+
 ## PDF Version
 
 `version` sets the PDF level written into the byte output. Recipe accepts the

--- a/packages/wasm/index.d.ts
+++ b/packages/wasm/index.d.ts
@@ -178,7 +178,9 @@ export interface RecipeTextBoxClipResult {
 }
 export interface RecipeTextOptions extends RecipePathOptions {
   font?: string;
+  /** Font size in points for text() and textDimensions(); defaults to 14 when both fontSize and size are omitted. */
   fontSize?: number;
+  /** Alternative font size in points; defaults to 14 when both size and fontSize are omitted. */
   size?: number;
   bold?: boolean;
   italic?: boolean;

--- a/packages/wasm/lib/recipe.js
+++ b/packages/wasm/lib/recipe.js
@@ -268,7 +268,7 @@ export function createRecipeFactory({
       var point = this._calibrateCoordinate(x, y);
       if (this._pageContext) {
         var editFont = this.writer.getFontForBytes(getFont(fonts, options));
-        var editSize = options.fontSize || options.size || 12;
+        var editSize = options.fontSize || options.size || 14;
         this._pageContext
           .BT()
           .Tf(editFont, editSize)
@@ -280,7 +280,7 @@ export function createRecipeFactory({
         return this;
       }
       var fontPath = getFont(fonts, options);
-      var fontSize = options.fontSize || options.size || 12;
+      var fontSize = options.fontSize || options.size || 14;
       var dimensions = this.textDimensions(value, { ...options, fontSize });
       var transformed =
         options.rotation ||
@@ -359,7 +359,7 @@ export function createRecipeFactory({
             .getFontForBytes(fontPath)
             .calculateTextDimensions(
               String(value),
-              options.fontSize || options.size || 12,
+              options.fontSize || options.size || 14,
             );
         }
         var resultPointer = module._malloc(48);
@@ -371,7 +371,7 @@ export function createRecipeFactory({
                 this._recipe,
                 textPointer,
                 fontPointer,
-                options.fontSize || options.size || 12,
+                options.fontSize || options.size || 14,
                 resultPointer,
               );
               var offset = resultPointer >>> 3;

--- a/packages/wasm/lib/recipe/text.js
+++ b/packages/wasm/lib/recipe/text.js
@@ -101,14 +101,14 @@ export function createTextMethods({ drawText, measure, module }) {
     textDimensions(value, options = {}) {
       return dimensions(this, value, {
         ...options,
-        fontSize: options.fontSize || options.size || 12,
+        fontSize: options.fontSize || options.size || 14,
       });
     },
 
     _measureTextBoxHeight(value, options = {}) {
       var box = options.textBox || options.cell || {};
       var [top, right, bottom, left] = padding(box.padding);
-      var fontSize = options.fontSize || options.size || 12;
+      var fontSize = options.fontSize || options.size || 14;
       var width = box.width || 0;
       var lineHeight =
         box.lineHeight ||
@@ -188,7 +188,7 @@ export function createTextMethods({ drawText, measure, module }) {
         y = column.y;
         box = merge(box, { width: column.width, height: column.height });
       }
-      var fontSize = options.fontSize || options.size || 12;
+      var fontSize = options.fontSize || options.size || 14;
       var width =
         box.width ||
         (options.flow ? this._pageWidth - x - this._margin.right : 0);

--- a/packages/wasm/tests/browser/validation.mjs
+++ b/packages/wasm/tests/browser/validation.mjs
@@ -397,17 +397,22 @@ export async function runValidation() {
   equal(overflowCalls, 1, "table overflow callback");
   equal(continuationHeaders.length, 2, "repeated table headers");
   assert(
-    continuationHeaders[0].textMatrix[5] >
-      overflowText.find((entry) => entry.content === "first row").textMatrix[5],
+    overflowText.every((entry) => entry.fontSize === 14),
+    "Recipe text and tables default to 14pt",
+  );
+  var firstRow = overflowText.find((entry) => entry.content === "first row");
+  var secondRow = overflowText.find((entry) => entry.content === "second");
+  assert(firstRow, "first wrapped row is present");
+  assert(secondRow, "continued row wraps at the 14pt default");
+  assert(
+    continuationHeaders[0].textMatrix[5] > firstRow.textMatrix[5],
     "first header precedes wrapped row",
   );
   assert(
-    continuationHeaders[1].textMatrix[5] >
-      overflowText.find((entry) => entry.content === "second row")
-        .textMatrix[5],
+    continuationHeaders[1].textMatrix[5] > secondRow.textMatrix[5],
     "continued header precedes wrapped row",
   );
-  assertions += 7;
+  assertions += 10;
 
   var sourceRecipe = new Recipe(overflowBytes, { compress: false });
   sourceRecipe

--- a/packages/wasm/tests/recipe/text-defaults.test.mjs
+++ b/packages/wasm/tests/recipe/text-defaults.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { createMuhammaraWasm } from "../../index.js";
+import { getRecipe } from "./recipe.mjs";
+
+describe("Recipe text default-size parity", function () {
+  [false, true].forEach(function (editing) {
+    it(`uses 14pt by default and preserves explicit sizes when ${editing ? "editing" : "creating"}`, async function () {
+      var Recipe = await getRecipe();
+      var recipe = new Recipe();
+      if (editing) {
+        var source = recipe.createPage("letter").endPage().endPDF();
+        recipe = new Recipe(source).editPage(1);
+      } else {
+        recipe.createPage("letter");
+      }
+      assert.deepEqual(
+        recipe.textDimensions("Hello", { font: "arial" }),
+        recipe.textDimensions("Hello", { font: "arial", size: 14 }),
+      );
+      assert.notDeepEqual(
+        recipe.textDimensions("Hello", { font: "arial" }),
+        recipe.textDimensions("Hello", { font: "arial", size: 12 }),
+      );
+      [{}, { size: 12 }, { fontSize: 18 }, {}].forEach(
+        function (options, index) {
+          recipe.text("Hello", 72, 72 + index * 30, {
+            font: "arial",
+            ...options,
+          });
+        },
+      );
+      var bytes = recipe.endPage().endPDF();
+      var reader = (await createMuhammaraWasm()).createReader(bytes);
+      try {
+        var sizes;
+        if (editing) {
+          // Edits put text in Form XObjects, outside extractPageText's scope.
+          var page = reader.parsePage(0).getDictionary().toPDFDictionary();
+          var resources = reader
+            .queryDictionaryObject(page, "Resources")
+            .toPDFDictionary();
+          var forms = reader
+            .queryDictionaryObject(resources, "XObject")
+            .toPDFDictionary();
+          sizes = Object.keys(forms.toJSObject()).flatMap(function (name) {
+            var stream = reader.startReadingFromStream(
+              reader.queryDictionaryObject(forms, name).toPDFStream(),
+            );
+            var chunks = [];
+            while (stream.notEnded())
+              chunks.push(Buffer.from(stream.read(4096)));
+            return Array.from(
+              Buffer.concat(chunks)
+                .toString("latin1")
+                .matchAll(/\/\S+\s+([\d.]+)\s+Tf\b/g),
+              (match) => Number(match[1]),
+            );
+          });
+        } else {
+          sizes = reader.extractPageText(0).map((item) => item.fontSize);
+        }
+        assert.deepEqual(sizes, [14, 12, 18, 14]);
+      } finally {
+        reader.end();
+      }
+    });
+  });
+
+  it("lays out wrapped text and table rows like explicit 14pt", async function () {
+    var Recipe = await getRecipe();
+    var recipe = new Recipe();
+    [{}, { size: 14 }].forEach(function (options) {
+      recipe
+        .createPage("letter")
+        .text("Hello world wraps across several lines", 150, 72, {
+          font: "arial",
+          ...options,
+          align: "center",
+          textBox: { width: 90, wrap: "auto" },
+        })
+        .text("Centered", 150, 160, {
+          font: "arial",
+          ...options,
+          align: "center",
+        })
+        .table(
+          72,
+          200,
+          [
+            { value: "Hello world wraps across several lines" },
+            { value: "Next row" },
+          ],
+          {
+            font: "arial",
+            ...options,
+            columns: [{ name: "value", width: 90 }],
+          },
+        )
+        .endPage();
+    });
+    var reader = (await createMuhammaraWasm()).createReader(recipe.endPDF());
+    try {
+      var output = reader.extractPageText(0);
+      assert.ok(
+        output.length > 3,
+        "text and table cells wrap into multiple lines",
+      );
+      assert.ok(output.every((item) => item.fontSize === 14));
+      assert.deepEqual(output, reader.extractPageText(1));
+    } finally {
+      reader.end();
+    }
+  });
+});

--- a/packages/wasm/tests/types/types.test.ts
+++ b/packages/wasm/tests/types/types.test.ts
@@ -267,6 +267,9 @@ async function usesLowLevelSurface() {
       return this;
     })
     .createPage("letter", 90, { left: 36 })
+    .text("Default size", 72, 72)
+    .text("Explicit size", 72, 100, { size: 12 })
+    .text("Explicit fontSize", 72, 128, { fontSize: 12 })
     .margins(36, 36, 72, 72)
     .save()
     .transform(1, 0, 0, 1, 10, 10)
@@ -358,6 +361,10 @@ async function usesLowLevelSurface() {
     .insertPage(0, "pdf", 1);
   recipe.knownColors.rgb.blue;
   recipe.margins().left;
+  var textWidth: number = recipe.textDimensions("text").width;
+  recipe.textDimensions("text", { size: 12 }).width;
+  recipe.textDimensions("text", { fontSize: 12 }).width;
+  void textWidth;
   recipe.pageInfo(1)?.mediaBox[3];
   recipe.endPage().endPDF();
   var byteRecipe = new Recipe(source, { compress: false });


### PR DESCRIPTION
## Summary
- Choose the documented native 14pt default for both Recipe implementations, correcting all Wasm drawing, measurement, and layout fallbacks without changing low-level APIs.
- Add mirrored native/Wasm regressions for new and edited PDFs, emitted font sizes, explicit size/fontSize overrides, measurement, centered/wrapped text, and table layout.
- Update browser page and Worker validation for table wrapping at 14pt, assert the default font size, and report missing rows before accessing their text matrices.
- Document defaults in both API declarations and doc sets, with strict type-test coverage in all three packages.

## Release Notes
Record the Wasm default-size alignment under Fixed: the previous 12pt default existed only in alpha and beta releases. Explicit size and fontSize values remain unchanged.

Native runtime behavior is unchanged, so its changes are regression coverage and documentation only; no native changelog entry is needed. No deliberate divergence remains for the default size. No new browser example tab is warranted for a default correction; existing browser examples and page/Worker validation cover it.

## Validation
Rebased onto develop at 084076e1 and consolidated the release-note correction and browser fix into the implementation commit.

- `npm test`: 210 passing.
- `npm run wasm:test`: 157 passing, using the worktree-local Wasm build.
- `npm run wasm:test:browser` with Chrome 153.0.8010.36: passing, 86 assertions each in page and Worker contexts, plus example UI validation.
- `npm run native:test:types`, `npm run native-with-source:test:types`, and `npm run wasm:test:types`: passing.
- `npm run docs:check` and `npm run docs:check --workspace=@muhammara/wasm`: passing.
- `npm run test:codestyle`, `npm run wasm:test:paths`, `npm run wasm:test:exports`, and `git diff --check`: passing.
- Reproduced the reported Actions browser failure before fixing the stale 12pt wrapping expectation.
- Native tests use worktree-local JavaScript with the existing native addon binary. No C++ or ABI changes are included.

Closes #605