### PR TITLE
Correct native Recipe option types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Declare documented native Recipe metadata and call forms in TypeScript,
   including font styles, overlay shortcuts, flowing text, and centered text and
   images [#628](https://github.com/julianhille/MuhammaraJS/issues/628)
+- Correct native Recipe TypeScript declarations for text style and image transformation options [#625](https://github.com/julianhille/MuhammaraJS/issues/625)
 - Build Linux prebuilds against the Debian archive now that Debian 11
   bullseye is end of life [#577](https://github.com/julianhille/MuhammaraJS/issues/577)
 - Force the packaged-source Electron rebuild check in CI to build from source.

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -1041,6 +1041,10 @@ declare namespace muhammara {
       keepAspectRatio?: boolean;
       opacity?: number;
       align?: string;
+      rotation?: number;
+      rotationOrigin?: [number, number];
+      skewX?: number;
+      skewY?: number;
     }
 
     interface InfoOptions {
@@ -1120,8 +1124,12 @@ declare namespace muhammara {
       rotation?: number;
       rotationOrigin?: [number, number];
       font?: string;
+      /** Font size in points for text() and textDimensions(); defaults to 14 when both fontSize and size are omitted. */
+      fontSize?: number;
       /** Font size in points for text() and textDimensions(); defaults to 14. */
       size?: number;
+      bold?: boolean;
+      italic?: boolean;
       align?: string;
       highlight?: boolean;
       underline?: boolean;

--- a/packages/native-with-source/tests/types/types.test.ts
+++ b/packages/native-with-source/tests/types/types.test.ts
@@ -24,6 +24,18 @@ recipe
   .text("Flowing text", { layout: "article", flow: false })
   .text("Centered text", "center", "center")
   .image("photo.jpg", "center", "center");
+recipe
+  .text("Explicit styled size", 72, 100, {
+    fontSize: 12,
+    bold: true,
+    italic: true,
+  })
+  .image("image.png", 72, 128, {
+    rotation: 45,
+    rotationOrigin: [72, 128],
+    skewX: 10,
+    skewY: 5,
+  });
 var textWidth: number = recipe.textDimensions("text").width;
 recipe.textDimensions("text", { size: 12 }).width;
 var pages: number = recipe.metadata.pages;

--- a/packages/native/tests/types/types.test.ts
+++ b/packages/native/tests/types/types.test.ts
@@ -60,6 +60,18 @@ recipe
   .text("Centered text", "center", "center")
   .image("photo.jpg", "center", "center");
 var pages: number = recipe.metadata.pages;
+recipe
+  .text("Explicit styled size", 72, 100, {
+    fontSize: 12,
+    bold: true,
+    italic: true,
+  })
+  .image("image.png", 72, 128, {
+    rotation: 45,
+    rotationOrigin: [72, 128],
+    skewX: 10,
+    skewY: 5,
+  });
 var coordinates: muhammara.Recipe | number[] = recipe.movedown(1, Boolean(1));
 recipe.structure("structure.json").endPDF();
 recipe


### PR DESCRIPTION
## Summary
- declare native Recipe text style and font size options
- declare native Recipe image transformation options
- cover the declarations in both native type suites

## Testing
- npm run native:test:types
- npm run native-with-source:test:types
- npm run test:codestyle

Closes #625