### PR TITLE
Validate browser example documentation links

### DIFF
--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to `@muhammara/wasm` are documented in this file.
 
 ### Added
 
+- Add a MkDocs-validated guide index for browser examples
+  [#627](https://github.com/julianhille/MuhammaraJS/issues/627)
 - Add byte-first `recrypt()` and Recipe `encrypt()` with native-compatible
   password options, plus the password-change browser example
   [#595](https://github.com/julianhille/MuhammaraJS/issues/595)

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -45,6 +45,9 @@ var pdfBytes = muhammara.createBlankPdf(595, 842);
 `pdfBytes` is a standalone `Uint8Array` and can be passed to `Blob`, downloaded,
 or uploaded without depending on Emscripten memory after the call returns.
 
+See the [executable browser examples](docs/browser-examples.md) for interactive
+PDF creation and modification in a page or module Worker.
+
 All byte-taking APIs synchronously accept `Uint8Array` and `ArrayBuffer`. When
 hosted by Node, `Buffer` is incidentally accepted as a `Uint8Array` subclass;
 it is not a browser API or separate Wasm input contract. `Blob` and `File`

--- a/packages/wasm/docs/browser-examples.md
+++ b/packages/wasm/docs/browser-examples.md
@@ -1,0 +1,26 @@
+# Browser Examples
+
+The executable browser example creates PDFs on the page or in a module Worker.
+Build the package, run `npm run wasm:server:browser` from the repository root,
+and open <http://127.0.0.1:8080/>.
+
+## Focused Examples
+
+- [Add Review Annotations](how-to/add-review-annotations.md) creates markup,
+  comments, and replies.
+- [Add Clickable URL Links](how-to/add-url-links.md) adds link regions with
+  Recipe coordinates.
+- [Set Page Boxes](how-to/set-page-boxes.md) writes and visualizes page boxes.
+- [Draw a Grayscale Form XObject](low-level.md) creates a reusable low-level
+  form XObject and places it on a page.
+- [Add Content to Rotated Pages](how-to/add-content-to-rotated-pages.md) places
+  Recipe content and annotations on a rotated page.
+- [Place and Transform Images](how-to/place-and-transform-images.md) accepts a
+  JPEG, PNG, or TIFF upload.
+- [Create Multi-Page Tables](how-to/create-tables.md) accepts a TTF or OTF font
+  upload.
+- [Change PDF Passwords](how-to/change-pdf-passwords.md) encrypts a PDF and
+  creates a decrypted verification copy.
+
+See [Browser Setup](browser-setup.md) for loading the package and [Byte Assets,
+Blob, and File Input](byte-assets.md) for browser-safe assets.

--- a/packages/wasm/examples/browser/README.md
+++ b/packages/wasm/examples/browser/README.md
@@ -1,16 +1,6 @@
-# Executable Browser And Module Worker Example
+# Browser Example
 
-This dependency-free application exercises the public byte-first package from a
-browser page or module Worker. It creates a low-level PDF, parses it, modifies
-it, copies/appends/merges/embeds pages, builds and edits a Recipe composition,
-parses both final outputs, and exposes preview and download controls.
-
-The tabs keep that complete laboratory intact and add focused, runnable how-to
-examples for annotations, URL links, page boxes, rotated-page coordinates,
-image transformations, and tables. Each focused example generates and parses
-its own previewable PDF; only image transformations and tables require uploads.
-
-## Run It
+## Run Locally
 
 Build the package first, then serve the repository root. The existing static
 server supplies the correct JavaScript and WebAssembly MIME types:
@@ -21,70 +11,3 @@ npm run wasm:server:browser
 ```
 
 Open <http://127.0.0.1:8080/>.
-`module-options.mjs` deliberately supplies `locateFile`, resolving only the
-package's public `index.js` and generated `dist/muhammara-wasm.wasm` files. The
-workflow modules contain no repository fixture paths. When installed in another
-application, preserve that relationship or replace the two relative package
-URLs with your bundler's `@muhammara/wasm` import and emitted `.wasm` URL.
-
-The workflow is useful without uploads. Supplying a permissively licensed font
-and JPEG/PNG/TIFF files additionally exercises registered fonts, metrics,
-asynchronous `Blob`/`File` registration, image inspection, TIFF directory
-selection and TIFF color treatment. No example binaries are checked in; the
-automated test injects existing repository fixtures into these byte parameters.
-
-## Modules
-
-- `module-options.mjs`: asynchronous ESM loading and explicit `.wasm` location.
-- `low-level.mjs`: boxes, graphics/text state, paths, clipping, colors, forms,
-  images, metadata, links, annotations, raw streams, readers, modification,
-  copying contexts, append, merge, and PDF-page forms.
-- `recipe.mjs`: creation/editing, flowed HTML text, tables, shapes, metadata,
-  annotations, links, registered PDF composition, overlay, split, and inspection.
-- `workflow.mjs`: staged orchestration and parse-back results.
-- `example-worker.mjs`: structured progress/results/errors across a transferable
-  module Worker boundary.
-- `lifecycle.mjs`: cancellation checks, structured errors, and object-URL cleanup.
-- `app.mjs`: responsive UI, preview/download selection, and Worker termination.
-
-The matching guides explain the focused examples:
-
-- [annotations](https://muhammarajs-wasm.readthedocs.io/how-to/add-review-annotations/)
-- [links](https://muhammarajs-wasm.readthedocs.io/how-to/add-url-links/)
-- [page boxes](https://muhammarajs-wasm.readthedocs.io/how-to/set-page-boxes/)
-- [rotated pages](https://muhammarajs-wasm.readthedocs.io/how-to/add-content-to-rotated-pages/)
-- [image transformations](https://muhammarajs-wasm.readthedocs.io/how-to/place-and-transform-images/)
-- [tables](https://muhammarajs-wasm.readthedocs.io/how-to/create-tables/)
-
-Focused documentation: [browser setup](https://muhammarajs-wasm.readthedocs.io/browser-setup/),
-[byte and Blob/File assets](https://muhammarajs-wasm.readthedocs.io/byte-assets/),
-[low-level API](https://muhammarajs-wasm.readthedocs.io/low-level/),
-[Recipe](https://muhammarajs-wasm.readthedocs.io/recipe/),
-[restrictions](https://muhammarajs-wasm.readthedocs.io/differences/), and the
-[TypeScript reference](https://muhammarajs-wasm.readthedocs.io/reference/).
-
-## Resource And Trust Boundaries
-
-Keep input and output size limits appropriate to the application. PDF parsing,
-font loading, and image decoding can perform synchronous CPU and memory work;
-run untrusted documents in a terminable Worker rather than the main thread.
-This sample suggests 25 MB input and 50 MB output as illustrative UI guidance,
-not library-enforced limits.
-
-PDF 2.0/AES-256 encryption, continuation state files, filesystem paths, Node
-streams, plugins, and Node EventEmitter hooks are unsupported. The example uses
-`Uint8Array`, exact `ArrayBuffer` slices, `Blob`, and `File` inputs. It calls
-`end()` or `dispose()` for owners, unregisters assets, calls `disposeAssets()`,
-terminates Workers, and revokes replaced/final object URLs.
-
-## Automated Chrome Validation
-
-```sh
-npm run wasm:test:browser
-```
-
-The Chrome runner uses `puppeteer-core`, imports `workflow.mjs`, injects
-font/JPEG/PNG/TIFF fixtures as bytes, executes the complete workflow in both the
-page and module Worker validation contexts, asserts parse-back summaries, and
-checks object-URL replacement/disposal behavior. Set `CHROME_BIN` when Chrome is
-not discoverable by the runner.

--- a/packages/wasm/mkdocs.yml
+++ b/packages/wasm/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - Getting Started:
       - Browser Setup: browser-setup.md
       - Byte Assets, Blob, and File Input: byte-assets.md
+  - Browser Examples: browser-examples.md
   - High-Level Recipe: recipe.md
   - Low-Level API: low-level.md
   - API Reference: reference.md


### PR DESCRIPTION
## Summary
- move the browser example guide index into MkDocs-managed documentation
- include the missing grayscale form example in that index
- remove unvalidated deep documentation URLs from the shipped browser README

## Validation
- npm run docs:check --workspace=@muhammara/wasm
- npx prettier --check packages/wasm/CHANGELOG.md packages/wasm/docs/browser-examples.md packages/wasm/examples/browser/README.md packages/wasm/mkdocs.yml

Closes #627