### PR TITLE
Restore the Electron 39 through 44 build matrix

### DIFF
--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -203,7 +203,7 @@ jobs:
           path: packages/native-with-source/build/stage/julianhille/MuhammaraJS/releases/download/**/*.gz
           name: bindings-node-musl-${{ matrix.node }}
           if-no-files-found: error
-  build-electron:
+  build-electron-legacy:
     strategy:
       fail-fast: false
       matrix:
@@ -280,7 +280,7 @@ jobs:
           - os: windows-2022
             architecture: arm64
     runs-on: ${{ matrix.os }}
-    steps:
+    steps: &build-electron-steps
       - name: Set up GCC
         uses: egor-tensin/setup-gcc@v1
         with:
@@ -354,6 +354,499 @@ jobs:
           path: packages/native-with-source/build/stage/julianhille/MuhammaraJS/releases/download/**/*.gz
           name: bindings-electron-${{ matrix.os }}-${{ matrix.target_architecture }}-${{matrix.electron}}
           if-no-files-found: error
+
+  build-electron-38-39:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-15, windows-2022]
+        architecture: [x64, arm64]
+        electron:
+          - 38.2.0
+          - 38.2.1
+          - 38.2.2
+          - 38.3.0
+          - 38.4.0
+          - 38.5.0
+          - 38.6.0
+          - 38.7.0
+          - 38.7.1
+          - 38.7.2
+          - 38.8.0
+          - 38.8.1
+          - 38.8.2
+          - 38.8.4
+          - 38.8.6
+          - 39.0.0
+          - 39.1.0
+          - 39.1.1
+          - 39.1.2
+          - 39.2.0
+          - 39.2.1
+          - 39.2.2
+          - 39.2.3
+          - 39.2.4
+          - 39.2.5
+          - 39.2.6
+          - 39.2.7
+          - 39.3.0
+          - 39.4.0
+          - 39.5.0
+          - 39.5.1
+          - 39.5.2
+          - 39.6.0
+          - 39.6.1
+          - 39.7.0
+          - 39.8.0
+          - 39.8.1
+          - 39.8.2
+          - 39.8.3
+          - 39.8.4
+          - 39.8.5
+          - 39.8.6
+          - 39.8.7
+          - 39.8.8
+          - 39.8.9
+          - 39.8.10
+        include:
+          - electron_mocha_version: ^13
+            python_version: "3.10"
+          - architecture: arm64
+            architecture_node: x64
+            target_architecture: arm64
+            extra_compile_flags: -arch arm64
+          - architecture: x64
+            architecture_node: x64
+            target_architecture: x64
+          - electron: 38.2.0
+            node: 22.19.0
+          - electron: 38.2.1
+            node: 22.19.0
+          - electron: 38.2.2
+            node: 22.19.0
+          - electron: 38.3.0
+            node: 22.20.0
+          - electron: 38.4.0
+            node: 22.20.0
+          - electron: 38.5.0
+            node: 22.20.0
+          - electron: 38.6.0
+            node: 22.21.1
+          - electron: 38.7.0
+            node: 22.21.1
+          - electron: 38.7.1
+            node: 22.21.1
+          - electron: 38.7.2
+            node: 22.21.1
+          - electron: 38.8.0
+            node: 22.22.0
+          - electron: 38.8.1
+            node: 22.22.0
+          - electron: 38.8.2
+            node: 22.22.0
+          - electron: 38.8.4
+            node: 22.22.0
+          - electron: 38.8.6
+            node: 22.22.0
+          - electron: 39.0.0
+            node: 22.20.0
+          - electron: 39.1.0
+            node: 22.21.1
+          - electron: 39.1.1
+            node: 22.21.1
+          - electron: 39.1.2
+            node: 22.21.1
+          - electron: 39.2.0
+            node: 22.21.1
+          - electron: 39.2.1
+            node: 22.21.1
+          - electron: 39.2.2
+            node: 22.21.1
+          - electron: 39.2.3
+            node: 22.21.1
+          - electron: 39.2.4
+            node: 22.21.1
+          - electron: 39.2.5
+            node: 22.21.1
+          - electron: 39.2.6
+            node: 22.21.1
+          - electron: 39.2.7
+            node: 22.21.1
+          - electron: 39.3.0
+            node: 22.21.1
+          - electron: 39.4.0
+            node: 22.22.0
+          - electron: 39.5.0
+            node: 22.22.0
+          - electron: 39.5.1
+            node: 22.22.0
+          - electron: 39.5.2
+            node: 22.22.0
+          - electron: 39.6.0
+            node: 22.22.0
+          - electron: 39.6.1
+            node: 22.22.0
+          - electron: 39.7.0
+            node: 22.22.0
+          - electron: 39.8.0
+            node: 22.22.0
+          - electron: 39.8.1
+            node: 22.22.1
+          - electron: 39.8.2
+            node: 22.22.1
+          - electron: 39.8.3
+            node: 22.22.1
+          - electron: 39.8.4
+            node: 22.22.1
+          - electron: 39.8.5
+            node: 22.22.1
+          - electron: 39.8.6
+            node: 22.22.1
+          - electron: 39.8.7
+            node: 22.22.1
+          - electron: 39.8.8
+            node: 22.22.1
+          - electron: 39.8.9
+            node: 22.22.1
+          - electron: 39.8.10
+            node: 22.22.1
+        exclude:
+          - os: ubuntu-22.04
+            architecture: arm64
+          - os: windows-2022
+            architecture: arm64
+          - os: macos-15
+            architecture: x64
+    runs-on: ${{ matrix.os }}
+    steps: *build-electron-steps
+  build-electron-40-41:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-15, windows-2022]
+        architecture: [x64, arm64]
+        electron:
+          - 40.0.0
+          - 40.1.0
+          - 40.2.1
+          - 40.3.0
+          - 40.4.0
+          - 40.4.1
+          - 40.5.0
+          - 40.6.0
+          - 40.6.1
+          - 40.7.0
+          - 40.8.0
+          - 40.8.1
+          - 40.8.2
+          - 40.8.3
+          - 40.8.4
+          - 40.8.5
+          - 40.9.1
+          - 40.9.2
+          - 40.9.3
+          - 40.10.0
+          - 40.10.1
+          - 40.10.2
+          - 40.10.3
+          - 40.10.4
+          - 40.10.5
+          - 40.10.6
+          - 41.0.0
+          - 41.0.1
+          - 41.0.2
+          - 41.0.3
+          - 41.0.4
+          - 41.1.0
+          - 41.1.1
+          - 41.2.0
+          - 41.2.1
+          - 41.2.2
+          - 41.3.0
+          - 41.4.0
+          - 41.5.0
+          - 41.5.1
+          - 41.5.2
+          - 41.6.0
+          - 41.6.1
+          - 41.7.0
+          - 41.7.1
+          - 41.7.2
+          - 41.8.0
+          - 41.9.0
+          - 41.9.1
+          - 41.9.2
+          - 41.10.0
+          - 41.10.1
+          - 41.10.2
+          - 41.10.3
+          - 41.10.4
+          - 41.10.5
+          - 41.10.6
+          - 41.10.7
+        include:
+          - electron_mocha_version: ^13
+            python_version: "3.10"
+          - architecture: arm64
+            architecture_node: x64
+            target_architecture: arm64
+            extra_compile_flags: -arch arm64
+          - architecture: x64
+            architecture_node: x64
+            target_architecture: x64
+          - electron: 40.0.0
+            node: 24.11.1
+          - electron: 40.1.0
+            node: 24.11.1
+          - electron: 40.2.1
+            node: 24.11.1
+          - electron: 40.3.0
+            node: 24.13.0
+          - electron: 40.4.0
+            node: 24.13.0
+          - electron: 40.4.1
+            node: 24.13.0
+          - electron: 40.5.0
+            node: 24.13.1
+          - electron: 40.6.0
+            node: 24.13.1
+          - electron: 40.6.1
+            node: 24.13.1
+          - electron: 40.7.0
+            node: 24.14.0
+          - electron: 40.8.0
+            node: 24.14.0
+          - electron: 40.8.1
+            node: 24.14.0
+          - electron: 40.8.2
+            node: 24.14.0
+          - electron: 40.8.3
+            node: 24.14.0
+          - electron: 40.8.4
+            node: 24.14.0
+          - electron: 40.8.5
+            node: 24.14.0
+          - electron: 40.9.1
+            node: 24.14.1
+          - electron: 40.9.2
+            node: 24.14.1
+          - electron: 40.9.3
+            node: 24.14.1
+          - electron: 40.10.0
+            node: 24.15.0
+          - electron: 40.10.1
+            node: 24.15.0
+          - electron: 40.10.2
+            node: 24.15.0
+          - electron: 40.10.3
+            node: 24.15.0
+          - electron: 40.10.4
+            node: 24.15.0
+          - electron: 40.10.5
+            node: 24.15.0
+          - electron: 40.10.6
+            node: 24.15.0
+          - electron: 41.0.0
+            node: 24.14.0
+          - electron: 41.0.1
+            node: 24.14.0
+          - electron: 41.0.2
+            node: 24.14.0
+          - electron: 41.0.3
+            node: 24.14.0
+          - electron: 41.0.4
+            node: 24.14.0
+          - electron: 41.1.0
+            node: 24.14.0
+          - electron: 41.1.1
+            node: 24.14.0
+          - electron: 41.2.0
+            node: 24.14.0
+          - electron: 41.2.1
+            node: 24.14.1
+          - electron: 41.2.2
+            node: 24.14.1
+          - electron: 41.3.0
+            node: 24.15.0
+          - electron: 41.4.0
+            node: 24.15.0
+          - electron: 41.5.0
+            node: 24.15.0
+          - electron: 41.5.1
+            node: 24.15.0
+          - electron: 41.5.2
+            node: 24.15.0
+          - electron: 41.6.0
+            node: 24.15.0
+          - electron: 41.6.1
+            node: 24.15.0
+          - electron: 41.7.0
+            node: 24.15.0
+          - electron: 41.7.1
+            node: 24.15.0
+          - electron: 41.7.2
+            node: 24.15.0
+          - electron: 41.8.0
+            node: 24.16.0
+          - electron: 41.9.0
+            node: 24.17.0
+          - electron: 41.9.1
+            node: 24.17.0
+          - electron: 41.9.2
+            node: 24.17.0
+          - electron: 41.10.0
+            node: 24.18.0
+          - electron: 41.10.1
+            node: 24.18.0
+          - electron: 41.10.2
+            node: 24.18.0
+          - electron: 41.10.3
+            node: 24.18.0
+          - electron: 41.10.4
+            node: 24.18.0
+          - electron: 41.10.5
+            node: 24.18.0
+          - electron: 41.10.6
+            node: 24.18.0
+          - electron: 41.10.7
+            node: 24.18.0
+        exclude:
+          - os: ubuntu-22.04
+            architecture: arm64
+          - os: windows-2022
+            architecture: arm64
+          - os: macos-15
+            architecture: x64
+    runs-on: ${{ matrix.os }}
+    steps: *build-electron-steps
+  build-electron:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-15, windows-2022]
+        architecture: [x64, arm64]
+        electron:
+          - 42.0.0
+          - 42.0.1
+          - 42.1.0
+          - 42.2.0
+          - 42.3.0
+          - 42.3.1
+          - 42.3.2
+          - 42.3.3
+          - 42.4.0
+          - 42.4.1
+          - 42.5.0
+          - 42.5.1
+          - 42.5.2
+          - 42.6.0
+          - 42.6.1
+          - 42.6.2
+          - 42.7.0
+          - 42.7.1
+          - 42.8.0
+          - 42.8.1
+          - 42.9.0
+          - 42.9.1
+          - 42.9.2
+          - 42.9.3
+          - 42.10.0
+          - 42.10.1
+          - 43.0.0
+          - 43.1.0
+          - 43.1.1
+          - 43.2.0
+          - 43.3.0
+          - 43.4.0
+          - 43.4.1
+          - 44.0.0
+        include:
+          - electron_mocha_version: ^13
+            python_version: "3.10"
+          - architecture: arm64
+            architecture_node: x64
+            target_architecture: arm64
+            extra_compile_flags: -arch arm64
+          - architecture: x64
+            architecture_node: x64
+            target_architecture: x64
+          - electron: 42.0.0
+            node: 24.15.0
+          - electron: 42.0.1
+            node: 24.15.0
+          - electron: 42.1.0
+            node: 24.15.0
+          - electron: 42.2.0
+            node: 24.15.0
+          - electron: 42.3.0
+            node: 24.15.0
+          - electron: 42.3.1
+            node: 24.15.0
+          - electron: 42.3.2
+            node: 24.15.0
+          - electron: 42.3.3
+            node: 24.15.0
+          - electron: 42.4.0
+            node: 24.16.0
+          - electron: 42.4.1
+            node: 24.16.0
+          - electron: 42.5.0
+            node: 24.17.0
+          - electron: 42.5.1
+            node: 24.17.0
+          - electron: 42.5.2
+            node: 24.17.0
+          - electron: 42.6.0
+            node: 24.18.0
+          - electron: 42.6.1
+            node: 24.18.0
+          - electron: 42.6.2
+            node: 24.18.0
+          - electron: 42.7.0
+            node: 24.18.0
+          - electron: 42.7.1
+            node: 24.18.0
+          - electron: 42.8.0
+            node: 24.18.0
+          - electron: 42.8.1
+            node: 24.18.1
+          - electron: 42.9.0
+            node: 24.18.1
+          - electron: 42.9.1
+            node: 24.18.1
+          - electron: 42.9.2
+            node: 24.18.1
+          - electron: 42.9.3
+            node: 24.18.1
+          - electron: 42.10.0
+            node: 24.18.1
+          - electron: 42.10.1
+            node: 24.18.1
+          - electron: 43.0.0
+            node: 24.17.0
+          - electron: 43.1.0
+            node: 24.18.0
+          - electron: 43.1.1
+            node: 24.18.0
+          - electron: 43.2.0
+            node: 24.18.0
+          - electron: 43.3.0
+            node: 24.18.1
+          - electron: 43.4.0
+            node: 24.18.1
+          - electron: 43.4.1
+            node: 24.18.1
+          - electron: 44.0.0
+            node: 24.18.1
+        exclude:
+          - os: ubuntu-22.04
+            architecture: arm64
+          - os: windows-2022
+            architecture: arm64
+          - os: macos-15
+            architecture: x64
+    runs-on: ${{ matrix.os }}
+    steps: *build-electron-steps
 
   build-node-linux:
     strategy:
