### PR TITLE
Document Wasm package provenance

### DIFF
--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to `@muhammara/wasm` are documented in this file.
   [#618](https://github.com/julianhille/MuhammaraJS/issues/618)
 - Document Recipe `lineStyle()` option compatibility with native
   [#617](https://github.com/julianhille/MuhammaraJS/issues/617)
+- Add third-party notices and security, provenance, and contribution guidance
+  for the WebAssembly package [#626](https://github.com/julianhille/MuhammaraJS/issues/626)
 - Add byte-first `recrypt()` and Recipe `encrypt()` with native-compatible
   password options, plus the password-change browser example
   [#595](https://github.com/julianhille/MuhammaraJS/issues/595)

--- a/packages/wasm/THIRD_PARTY_NOTICES.md
+++ b/packages/wasm/THIRD_PARTY_NOTICES.md
@@ -1,4 +1,4 @@
-# Third-party notices
+# Third-Party Notices
 
 ## Roboto Regular
 
@@ -11,3 +11,88 @@
 
 Recipe uses this openly licensed face as its automatic default. No proprietary
 native font faces are included in the Wasm package.
+`@muhammara/wasm` statically links the following libraries from the vendored
+source tree at `packages/native-with-source/src/deps/`. OpenSSL is not linked
+into the WebAssembly target.
+
+| Library   | Version or baseline                                                    | License                          |
+| --------- | ---------------------------------------------------------------------- | -------------------------------- |
+| PDFWriter | [v4.9.0](https://github.com/galkahana/PDF-Writer/tree/v4.9.0) baseline | Apache License 2.0               |
+| FreeType  | 2.13.0                                                                 | FreeType License                 |
+| LibAesgm  | Brian Gladman AES snapshot, copyright 1998-2013                        | Brian Gladman permissive license |
+| LibJpeg   | IJG JPEG 9d                                                            | Independent JPEG Group license   |
+| LibPng    | 1.6.37                                                                 | libpng License                   |
+| LibTiff   | 4.6.0                                                                  | libtiff license                  |
+| Zlib      | 1.2.11                                                                 | zlib License                     |
+
+## PDFWriter
+
+Copyright 2011-2025 Gal Kahana and PDFWriter contributors.
+
+Licensed under the Apache License, Version 2.0. You may obtain a copy of the
+license at <https://www.apache.org/licenses/LICENSE-2.0>. Unless required by
+applicable law or agreed to in writing, software distributed under the license
+is distributed on an "AS IS" BASIS, without warranties or conditions of any
+kind, either express or implied.
+
+## FreeType
+
+Copyright 1996-2023 by David Turner, Robert Wilhelm, and Werner Lemberg.
+
+FreeType is distributed under the FreeType License, a BSD-style permissive
+license. The full license is available from the
+[FreeType project](https://freetype.org/license.html).
+
+## LibAesgm
+
+Copyright (c) 1998-2013, Brian Gladman, Worcester, UK. All rights reserved.
+
+Redistribution and use of this software, with or without changes, is allowed
+without payment of fees or royalties provided that source distributions retain
+this copyright notice, conditions, and disclaimer, and binary distributions
+include them in their documentation. This software is provided "as is" with no
+explicit or implied warranties, including correctness and fitness for purpose.
+
+## LibJpeg
+
+Copyright (C) 1991-1998, Thomas G. Lane. Modified 2002-2019 by Guido
+Vollbeding. This software is part of the Independent JPEG Group's software.
+
+The Independent JPEG Group license permits use, copying, modification, and
+distribution for any purpose, with these conditions: do not misrepresent the
+origin of the software; plainly mark altered source versions; and do not alter
+or remove this notice from source distributions. The software is provided
+"AS IS", without warranty of any kind.
+
+## LibPng
+
+Copyright (c) 1995-2019 The PNG Reference Library Authors, Cosmin Truta, Glenn
+Randers-Pehrson, Andreas Dilger, and Guy Eric Schalnat, Group 42, Inc.
+
+libpng is supplied "as is", without warranty of any kind. Permission is
+granted to use, copy, modify, and distribute it for any purpose without fee,
+provided that its origin is not misrepresented, altered versions are plainly
+marked, and its copyright notice is retained. See the
+[libpng License](http://www.libpng.org/pub/png/libpng-licenses.html).
+
+## LibTiff
+
+Copyright (c) 1988-1997 Sam Leffler. Copyright (c) 1991-1997 Silicon Graphics,
+Inc.
+
+Permission to use, copy, modify, distribute, and sell this software and its
+documentation for any purpose is granted without fee, provided that the above
+copyright notices and permission notice appear in all copies and related
+documentation. The names Sam Leffler and Silicon Graphics may not be used in
+advertising or publicity without prior written permission. The software is
+provided "AS-IS" without warranty of any kind.
+
+## Zlib
+
+Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler.
+
+zlib is provided "as-is", without any express or implied warranty. Permission
+is granted to use it for any purpose, including commercial applications, and to
+alter and redistribute it freely, provided that its origin is not
+misrepresented, altered source versions are plainly marked, and this notice is
+not removed or altered from source distributions.

--- a/packages/wasm/docs/contributing.md
+++ b/packages/wasm/docs/contributing.md
@@ -1,0 +1,51 @@
+# Contributing Documentation
+
+WebAssembly documentation changes use Markdown under `packages/wasm/docs/` and
+pass a strict package-local MkDocs build.
+
+## Local Preview
+
+The Python dependencies in `packages/wasm/docs/requirements.txt` are needed
+only when you want to preview or edit documentation. They are not required to
+install, build, or use `@muhammara/wasm`.
+
+To edit documentation, create and activate a Python virtual environment,
+install `packages/wasm/docs/requirements.txt`, then run:
+
+```sh
+python -m venv .docs-venv
+source .docs-venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r packages/wasm/docs/requirements.txt
+npm run docs:check --workspace=@muhammara/wasm
+mkdocs serve --config-file packages/wasm/mkdocs.yml
+```
+
+Open <http://127.0.0.1:8000/>. Run `npm run docs:check --workspace=@muhammara/wasm`
+before opening a pull request. The command generates `docs/reference.md` and
+writes the generated site to `packages/wasm/site/`; both are generated output
+and ignored by Git.
+
+## Examples
+
+Copyable browser examples belong in `packages/wasm/examples/browser/`. Add a
+focused test under `packages/wasm/tests/integration/` and register a browser
+workflow in `examples/browser/how-tos.mjs` when it is a common browser task.
+Do not document behavior based only on an untested snippet.
+
+## Self-Contained Examples
+
+Keep pages self-contained. Include the code required to explain a workflow
+rather than linking readers to implementation tests or source files. Small
+duplication is preferable to documentation that depends on a particular source
+revision.
+
+## Writing Rules
+
+- Clearly label Recipe as the high-level API and writer, reader, and modifier
+  APIs as low-level.
+- Document byte-first behavior, browser and Worker support, and platform
+  restrictions.
+- Use the package name `@muhammara/wasm` in new JavaScript examples.
+- Link to, but do not copy, issue and discussion content without explicit
+  permission and attribution review.

--- a/packages/wasm/docs/development.md
+++ b/packages/wasm/docs/development.md
@@ -67,3 +67,57 @@ Wasm documentation sources are package-local and are not published in the npm
 package. The standalone WebAssembly documentation site is configured by
 `packages/wasm/.readthedocs.yaml`; configure its Read the Docs project to use
 that file. Native documentation is maintained separately in `packages/native/docs/`.
+
+## Documentation
+
+Create a Python virtual environment and install the WebAssembly site's pinned
+documentation dependencies:
+
+```sh
+python -m venv .docs-venv
+source .docs-venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r packages/wasm/docs/requirements.txt
+```
+
+Build the site strictly before opening a pull request:
+
+```sh
+npm run docs:check --workspace=@muhammara/wasm
+```
+
+Serve a local preview with:
+
+```sh
+mkdocs serve --config-file packages/wasm/mkdocs.yml
+```
+
+Never commit generated `packages/wasm/docs/reference.md` or `packages/wasm/site/`
+output.
+
+## Release Tags
+
+WebAssembly package tags trigger validation and publication. The package version
+must match the version in the tag. Wasm releases use npm trusted publishing
+through GitHub Actions OIDC and do not require an npm token.
+
+Before the first Wasm release, configure an npm trusted publisher for
+`@muhammara/wasm` that trusts this repository's Wasm release workflow and
+release environment.
+
+```sh
+# WebAssembly release example.
+git tag wasm-v1.0.0
+git push origin wasm-v1.0.0
+```
+
+After successful publication, the workflow automatically creates a matching
+`wasm-doc-v<version>` documentation tag. A later documentation-only correction
+can be tagged without rebuilding or publishing the package:
+
+```sh
+git tag wasm-doc-v1.0.0.1
+git push origin wasm-doc-v1.0.0.1
+```
+
+Documentation tags trigger only the documentation workflow.

--- a/packages/wasm/docs/index.md
+++ b/packages/wasm/docs/index.md
@@ -4,6 +4,16 @@
 MuhammaraJS. It exposes a browser-safe, byte-first API instead of the native
 Node package's filesystem and stream API.
 
+## Documentation Versions
+
+`latest` tracks the `develop` branch and can include unreleased behavior. Each
+normal release tag has its own documentation version. After a release, its tag
+is made the default Read the Docs version while `latest` continues to track
+development.
+
+For current release history, read the
+[Wasm changelog on GitHub](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/wasm/CHANGELOG.md).
+
 ## Node.js Native Addon
 
 For Node.js applications that need filesystem paths, Node streams, or the full

--- a/packages/wasm/docs/provenance.md
+++ b/packages/wasm/docs/provenance.md
@@ -1,0 +1,15 @@
+# Documentation Sources
+
+| Source                         | Status                         | Use                                                                          |
+| ------------------------------ | ------------------------------ | ---------------------------------------------------------------------------- |
+| `packages/wasm/README.md`      | Primary package source         | Installation, browser setup, and compatibility source material.              |
+| `packages/wasm/CHANGELOG.md`   | Canonical for the Wasm package | Current WebAssembly release history.                                         |
+| `packages/wasm/lib/`           | Primary implementation source  | Public byte-first and Recipe behavior.                                       |
+| `packages/wasm/index.d.ts`     | Secondary source               | Public TypeScript surface to reconcile with implementation.                  |
+| `packages/wasm/tests/`         | Primary verification source    | Executable behavior and browser-example candidates.                          |
+| Native documentation and tests | Parity reference               | Equivalent behavior, where it does not depend on paths, streams, or OpenSSL. |
+| GitHub issues and discussions  | Reviewed backlog source        | Identify documentation needs; independently author and verify guides.        |
+
+Wasm documentation is authored from this repository's implementation and tests.
+Native documentation is a useful parity source, but the Wasm site documents its
+own byte-first API and its documented platform restrictions.

--- a/packages/wasm/docs/security.md
+++ b/packages/wasm/docs/security.md
@@ -1,0 +1,49 @@
+# Security And Vendored Dependencies
+
+MuhammaraJS compiles the WebAssembly target from vendored C and C++ source under
+`packages/native-with-source/src/deps/`. Those directories are not installed or
+kept current automatically by npm or another package manager. The versions
+below describe the source currently in this repository.
+
+## Vendor Inventory
+
+| Vendored directory | Upstream baseline                                                        | Source and tracking                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `PDFWriter`        | [PDF-Writer v4.9.0](https://github.com/galkahana/PDF-Writer/tree/v4.9.0) | [Source](https://github.com/galkahana/PDF-Writer) and [issues](https://github.com/galkahana/PDF-Writer/issues)         |
+| `FreeType`         | [2.13.0](https://github.com/freetype/freetype/tree/VER-2-13-0)           | [Source](https://github.com/freetype/freetype) and [issues](https://gitlab.freedesktop.org/freetype/freetype/-/issues) |
+| `LibAesgm`         | Unversioned Brian Gladman AES snapshot (copyright 1998-2013)             | [Source](https://github.com/BrianGladman/AES)                                                                          |
+| `LibJpeg`          | [IJG JPEG 9d](https://ijg.org/files/jpegsrc.v9d.tar.gz)                  | [Source](https://ijg.org/)                                                                                             |
+| `LibPng`           | [1.6.37](https://github.com/pnggroup/libpng/tree/v1.6.37)                | [Source](https://github.com/pnggroup/libpng) and [issues](https://github.com/pnggroup/libpng/issues)                   |
+| `LibTiff`          | [4.6.0](https://gitlab.com/libtiff/libtiff/-/tree/v4.6.0)                | [Source](https://gitlab.com/libtiff/libtiff) and [issues](https://gitlab.com/libtiff/libtiff/-/issues)                 |
+| `Zlib`             | [1.2.11](https://github.com/madler/zlib/tree/v1.2.11)                    | [Source](https://github.com/madler/zlib) and [issues](https://github.com/madler/zlib/issues)                           |
+
+The PDFWriter tag is the vendored tree's upstream baseline. MuhammaraJS carries
+changes on top of it, so `packages/native-with-source/src/deps/PDFWriter` is not
+necessarily byte-for-byte identical to that tag. The other version identifiers
+come from the vendored source headers; `LibAesgm` does not declare an upstream
+release version.
+
+The WebAssembly build deliberately does not link OpenSSL: browsers have no
+OpenSSL runtime, and OpenSSL-backed encryption is excluded from this target.
+
+## Reporting A Defect
+
+For a suspected defect in the PDF processing engine, first check the
+[PDF-Writer issue tracker](https://github.com/galkahana/PDF-Writer/issues) and
+report it upstream when it belongs there. Include a minimal input and expected
+behavior, and link the upstream report from the corresponding MuhammaraJS issue
+when the WebAssembly integration or local patches are relevant.
+
+Use the same approach for FreeType, libpng, libtiff, zlib, and the other
+vendored libraries: report a library defect to its upstream project where it
+can be maintained, and use a MuhammaraJS issue for effects specific to
+`@muhammara/wasm`.
+
+## Updating A Vendor
+
+An available newer upstream version is useful information. Open a MuhammaraJS
+issue requesting a dependency update when it includes a relevant security fix,
+bug fix, or compatibility improvement. Include the current inventory version,
+the proposed upstream version or immutable revision, the upstream release or
+advisory link, and any expected build or behavior impact. Maintainers can then
+evaluate, test, and review the vendor update independently.

--- a/packages/wasm/mkdocs.yml
+++ b/packages/wasm/mkdocs.yml
@@ -63,5 +63,9 @@ nav:
       - Place and Transform Images: how-to/place-and-transform-images.md
       - Set Page Boxes: how-to/set-page-boxes.md
   - Compatibility: differences.md
-  - Project: development.md
+  - Project:
+      - Development: development.md
+      - Security: security.md
+      - Documentation Sources: provenance.md
+      - Contributing Documentation: contributing.md
   - Breaking Changes: breaking-changes.md


### PR DESCRIPTION
## Summary
- add distributable third-party notices for the seven WebAssembly-linked vendored libraries
- document scoped Wasm security inventory, provenance, and contribution workflow
- add documentation version and Wasm release-tag guidance

## Validation
- npm run docs:check --workspace=@muhammara/wasm
- npm run test:codestyle
- git diff --check
- npm pack --workspace=@muhammara/wasm --ignore-scripts --dry-run --json

Closes #626