### PR TITLE
Document native low-level exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Document native writer encryption, reader passwords, continuation state, and
+  previously undocumented public low-level exports
+  [#629](https://github.com/julianhille/MuhammaraJS/issues/629)
 - Support native Recipe `annot()` opacity and `comment()` replies, including
   TypeScript options, matching Wasm annotation dictionaries
   [#606](https://github.com/julianhille/MuhammaraJS/issues/606)

--- a/packages/native/docs/api/options-and-constants.md
+++ b/packages/native/docs/api/options-and-constants.md
@@ -2,12 +2,21 @@
 
 Writer, reader, modification, copying, image, text, and transformation options
 are declared in `muhammara.d.ts`. Public constants include PDF versions
-`ePDFVersion10` through `ePDFVersion17` plus `ePDFVersion20`, page-box
-constants, range constants, and PDF object-type constants.
+`ePDFVersion10` through `ePDFVersion17` plus `ePDFVersion20`, page-box and range
+constants, `ePDFObject*` type constants, and `ePDFPageContentItem*` page-mark
+types.
 
-Use the option descriptions on the corresponding guide pages rather than relying
-on unverified declaration fields. Known declaration gaps, including advanced TIFF
-options and parts of the Recipe API, are tracked in the documentation backlog.
+`LineCapStyle` provides `LINECAP_BUTT`, `LINECAP_ROUND`, and `LINECAP_SQUARE` for
+content contexts. `ETokenSeparator` provides `eTokenSeparatorSpace`,
+`eTokenSeparatorEndLine`, and `eTokenSeparatorNone` for low-level object-array
+writing. `EInfoTrappedTrue`, `EInfoTrappedFalse`, and `EInfoTrappedUnknown` set
+the Info dictionary's `trapped` field. `kProcsetPDF`, `kProcsetText`, and
+`KProcsetImageB`/`C`/`I` name PDF resource procsets. `eXrefEntryExisting`,
+`eXrefEntryDelete`, `eXrefEntryStreamObject`, and `eXrefEntryUndefined` describe
+xref entry types.
+
+`getTypeLabel(pdfObject.getType())` converts an `ePDFObject*` value into its
+readable label while inspecting raw PDF objects.
 
 ```javascript
 var writer = muhammara.createWriter("output.pdf", {

--- a/packages/native/docs/api/reader-and-objects.md
+++ b/packages/native/docs/api/reader-and-objects.md
@@ -3,6 +3,16 @@
 `muhammara.createReader(input, options)` returns a `PDFReader` for a file path
 or compatible random-access read stream.
 
+Pass `{ password: "..." }` as the options argument to open an encrypted PDF.
+Either its user or owner password is accepted. Call `isEncrypted()` after
+creation when the input may be encrypted:
+
+```javascript
+var reader = muhammara.createReader("encrypted.pdf", {
+  password: "open-password",
+});
+```
+
 The reader provides document information with `getPDFLevel`, `getPagesCount`,
 `getTrailer`, and `isEncrypted`; page access with `parsePage`,
 `parsePageDictionary`, and `getPageObjectID`; and object access with
@@ -51,3 +61,10 @@ reader.end();
 and object conversion.
 
 For a complete reader workflow, see [Read PDFs](../low-level/read-pdfs.md).
+
+`getXrefSize`, `getXrefPosition`, `getParserStream`,
+`startReadingFromStream`, `startReadingFromStreamForPlainCopying`,
+`startReadingObjectsFromStream`, and `startReadingObjectsFromStreams` expose
+raw parser internals for specialized low-level processing. They are not stable
+general-purpose reading workflows; use the page and object methods above unless
+you need to build a PDF parser integration.

--- a/packages/native/docs/api/writer.md
+++ b/packages/native/docs/api/writer.md
@@ -22,6 +22,34 @@ and `getEvents` for page and catalog write events. `createFormXObject` starts a
 reusable drawing form; finish it with `endFormXObject` before placement. Image
 and form creation must not occur while a page content context is active.
 
+## Continuation State
+
+`shutdown(restartStateFile)` saves an unfinished writer's state and closes it.
+Later, `createWriterToContinue(pdfPath, restartStateFile, options)` resumes that
+document. This path-based workflow is specific to the native package; it is not
+available in Wasm. `options.modifiedFilePath` writes the resumed output to a
+different path, and `options.log` configures writer logging.
+
+```javascript
+writer.shutdown("writer-state.txt");
+
+var resumedWriter = muhammara.createWriterToContinue(
+  "output.pdf",
+  "writer-state.txt",
+);
+```
+
+`InputFile` and `OutputFile` are native file wrappers returned by
+`getModifiedInputFile()` and `getOutputFile()` while modifying a PDF. They expose
+`openFile`, `closeFile`, the file path, and their synchronous byte stream; prefer
+`createReader`, `createWriter`, and the stream classes for normal application
+code. The continuation lifecycle is exercised in [`tests/ShutdownRestartTest.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/ShutdownRestartTest.js).
+
+`createPDFDate()` returns a mutable PDF date. Call `setToCurrentTime()` or use
+the initial value, then pass its `toString()` result to a PDF date field. The
+method is intended for low-level dictionary writing; Recipe metadata accepts
+JavaScript `Date` values directly.
+
 [`tests/EmptyPagesPDF.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/EmptyPagesPDF.js), [`tests/FormXObjectTest.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/FormXObjectTest.js), and
 [`tests/WriterEvents.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/WriterEvents.js) cover these lifecycles.
 

--- a/packages/native/docs/how-to/change-pdf-passwords.md
+++ b/packages/native/docs/how-to/change-pdf-passwords.md
@@ -16,6 +16,26 @@ muhammara.recrypt("input.pdf", "output.pdf", {
 To remove encryption, provide the input `password` without new output password
 options. File and stream scenarios are exercised in [`tests/Xcryption.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/Xcryption.js).
 
+## Encrypt A New PDF
+
+Pass `userPassword`, `ownerPassword`, and optionally `userProtectionFlag` to
+`createWriter` when creating an encrypted PDF. A user password opens the PDF;
+the owner password controls permission changes. `userProtectionFlag` is the PDF
+permission bit field passed to the encryption dictionary.
+
+```javascript
+var writer = muhammara.createWriter("encrypted.pdf", {
+  version: muhammara.ePDFVersion17,
+  userPassword: "open-password",
+  ownerPassword: "owner-password",
+  userProtectionFlag: 4,
+});
+```
+
+Use the same version rules below to choose the encryption algorithm. To open
+this document with a low-level reader, pass the user or owner password as the
+reader's `password` option.
+
 The tested workflows cover the library's current password and PDF-version
 options. The encryption algorithm is selected automatically from the PDF
 `version`; there is no separate algorithm option.

--- a/packages/native/docs/low-level/read-pdfs.md
+++ b/packages/native/docs/low-level/read-pdfs.md
@@ -12,6 +12,18 @@ console.log(reader.getPagesCount());
 reader.end();
 ```
 
+For an encrypted input, provide its user or owner password when creating the
+reader:
+
+```javascript
+var reader = muhammara.createReader("encrypted.pdf", {
+  password: "open-password",
+});
+```
+
+See [Change PDF Passwords](../how-to/change-pdf-passwords.md) to create,
+re-encrypt, or remove encryption.
+
 Call `end()` when the reader is no longer needed, after every object and stream
 parsed from it has been consumed. It closes the underlying file handle; skipping
 it leaves `input.pdf` locked on Windows, where the file then cannot be deleted


### PR DESCRIPTION
## Summary
- document native writer encryption and reader password options
- cover continuation state, file wrappers, PDF dates, constants, and advanced reader hooks
- keep Wasm-only restrictions cross-referenced rather than exposing native path APIs there

## Validation
- npm run test:codestyle
- npm run docs:check
- npm run docs:check --workspace=@muhammara/wasm
- npm run test:docs

Closes #629