@@ -500,6 +993,9 @@ jobs:
         sanitizer,
         build-musl,
         build-musl-arm,
+        build-electron-legacy,
+        build-electron-38-39,
+        build-electron-40-41,
         build-electron,
         build-node-linux,
         build-node,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Preserve custom Info dictionary keys passed to native `Recipe.info(options)`,
   matching Wasm, instead of silently discarding them; `custom(key, value)` remains
   the explicit spelling [#607](https://github.com/julianhille/MuhammaraJS/issues/607)
+
+- Actually build and publish the Electron 38.2 through 44.0 prebuilds announced
+  in 7.0.0-beta.1. The build matrix was lost when the branch was rebased across
+  the native/Wasm workflow split, so `ci-native.yml` only ever built Electron
+  36.0 through 38.1 [#537](https://github.com/julianhille/MuhammaraJS/issues/537)
 - Release the source PDF file handle that `Recipe` holds, so the source,
   appended, and overlaid files can be deleted right after `endPDF()` instead of
   failing with `EBUSY` on Windows [#381](https://github.com/julianhille/MuhammaraJS/issues/381)

--- a/packages/native/docs/getting-started/installation.md
+++ b/packages/native/docs/getting-started/installation.md
@@ -92,11 +92,13 @@ any other platform, architecture, runtime, or libc combination, install
 | Node.js  | Any other combination | Any                               | Use source package |
 | Electron | 36.0 through 44.0     | Linux x64                         | Yes                |
 | Electron | 36.0 through 44.0     | macOS arm64                       | Yes                |
+| Electron | 36.0 through 38.1     | macOS x64                         | Yes                |
 | Electron | 36.0 through 44.0     | Windows x64                       | Yes                |
 | Electron | Any other combination | Any                               | Use source package |
 
-Windows arm64, Linux arm64, and macOS x64 Electron builds are not part of the
-current prebuilt matrix. The package `engines` field is the authoritative
+Windows arm64 and Linux arm64 Electron builds are not part of the current
+prebuilt matrix, and macOS x64 Electron builds cover only 36.0 through 38.1.
+The package `engines` field is the authoritative
 Node.js version policy; this table describes the release workflow's binary
 coverage.
 


### PR DESCRIPTION
## Problem

PR #538 announced Electron 38.x through 44.x prebuilds and shipped that claim in the tagged `native-v7.0.0-beta.1` release — but the build matrix never reached CI. `ci-native.yml` has only ever built Electron **36.0.0 through 38.1.0**.

The branch `issue/537-electron-42-44` was cut before `18f89782` "Split native and wasm packages", which deleted `.github/workflows/build.yml` and replaced it with `ci-native.yml` + `ci-wasm.yml`. On rebase, every hunk targeting the deleted file was dropped silently instead of conflicting:

- `10ffee80` (`build.yml | 102 ++++` + 1 CHANGELOG line) landed as `9bb63afe` with **only the CHANGELOG line** — the entire Electron 42.0.0–44.0.0 matrix gone.
- `81738d29` "Split Electron legacy builds" (621 lines, adding Electron 39/40/41) **vanished entirely** — it has no counterpart on develop.

Only the C++ changes survived. The gap was invisible because the workflow file itself was the evidence anyone would check.

## Fix

Matrix restored from `fix/538-macos-architecture` (`829a5da4`), whose last full Build run ([`33481067697`](https://github.com/julianhille/MuhammaraJS/actions/runs/33481067697)) finished **499 jobs green**. Versions and Node mappings are copied verbatim rather than regenerated; unpublished `40.2.0` and `40.9.0` stay out.

The existing job is renamed `build-electron-legacy` and exposes its steps as a `&build-electron-steps` anchor; three new jobs reuse it, keeping each matrix under the 256-job cap:

| Job | Versions | Range | Jobs |
|---|---|---|---|
| `build-electron-legacy` | 18 | 36.0.0 – 38.1.0 | 72 |
| `build-electron-38-39` | 46 | 38.2.0 – 39.8.10 | 138 |
| `build-electron-40-41` | 58 | 40.0.0 – 41.10.7 | 174 |
| `build-electron` | 34 | 42.0.0 – 44.0.0 | 102 |

**GCC 11, not Clang.** `81dd68c5` "Use Clang for Linux Electron builds" was tried and reverted by `78347e3a` in favour of suppressing the V8 deprecation warnings in `binding.gyp`. That half already landed on develop and is byte-identical, so this is a workflow-only change — no C++ or gyp work.

**macOS x64 excluded from the three new jobs.** It is built and published today for 36.0–38.1 and stays that way. But macOS is the run's bottleneck — the baseline spent **21h25m** across 161 macOS jobs (30.5 min mean, vs 5.5 for ubuntu) — and covering x64 across all 156 versions would double that past the **24-hour queue timeout that silently cancels jobs**, i.e. a release missing prebuilds while still reporting green. This keeps macOS at 174 jobs, 8% over the proven run. This is also the likely original reason for `2048bcff` "Skip x64 Electron builds on macOS".

Totals: 486 Electron jobs — ubuntu 156, macOS 174, windows 156.

## Verification

- All four jobs' version lists and Node mappings verified set-equal to `829a5da4`.
- Anchor expands to 16 identical steps per job, GCC 11 throughout.
- `actionlint` clean — the only output is the 5 pre-existing `SC2086` infos that already occur on develop (same count before and after).
- Every matrix under the 256-job cap; largest is 174.
- All four jobs added to `publish`'s `needs`; artifact naming was already identical across jobs, so the `bindings-*` download glob is unchanged.

Watch for `build-electron (windows-2022, x64, 36.6.0)` — a pre-existing flake on develop (run `34282004590`), not a regression from this change.

## Docs

`installation.md` now distinguishes the coverage honestly: macOS x64 is listed as 36.0–38.1, everything else 36.0–44.0. The CHANGELOG claim sits in the released `7.0.0-beta.1` section, so that history is left intact and a Fixed entry is added under Unreleased instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
