### PR TITLE
Declare native Recipe call shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Document that native writer events have no WebAssembly equivalent
   [#624](https://github.com/julianhille/MuhammaraJS/issues/624)
+- Declare documented native Recipe metadata and call forms in TypeScript,
+  including font styles, overlay shortcuts, flowing text, and centered text and
+  images [#628](https://github.com/julianhille/MuhammaraJS/issues/628)
 - Build Linux prebuilds against the Debian archive now that Debian 11
   bullseye is end of life [#577](https://github.com/julianhille/MuhammaraJS/issues/577)
 - Force the packaged-source Electron rebuild check in CI to build from source.

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -972,6 +972,11 @@ declare namespace muhammara {
       | "Paragraph"
       | "Insert";
 
+    type RecipeCoordinate = number | "center";
+
+    type RecipeFontStyle =
+      "regular" | "bold" | "italic" | "bold-italic" | "r" | "b" | "i" | "bi";
+
     interface RecipeOptions {
       version?: number;
       author?: string;
@@ -1054,6 +1059,23 @@ declare namespace muhammara {
       keepAspectRatio?: boolean;
       fitWidth?: boolean;
       fitHeight?: boolean;
+    }
+
+    interface MetadataPage {
+      pageNumber: number;
+      mediaBox: number[];
+      layout: "portrait" | "landscape";
+      rotate: number;
+      width: number;
+      height: number;
+      size?: number[];
+      offsetX?: number;
+      offsetY?: number;
+    }
+
+    interface Metadata {
+      pages: number;
+      [page: number]: MetadataPage;
     }
 
     interface TextBoxStyle {
@@ -1179,6 +1201,8 @@ declare namespace muhammara {
     );
 
     readonly position: { x: number; y: number };
+    /** Metadata read from the source PDF, keyed by one-based page number. */
+    readonly metadata: Recipe.Metadata;
     read(inSrc?: string | Buffer): { pages: number; [page: number]: object };
     register(key: string, callback: Function): void;
     register(callback: Function & { name: string }): void;
@@ -1210,12 +1234,16 @@ declare namespace muhammara {
 
     encrypt(options?: Recipe.EncryptOptions): Recipe;
 
-    registerFont(fontName: string, fontSrcPath: string): Recipe;
+    registerFont(
+      fontName: string,
+      fontSrcPath: string,
+      type?: Recipe.RecipeFontStyle,
+    ): Recipe;
 
     image(
       imgSrc: string,
-      x: number,
-      y: number,
+      x: Recipe.RecipeCoordinate,
+      y: Recipe.RecipeCoordinate,
       options?: Recipe.ImageOptions,
     ): Recipe;
 
@@ -1229,6 +1257,7 @@ declare namespace muhammara {
       srcPageNumber: number,
     ): Recipe;
 
+    overlay(pdfSrc: string, options?: Recipe.OverlayOptions): Recipe;
     overlay(
       pdfSrc: string,
       x: number,
@@ -1272,10 +1301,11 @@ declare namespace muhammara {
     resumeContext(): void;
     split(outputDir?: string, prefix?: string): Recipe;
 
+    text(text: string, options?: Recipe.TextOptions): Recipe;
     text(
       text: string,
-      x: number,
-      y: number,
+      x: Recipe.RecipeCoordinate,
+      y: Recipe.RecipeCoordinate,
       options?: Recipe.TextOptions,
     ): Recipe;
     textDimensions(text: string, options?: Recipe.TextOptions): TextDimension;

--- a/packages/native-with-source/tests/types/types.test.ts
+++ b/packages/native-with-source/tests/types/types.test.ts
@@ -17,9 +17,18 @@ recipe
 recipe
   .text("Default size", 72, 72)
   .text("Explicit size", 72, 100, { size: 12 });
+recipe
+  .registerFont("body", "./fonts/body-bold.ttf", "bold")
+  .editPage(1)
+  .overlay("overlay.pdf")
+  .text("Flowing text", { layout: "article", flow: false })
+  .text("Centered text", "center", "center")
+  .image("photo.jpg", "center", "center");
 var textWidth: number = recipe.textDimensions("text").width;
 recipe.textDimensions("text", { size: 12 }).width;
+var pages: number = recipe.metadata.pages;
 void textWidth;
+void pages;
 
 var info: muhammara.Recipe.InfoOptions = {
   author: "A",

--- a/packages/native/docs/how-to/flow-text-into-columns.md
+++ b/packages/native/docs/how-to/flow-text-into-columns.md
@@ -20,6 +20,6 @@ pdfDoc
   });
 ```
 
-`layout()` and flowing-text forms are tested implementation behavior but are not
-fully declared in `muhammara.d.ts`. See [`tests/recipe/text-columns.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/text-columns.js) and
+`layout()` and flowing-text forms are tested implementation behavior. See
+[`tests/recipe/text-columns.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/text-columns.js) and
 [`tests/recipe/text-continued.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/text-continued.js).

--- a/packages/native/tests/types/types.test.ts
+++ b/packages/native/tests/types/types.test.ts
@@ -52,6 +52,14 @@ recipe.textDimensions("text", { size: 12 }).width;
 recipe
   .text("Default size", 72, 72)
   .text("Explicit size", 72, 100, { size: 12 });
+recipe
+  .registerFont("body", "./fonts/body-bold.ttf", "bold")
+  .editPage(1)
+  .overlay("overlay.pdf")
+  .text("Flowing text", { layout: "article", flow: false })
+  .text("Centered text", "center", "center")
+  .image("photo.jpg", "center", "center");
+var pages: number = recipe.metadata.pages;
 var coordinates: muhammara.Recipe | number[] = recipe.movedown(1, Boolean(1));
 recipe.structure("structure.json").endPDF();
 recipe
@@ -75,4 +83,5 @@ void callbackResult;
 void margins;
 void title;
 void textWidth;
+void pages;
 void coordinates;


### PR DESCRIPTION
## Summary
- declare the documented native Recipe metadata and call forms
- add strict type coverage for both published native packages
- correct the flowing-text guide now that the declaration matches runtime behavior

## Validation
- npm run native:test:types
- npm run native-with-source:test:types
- npm run test:codestyle
- npm run docs:check

Closes #628