### PR TITLE
Add native Recipe current page info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `Recipe.rotate()` to set `/Rotate` on the current native Recipe page,
   including pages created with explicit dimensions, matching Wasm Recipe
   [#620](https://github.com/julianhille/MuhammaraJS/issues/620)
+- Add `Recipe.getCurrentPageInfo()` for the geometry of the active native
+  Recipe page, matching the Wasm API
+  [#621](https://github.com/julianhille/MuhammaraJS/issues/621)
 - Support native Recipe `annot()` opacity and `comment()` replies, including
   TypeScript options, matching Wasm annotation dictionaries
   [#606](https://github.com/julianhille/MuhammaraJS/issues/606)

--- a/packages/native-core/lib/recipe/page.js
+++ b/packages/native-core/lib/recipe/page.js
@@ -266,7 +266,7 @@ exports._resumePageRotation = function _resumePageRotation(
  * @function
  * @memberof Recipe#
  * @param {number} pageNumber - The page number.
- * @returns {{width: number, height: number, rotate: number, pageNumber: number}} The page information.
+ * @returns {RecipePageInfo} The page information.
  */
 exports.pageInfo = function pageInfo(pageNumber) {
   const pageInfo = this.metadata[pageNumber];
@@ -276,6 +276,19 @@ exports.pageInfo = function pageInfo(pageNumber) {
     rotate: pageInfo.rotate,
     pageNumber,
   };
+};
+
+/**
+ * Get information about the current page.
+ * @name getCurrentPageInfo
+ * @function
+ * @memberof Recipe#
+ * @returns {RecipePageInfo|null} The current page information, or null when no page has been created or edited.
+ */
+exports.getCurrentPageInfo = function getCurrentPageInfo() {
+  const pageNumber =
+    this.pageNumber || this.metadata?.pageCount || this.metadata?.pages;
+  return pageNumber ? this.pageInfo(pageNumber) : null;
 };
 
 /**

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -910,6 +910,13 @@ declare namespace muhammara {
     scope?: "global";
   }
 
+  export interface RecipePageInfo {
+    width: number;
+    height: number;
+    rotate: number;
+    pageNumber: number;
+  }
+
   namespace Recipe {
     type CommentOptionsFlag =
       | "invisible"
@@ -1298,12 +1305,8 @@ declare namespace muhammara {
 
     replaceText(text: string, replacement: string, pageNumber: number): Recipe;
 
-    pageInfo(pageNumber: number): {
-      width: number;
-      height: number;
-      rotate: number;
-      pageNumber: number;
-    };
+    pageInfo(pageNumber: number): RecipePageInfo;
+    getCurrentPageInfo(): RecipePageInfo | null;
 
     margins(): Required<Recipe.RecipeMargins>;
     margins(margins: Recipe.RecipeMargins): Recipe;

--- a/packages/native-with-source/tests/recipe/create.js
+++ b/packages/native-with-source/tests/recipe/create.js
@@ -4,6 +4,29 @@ const muhammara = require("@muhammara/native-with-source");
 const assert = require("chai").assert;
 
 describe("Create", () => {
+  it("reports active page geometry", (done) => {
+    const output = path.join(__dirname, "../output/current-page-info.pdf");
+    const recipe = new Recipe("new", output);
+
+    assert.equal(recipe.getCurrentPageInfo(), null);
+    recipe.createPage("letter", 90);
+    assert.deepEqual(recipe.getCurrentPageInfo(), recipe.pageInfo(1));
+    recipe.endPage();
+    assert.deepEqual(recipe.getCurrentPageInfo(), recipe.pageInfo(1));
+    recipe.endPDF(() => {
+      const modifiedOutput = path.join(
+        __dirname,
+        "../output/current-page-info-modified.pdf",
+      );
+      const sourceRecipe = new Recipe(output, modifiedOutput);
+      assert.deepEqual(
+        sourceRecipe.getCurrentPageInfo(),
+        sourceRecipe.pageInfo(1),
+      );
+      sourceRecipe.endPDF(done);
+    });
+  });
+
   it("blank pdf", (done) => {
     const output = path.join(__dirname, "../output/blank.pdf");
     const recipe = new Recipe("new", output, {

--- a/packages/native-with-source/tests/recipe/prototype.js
+++ b/packages/native-with-source/tests/recipe/prototype.js
@@ -70,6 +70,7 @@ describe("Recipe prototype", function () {
       "fill",
       "fillAndStroke",
       "fillOpacity",
+      "getCurrentPageInfo",
       "getPageInfo",
       "htmlToTextObjects",
       "image",

--- a/packages/native-with-source/tests/types/types.test.ts
+++ b/packages/native-with-source/tests/types/types.test.ts
@@ -42,6 +42,13 @@ var pages: number = recipe.metadata.pages;
 recipe.createPage(595, 842).rotate(90).endPage();
 void textWidth;
 void pages;
+var currentPageInfo = recipe.getCurrentPageInfo();
+var pageInfo: muhammara.RecipePageInfo = recipe.pageInfo(1);
+currentPageInfo?.width;
+currentPageInfo?.height;
+currentPageInfo?.rotate;
+currentPageInfo?.pageNumber;
+pageInfo.width;
 
 var info: muhammara.Recipe.InfoOptions = {
   author: "A",

--- a/packages/native/docs/recipe/modify-and-inspect.md
+++ b/packages/native/docs/recipe/modify-and-inspect.md
@@ -15,8 +15,10 @@ pdfDoc
   .endPDF();
 ```
 
-Use `pageInfo(pageNumber)` to inspect a page. To write a textual PDF structure,
-call `structure` on the Recipe instance:
+Use `pageInfo(pageNumber)` to inspect page geometry, or
+`getCurrentPageInfo()` while editing the active page. `getPageInfo()` has a
+similar name but returns document Info metadata, not page geometry. To write a
+textual PDF structure, call `structure` on the Recipe instance:
 
 ```javascript
 pdfDoc.structure("pdf-structure.txt").endPDF();

--- a/packages/native/docs/recipe/pages-and-positioning.md
+++ b/packages/native/docs/recipe/pages-and-positioning.md
@@ -14,10 +14,13 @@ The second argument for a named page is rotation. A 90- or 270-degree rotation
 swaps its width and height. `rotate(degrees)` sets the PDF `/Rotate` value on
 the current page, including a page created with an explicit width and height.
 When both are used on a named page, `rotate()` is the last rotation setting and
-wins; the named size's swapped dimensions remain unchanged. Use
-`pageInfo(pageNumber)` before adding size-dependent content to an existing
-page. Rectangles use a top-left anchor; circles and ellipses use center
-coordinates. `rotationOrigin` selects the point used for transformations.
+wins; the named size's swapped dimensions remain unchanged. `pageInfo(pageNumber)`
+returns page geometry for a specific one-based page. Inside a `createPage()` or
+`editPage()` block, `getCurrentPageInfo()` returns that same geometry for the
+active page, including after `endPage()`. Despite its similar name,
+`getPageInfo()` returns document Info metadata, not page geometry. Rectangles
+use a top-left anchor; circles and ellipses use center coordinates.
+`rotationOrigin` selects the point used for transformations.
 
 See [`tests/recipe/create.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/create.js), [`tests/recipe/positioning.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/positioning.js), and
 [`tests/recipe/rotation.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/rotation.js).

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to `@muhammara/wasm` are documented in this file.
   [#613](https://github.com/julianhille/MuhammaraJS/issues/613)
 - Add Recipe `replaceText()` for replacing literal text in a page content stream
   [#622](https://github.com/julianhille/MuhammaraJS/issues/622)
+- Document that Recipe `getPageInfo()` returns document Info metadata, while
+  `pageInfo()` and `getCurrentPageInfo()` return page geometry
+  [#621](https://github.com/julianhille/MuhammaraJS/issues/621)
 - Add byte-first `recrypt()` and Recipe `encrypt()` with native-compatible
   password options, plus the password-change browser example
   [#595](https://github.com/julianhille/MuhammaraJS/issues/595)

--- a/packages/wasm/docs/recipe.md
+++ b/packages/wasm/docs/recipe.md
@@ -31,6 +31,10 @@ The rotation argument to `createPage("letter", 90)` swaps named-page dimensions;
 `rotate(degrees)` sets `/Rotate` on the current page, including explicitly sized
 pages. When both are used, `rotate()` is the last rotation setting and wins,
 while the named size's swapped dimensions remain unchanged.
+`pageInfo(pageNumber)` returns page geometry for a specific one-based page, and
+`getCurrentPageInfo()` returns the same geometry for the active page.
+`getPageInfo()` has a similar name but returns document Info metadata, not page
+geometry.
 
 Recipe `text()` and `textDimensions()` default to 14 points when both `size`
 and `fontSize` are omitted, matching native Recipe. Pass `{ size: 12 }` (or

--- a/packages/wasm/tests/recipe/create.test.mjs
+++ b/packages/wasm/tests/recipe/create.test.mjs
@@ -78,4 +78,21 @@ describe("Recipe create", function () {
     assert.equal(explicit.pageInfo(1).height, 200);
     assert.equal(explicit.read(explicit.endPage().endPDF())[1].rotate, 90);
   });
+
+  it("reports active page geometry", function () {
+    var recipe = new Recipe();
+
+    assert.equal(recipe.getCurrentPageInfo(), null);
+    recipe.createPage("letter", 90);
+    assert.deepEqual(recipe.getCurrentPageInfo(), recipe.pageInfo(1));
+    recipe.endPage();
+    assert.deepEqual(recipe.getCurrentPageInfo(), recipe.pageInfo(1));
+    var bytes = recipe.endPDF();
+    var sourceRecipe = new Recipe(bytes);
+    assert.deepEqual(
+      sourceRecipe.getCurrentPageInfo(),
+      sourceRecipe.pageInfo(1),
+    );
+    sourceRecipe.endPDF();
+  });
 });

--- a/packages/wasm/tests/types/types.test.ts
+++ b/packages/wasm/tests/types/types.test.ts
@@ -1,5 +1,5 @@
 import { createMuhammaraWasm, createRecipe } from "../../index.js";
-import type { PDFPageContentItemType } from "../../index.js";
+import type { PDFPageContentItemType, RecipePageInfo } from "../../index.js";
 import { PDFPage } from "../../index.js";
 
 // @ts-expect-error PDFPage is available only from a loaded runtime instance.
@@ -395,6 +395,9 @@ async function usesLowLevelSurface() {
   recipe.textDimensions("text", { fontSize: 12 }).width;
   void textWidth;
   recipe.pageInfo(1)?.mediaBox[3];
+  var pageInfo: RecipePageInfo | null = recipe.pageInfo(1);
+  pageInfo?.width;
+  recipe.getCurrentPageInfo()?.mediaBox[3];
   recipe.endPage().endPDF();
   var byteRecipe = new Recipe(source, { compress: false });
   byteRecipe.replaceText("Before", "After", 1);


### PR DESCRIPTION
## Summary

- add native `Recipe.getCurrentPageInfo()` with Wasm-matched current-page semantics
- cover new, completed, and source-backed pages on both implementations
- document the distinction between page geometry and document Info metadata

## Validation

- `npx mocha packages/native-with-source/tests/recipe/create.js --timeout 15000`
- `npm run wasm:test`
- `npm run native:test:types && npm run native-with-source:test:types && npm run wasm:test:types`
- `npm run test:codestyle`
- `npm run docs:check`
- `npm run docs:check --workspace=@muhammara/wasm`

Closes #621