### PR TITLE
Add Wasm Recipe replaceText

### DIFF
--- a/packages/native-core/lib/recipe/replaceText.js
+++ b/packages/native-core/lib/recipe/replaceText.js
@@ -10,13 +10,14 @@ function escapePDFLiteralString(value) {
  * @memberof Recipe#
  * @param {string} text Text to replace.
  * @param {string} replacement Replacement text.
- * @param {number} [pageNumber=1] One-based page number.
+ * @param {number} pageNumber One-based page number.
  */
 exports.replaceText = function replaceText(text, replacement, pageNumber) {
-  pageNumber = pageNumber || 1;
-
   if (typeof text !== "string" || typeof replacement !== "string") {
     throw new TypeError("replaceText expects text and replacement strings");
+  }
+  if (!Number.isInteger(pageNumber) || pageNumber < 1) {
+    throw new TypeError("replaceText expects a positive integer page number");
   }
 
   var pageIndex = pageNumber - 1;

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -1296,7 +1296,7 @@ declare namespace muhammara {
 
     editPage(pageNumber: number): Recipe;
 
-    replaceText(text: string, replacement: string, pageNumber?: number): Recipe;
+    replaceText(text: string, replacement: string, pageNumber: number): Recipe;
 
     pageInfo(pageNumber: number): {
       width: number;

--- a/packages/native-with-source/docs/tests/modify-pdfs.js
+++ b/packages/native-with-source/docs/tests/modify-pdfs.js
@@ -134,7 +134,9 @@ describe("Documentation examples", function () {
     var outputPath = path.join(outputDirectory, "replaced-text.pdf");
     var Recipe = require("@muhammara/native").Recipe;
 
-    new Recipe(sourcePath, outputPath).replaceText("Before", "After").endPDF();
+    new Recipe(sourcePath, outputPath)
+      .replaceText("Before", "After", 1)
+      .endPDF();
 
     var reader = muhammara.createReader(outputPath);
     var text = reader.extractPageText(0);

--- a/packages/native-with-source/tests/recipe/replaceText.js
+++ b/packages/native-with-source/tests/recipe/replaceText.js
@@ -25,7 +25,14 @@ describe("Replace text", function () {
     writer.writePage(page);
     writer.end();
 
-    new Recipe(source, output).replaceText("Before", "After").endPDF();
+    var recipe = new Recipe(source, output);
+    expect(() => recipe.replaceText("Before", "After")).to.throw(
+      "replaceText expects a positive integer page number",
+    );
+    expect(() => recipe.replaceText("Before", "After", 0)).to.throw(
+      "replaceText expects a positive integer page number",
+    );
+    recipe.replaceText("Before", "After", 1).endPDF();
 
     var reader = muhammara.createReader(output);
     var text = reader.extractPageText(0);

--- a/packages/native-with-source/tests/types/types.test.ts
+++ b/packages/native-with-source/tests/types/types.test.ts
@@ -56,3 +56,6 @@ var pageBox: muhammara.PDFPageBoxType = muhammara.ePDFPageBoxCropBox;
 recipe.setPageBox(pageBox, 10, 20, 585, 822);
 recipe.setPageBox(muhammara.ePDFPageBoxMediaBox, 0, 0, 595, 842);
 void pageBox;
+recipe.replaceText("Before", "After", 1);
+// @ts-expect-error replaceText requires a one-based page number.
+recipe.replaceText("Before", "After");

--- a/packages/native/docs/recipe/modify-and-inspect.md
+++ b/packages/native/docs/recipe/modify-and-inspect.md
@@ -26,10 +26,12 @@ pdfDoc.structure("pdf-structure.txt").endPDF();
 
 `replaceText(text, replacement, pageNumber)` rewrites literal text-showing
 operands in a page's content stream, leaving the surrounding text position and
-font untouched. `pageNumber` is one-based and defaults to the first page.
+font untouched. `pageNumber` is a required one-based page number.
 
 ```javascript
-new Recipe("input.pdf", "output.pdf").replaceText("Before", "After").endPDF();
+new Recipe("input.pdf", "output.pdf")
+  .replaceText("Before", "After", 1)
+  .endPDF();
 ```
 
 The match is on the literal string as it appears in the content stream, so text

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to `@muhammara/wasm` are documented in this file.
   or `defaultFont: false` skip the font download, as does the low-level API.
   Make font uploads optional in the browser table example
   [#613](https://github.com/julianhille/MuhammaraJS/issues/613)
+- Add Recipe `replaceText()` for replacing literal text in a page content stream
+  [#622](https://github.com/julianhille/MuhammaraJS/issues/622)
 - Add byte-first `recrypt()` and Recipe `encrypt()` with native-compatible
   password options, plus the password-change browser example
   [#595](https://github.com/julianhille/MuhammaraJS/issues/595)

--- a/packages/wasm/docs/recipe.md
+++ b/packages/wasm/docs/recipe.md
@@ -118,10 +118,10 @@ JavaScript bundle.
 `replaceText(text, replacement, pageNumber)` rewrites literal text-showing
 operands in an existing page's content stream, leaving the surrounding text
 position and font untouched. Construct Recipe with the source `Uint8Array`;
-`pageNumber` is one-based and defaults to the first page.
+`pageNumber` is a required one-based page number.
 
 ```js
-var output = new Recipe(inputBytes).replaceText("Before", "After").endPDF();
+var output = new Recipe(inputBytes).replaceText("Before", "After", 1).endPDF();
 ```
 
 The match is on the literal string as it appears in the content stream, so text

--- a/packages/wasm/docs/recipe.md
+++ b/packages/wasm/docs/recipe.md
@@ -113,6 +113,23 @@ The separate module is fetched on demand with native ESM or a code-splitting
 bundler. Preserve dynamic-import splitting to keep its data out of your main
 JavaScript bundle.
 
+## Replace Literal Text
+
+`replaceText(text, replacement, pageNumber)` rewrites literal text-showing
+operands in an existing page's content stream, leaving the surrounding text
+position and font untouched. Construct Recipe with the source `Uint8Array`;
+`pageNumber` is one-based and defaults to the first page.
+
+```js
+var output = new Recipe(inputBytes).replaceText("Before", "After").endPDF();
+```
+
+The match is on the literal string as it appears in the content stream, so text
+split across several show operations, or encoded through a font that does not
+map to the source characters, is not replaced. Pages with more than one content
+stream are rejected with an error. When nothing matches, the page is left
+unchanged.
+
 ## PDF Version
 
 `version` sets the PDF level written into the byte output. Recipe accepts the

--- a/packages/wasm/examples/browser/how-tos.mjs
+++ b/packages/wasm/examples/browser/how-tos.mjs
@@ -527,7 +527,7 @@ async function replaceTextExample(assets) {
       .ET();
     writer.writePage(page);
     recipe = new Recipe(writer.end());
-    var bytes = recipe.replaceText("Before", "After").endPDF();
+    var bytes = recipe.replaceText("Before", "After", 1).endPDF();
     var reader = muhammara.createReader(bytes);
     var text = reader.extractPageText(0);
     reader.end();

--- a/packages/wasm/examples/browser/how-tos.mjs
+++ b/packages/wasm/examples/browser/how-tos.mjs
@@ -67,6 +67,15 @@ export var HOW_TO_EXAMPLES = [
       "Encrypt a byte-first Recipe PDF, then decrypt a verification copy with recrypt.",
     assets: [],
   },
+  {
+    id: "replace-text",
+    label: "Replace text",
+    title: "Replace literal page text",
+    description:
+      "Create a source page, replace its literal text operand, and verify the original placement survives.",
+    assets: ["font"],
+    requirement: "Requires a TTF or OTF font upload.",
+  },
 ];
 
 function assertAsset(value, message) {
@@ -497,6 +506,48 @@ async function passwordsExample() {
   }
 }
 
+async function replaceTextExample(assets) {
+  assertAsset(
+    assets.font,
+    "Choose a TTF or OTF font before running the text replacement example",
+  );
+  var muhammara = await createMuhammaraWasm();
+  var Recipe = await createRecipe();
+  var recipe;
+  try {
+    muhammara.registerFont("replace-text-font", assets.font);
+    var writer = muhammara.createWriter({ compress: false });
+    var page = writer.createPage(0, 0, 595, 300);
+    writer
+      .startPageContentContext(page)
+      .BT()
+      .Tf(writer.getFontForBytes("replace-text-font"), 24)
+      .Tm(1, 0, 0, 1, 72, 180)
+      .Tj("Before")
+      .ET();
+    writer.writePage(page);
+    recipe = new Recipe(writer.end());
+    var bytes = recipe.replaceText("Before", "After").endPDF();
+    var reader = muhammara.createReader(bytes);
+    var text = reader.extractPageText(0);
+    reader.end();
+    return {
+      bytes,
+      filename: "muhammara-replace-text.pdf",
+      summary: await summarize(bytes, {
+        howTo: "Replace literal page text",
+        replacement: text[0]?.content,
+        textMatrix: text[0]?.textMatrix,
+      }),
+    };
+  } finally {
+    recipe?.dispose();
+    muhammara.unregisterFont("replace-text-font");
+    muhammara.disposeAssets();
+    Recipe.disposeAssets();
+  }
+}
+
 var runners = {
   annotations: annotationsExample,
   links: linksExample,
@@ -506,6 +557,7 @@ var runners = {
   "image-transform": imageTransformExample,
   table: tableExample,
   passwords: passwordsExample,
+  "replace-text": replaceTextExample,
 };
 
 export async function runHowToExample(id, options = {}) {

--- a/packages/wasm/examples/browser/index.html
+++ b/packages/wasm/examples/browser/index.html
@@ -98,6 +98,15 @@
         >
           Passwords
         </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected="false"
+          tabindex="-1"
+          data-example="replace-text"
+        >
+          Replace text
+        </button>
       </div>
     </nav>
     <main>

--- a/packages/wasm/index.d.ts
+++ b/packages/wasm/index.d.ts
@@ -300,6 +300,8 @@ export interface Recipe {
   ): Promise<{ pages: number; [page: number]: RecipePageInfo }>;
   /** Starts a prepend-safe editing context for an existing one-based page number. */
   editPage(pageNumber: number): this;
+  /** Replaces literal `(...) Tj` operands in an existing page's single content stream. */
+  replaceText(text: string, replacement: string, pageNumber?: number): this;
   pauseContext(): this;
   resumeContext(): this;
   setPageBox(

--- a/packages/wasm/index.d.ts
+++ b/packages/wasm/index.d.ts
@@ -301,7 +301,7 @@ export interface Recipe {
   /** Starts a prepend-safe editing context for an existing one-based page number. */
   editPage(pageNumber: number): this;
   /** Replaces literal `(...) Tj` operands in an existing page's single content stream. */
-  replaceText(text: string, replacement: string, pageNumber?: number): this;
+  replaceText(text: string, replacement: string, pageNumber: number): this;
   pauseContext(): this;
   resumeContext(): this;
   setPageBox(

--- a/packages/wasm/lib/recipe.js
+++ b/packages/wasm/lib/recipe.js
@@ -24,6 +24,7 @@ import { createInfoMethods } from "./recipe/info.js";
 import { createInspectPdf } from "./recipe/inspection.js";
 import { createRegistrationMethods } from "./recipe/registration.js";
 import { createSecurityMethods, permission } from "./recipe/security.js";
+import { createReplaceTextMethods } from "./recipe/replace-text.js";
 import { standardInfoKeys } from "./recipe-info.js";
 
 /** Creates the high-level Recipe PDF composition factory. */
@@ -424,6 +425,7 @@ export function createRecipeFactory({
     createAnnotationMethods({ module, withString, withDoubles, colorValue }),
     createInfoMethods({ call, withString }),
     createSecurityMethods(),
+    createReplaceTextMethods(encoder),
   );
 
   // Composition modules receive closures rather than reaching into Recipe state.

--- a/packages/wasm/lib/recipe/replace-text.js
+++ b/packages/wasm/lib/recipe/replace-text.js
@@ -18,13 +18,17 @@ export function createReplaceTextMethods(encoder) {
      *
      * @param {string} text Text to replace.
      * @param {string} replacement Replacement text.
-     * @param {number} [pageNumber=1] One-based page number.
+     * @param {number} pageNumber One-based page number.
      * @returns {this}
      */
     replaceText: function (text, replacement, pageNumber) {
-      pageNumber = pageNumber || 1;
       if (typeof text !== "string" || typeof replacement !== "string") {
         throw new TypeError("replaceText expects text and replacement strings");
+      }
+      if (!Number.isInteger(pageNumber) || pageNumber < 1) {
+        throw new TypeError(
+          "replaceText expects a positive integer page number",
+        );
       }
 
       var parser = this.writer.getModifiedFileParser();

--- a/packages/wasm/lib/recipe/replace-text.js
+++ b/packages/wasm/lib/recipe/replace-text.js
@@ -1,0 +1,78 @@
+function escapePDFLiteralString(value) {
+  return value.replace(/([\\()])/g, "\\$1");
+}
+
+function oneByteString(bytes) {
+  var result = "";
+  for (var offset = 0; offset < bytes.length; offset += 0x8000) {
+    result += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+  }
+  return result;
+}
+
+/** Creates literal page-content text replacement methods. */
+export function createReplaceTextMethods(encoder) {
+  return {
+    /**
+     * Replaces literal text-showing operands in a page's single content stream.
+     *
+     * @param {string} text Text to replace.
+     * @param {string} replacement Replacement text.
+     * @param {number} [pageNumber=1] One-based page number.
+     * @returns {this}
+     */
+    replaceText: function (text, replacement, pageNumber) {
+      pageNumber = pageNumber || 1;
+      if (typeof text !== "string" || typeof replacement !== "string") {
+        throw new TypeError("replaceText expects text and replacement strings");
+      }
+
+      var parser = this.writer.getModifiedFileParser();
+      var contentsObjectId;
+      var source = "";
+      try {
+        var page = parser
+          .parsePage(pageNumber - 1)
+          .getDictionary()
+          .toPDFDictionary();
+        var contents = page.exists("Contents")
+          ? page.queryObject("Contents")
+          : null;
+        var reference = contents?.toPDFIndirectObjectReference();
+        if (!reference) {
+          throw new Error("replaceText supports pages with one content stream");
+        }
+        contentsObjectId = reference.getObjectID();
+        var stream = parser.parseNewObject(contentsObjectId).toPDFStream();
+        var streamReader = parser.startReadingFromStream(stream);
+        while (streamReader.notEnded()) {
+          source += oneByteString(new Uint8Array(streamReader.read(65536)));
+        }
+      } finally {
+        parser.end();
+      }
+
+      var textPattern = new RegExp(
+        "\\(" + escapePDFLiteralString(text) + "\\)(\\s+Tj\\b)",
+        "g",
+      );
+      var replaced = source.replace(
+        textPattern,
+        "(" + escapePDFLiteralString(replacement) + ")$1",
+      );
+      if (replaced === source) return this;
+
+      var objectsContext = this.writer.getObjectsContext();
+      var replacementObjectId = objectsContext.startNewIndirectObject();
+      var replacementStream = objectsContext.startUnfilteredPDFStream();
+      replacementStream.getWriteStream().write(encoder.encode(replaced));
+      objectsContext.endPDFStream(replacementStream).endIndirectObject();
+      this.writer.replaceObject(
+        pageNumber - 1,
+        contentsObjectId,
+        replacementObjectId,
+      );
+      return this;
+    },
+  };
+}

--- a/packages/wasm/tests/browser/run.mjs
+++ b/packages/wasm/tests/browser/run.mjs
@@ -147,6 +147,7 @@ try {
       "image-transform",
       "table",
       "passwords",
+      "replace-text",
     ];
     if (tabIds.join(",") !== expectedTabIds.join(",")) {
       throw new Error(`Unexpected example tabs: ${tabIds.join(", ")}`);

--- a/packages/wasm/tests/integration/BrowserExamples.test.mjs
+++ b/packages/wasm/tests/integration/BrowserExamples.test.mjs
@@ -42,6 +42,7 @@ describe("Browser how-to examples", function () {
         "image-transform",
         "table",
         "passwords",
+        "replace-text",
       ],
     );
   });

--- a/packages/wasm/tests/recipe/replaceText.test.mjs
+++ b/packages/wasm/tests/recipe/replaceText.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { createMuhammaraWasm, createRecipe } from "../../index.js";
+
+describe("Replace text", function () {
+  it("replaces text at its existing position", async function () {
+    var muhammara = await createMuhammaraWasm();
+    var fontBytes = new Uint8Array(
+      await readFile(
+        new URL(
+          "../../../native-with-source/tests/TestMaterials/fonts/arial.ttf",
+          import.meta.url,
+        ),
+      ),
+    );
+    muhammara.registerFont("replace-text-font", fontBytes);
+    var writer = muhammara.createWriter();
+    var page = writer.createPage(0, 0, 200, 200);
+    writer
+      .startPageContentContext(page)
+      .BT()
+      .Tf(writer.getFontForBytes("replace-text-font"), 12)
+      .Tm(1, 0, 0, 1, 20, 30)
+      .Tj("Before")
+      .ET();
+    writer.writePage(page);
+    var source = writer.end();
+
+    var Recipe = await createRecipe();
+    var output = new Recipe(source).replaceText("Before", "After").endPDF();
+    var reader = muhammara.createReader(output);
+    var text = reader.extractPageText(0);
+
+    assert.equal(text.length, 1);
+    assert.equal(text[0].content, "After");
+    assert.deepEqual(text[0].textMatrix, [1, 0, 0, 1, 20, 30]);
+    reader.end();
+    muhammara.unregisterFont("replace-text-font");
+    muhammara.disposeAssets();
+  });
+
+  it("matches native validation for arguments and page content streams", async function () {
+    var Recipe = await createRecipe();
+    assert.throws(
+      () => new Recipe().replaceText("Before", 1),
+      /replaceText expects text and replacement strings/,
+    );
+
+    var source = new Recipe().createPage(100, 100).endPage().endPDF();
+    assert.throws(
+      () => new Recipe(source).replaceText("Before", "After"),
+      /replaceText supports pages with one content stream/,
+    );
+  });
+});

--- a/packages/wasm/tests/recipe/replaceText.test.mjs
+++ b/packages/wasm/tests/recipe/replaceText.test.mjs
@@ -27,7 +27,7 @@ describe("Replace text", function () {
     var source = writer.end();
 
     var Recipe = await createRecipe();
-    var output = new Recipe(source).replaceText("Before", "After").endPDF();
+    var output = new Recipe(source).replaceText("Before", "After", 1).endPDF();
     var reader = muhammara.createReader(output);
     var text = reader.extractPageText(0);
 
@@ -46,9 +46,18 @@ describe("Replace text", function () {
       /replaceText expects text and replacement strings/,
     );
 
+    assert.throws(
+      () => new Recipe().replaceText("Before", "After"),
+      /replaceText expects a positive integer page number/,
+    );
+    assert.throws(
+      () => new Recipe().replaceText("Before", "After", 0),
+      /replaceText expects a positive integer page number/,
+    );
+
     var source = new Recipe().createPage(100, 100).endPage().endPDF();
     assert.throws(
-      () => new Recipe(source).replaceText("Before", "After"),
+      () => new Recipe(source).replaceText("Before", "After", 1),
       /replaceText supports pages with one content stream/,
     );
   });

--- a/packages/wasm/tests/types/types.test.ts
+++ b/packages/wasm/tests/types/types.test.ts
@@ -397,6 +397,7 @@ async function usesLowLevelSurface() {
   recipe.pageInfo(1)?.mediaBox[3];
   recipe.endPage().endPDF();
   var byteRecipe = new Recipe(source, { compress: false });
+  byteRecipe.replaceText("Before", "After");
   byteRecipe.getPageInfo();
   byteRecipe.getCurrentPageInfo()?.rotate;
   byteRecipe.editPage(1).pauseContext().resumeContext().endPage().endPDF();

--- a/packages/wasm/tests/types/types.test.ts
+++ b/packages/wasm/tests/types/types.test.ts
@@ -397,6 +397,8 @@ async function usesLowLevelSurface() {
   recipe.pageInfo(1)?.mediaBox[3];
   recipe.endPage().endPDF();
   var byteRecipe = new Recipe(source, { compress: false });
+  byteRecipe.replaceText("Before", "After", 1);
+  // @ts-expect-error replaceText requires a one-based page number.
   byteRecipe.replaceText("Before", "After");
   byteRecipe.getPageInfo();
   byteRecipe.getCurrentPageInfo()?.rotate;


### PR DESCRIPTION
## Summary
- Port `Recipe.replaceText()` to the byte-first Wasm modifier using existing reader, raw-object, and page-reference replacement primitives.
- Add Recipe types, literal-stream caveat documentation, regression coverage, and a font-backed browser example.
- Add the Wasm changelog entry.

## Testing
- `npm run wasm:test`
- `npm run wasm:test:types`
- `npx mocha packages/native-with-source/tests/recipe/replaceText.js --timeout 30000`
- `npm run docs:check --workspace=@muhammara/wasm`
- `npm run wasm:test:exports`
- `npm run wasm:test:paths`
- `npm run test:codestyle`

Closes #622