### PR TITLE
Add native Recipe rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Link native package READMEs and previously orphaned executable examples to
   their documentation, and document pnpm 10 installation approval
   [#630](https://github.com/julianhille/MuhammaraJS/issues/630)
+- Add `Recipe.rotate()` to set `/Rotate` on the current native Recipe page,
+  including pages created with explicit dimensions, matching Wasm Recipe
+  [#620](https://github.com/julianhille/MuhammaraJS/issues/620)
 - Support native Recipe `annot()` opacity and `comment()` replies, including
   TypeScript options, matching Wasm annotation dictionaries
   [#606](https://github.com/julianhille/MuhammaraJS/issues/606)

--- a/packages/native-core/lib/recipe/page.js
+++ b/packages/native-core/lib/recipe/page.js
@@ -77,6 +77,20 @@ exports.createPage = function createPage(pageWidth, pageHeight, margins) {
 };
 
 /**
+ * Set the rotation of the current page.
+ * @name rotate
+ * @function
+ * @memberof Recipe#
+ * @param {number} rotation - The page rotation in degrees.
+ * @returns {Recipe} The recipe instance.
+ */
+exports.rotate = function rotate(rotation) {
+  this.page.rotate = rotation;
+  this.metadata[this.pageNumber].rotate = rotation;
+  return this;
+};
+
+/**
  * Set a page box on the active new page.
  * @name setPageBox
  * @function

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -1284,6 +1284,7 @@ declare namespace muhammara {
       rotation?: number,
       margins?: Recipe.RecipeMargins,
     ): Recipe;
+    rotate(rotation: number): Recipe;
     endPage(): Recipe;
     setPageBox(
       box: PDFPageBoxType,

--- a/packages/native-with-source/tests/recipe/create.js
+++ b/packages/native-with-source/tests/recipe/create.js
@@ -1,5 +1,7 @@
 const path = require("path");
 const Recipe = require("@muhammara/native-with-source").Recipe;
+const muhammara = require("@muhammara/native-with-source");
+const assert = require("chai").assert;
 
 describe("Create", () => {
   it("blank pdf", (done) => {
@@ -107,5 +109,48 @@ describe("Create", () => {
       })
       .endPage()
       .endPDF(done);
+  });
+
+  it("tracks current-page rotation for named and explicit sizes", () => {
+    const namedOutput = path.join(__dirname, "../output/rotate-named.pdf");
+    const named = new Recipe("new", namedOutput)
+      .createPage("letter", 90)
+      .rotate(180)
+      .endPage();
+    assert.deepEqual(named.pageInfo(1), {
+      width: 792,
+      height: 612,
+      rotate: 180,
+      pageNumber: 1,
+    });
+    named.endPDF();
+
+    const explicitOutput = path.join(
+      __dirname,
+      "../output/rotate-explicit.pdf",
+    );
+    const explicit = new Recipe("new", explicitOutput)
+      .createPage(100, 200)
+      .rotate(90)
+      .endPage();
+    assert.deepEqual(explicit.pageInfo(1), {
+      width: 100,
+      height: 200,
+      rotate: 90,
+      pageNumber: 1,
+    });
+    explicit.endPDF();
+
+    [
+      [namedOutput, 180],
+      [explicitOutput, 90],
+    ].forEach(([output, rotation]) => {
+      const reader = muhammara.createReader(output);
+      try {
+        assert.equal(reader.parsePage(0).getRotate(), rotation);
+      } finally {
+        reader.end();
+      }
+    });
   });
 });

--- a/packages/native-with-source/tests/recipe/create.js
+++ b/packages/native-with-source/tests/recipe/create.js
@@ -114,13 +114,13 @@ describe("Create", () => {
   it("tracks current-page rotation for named and explicit sizes", () => {
     const namedOutput = path.join(__dirname, "../output/rotate-named.pdf");
     const named = new Recipe("new", namedOutput)
-      .createPage("letter", 90)
-      .rotate(180)
+      .createPage("letter")
+      .rotate(90)
       .endPage();
     assert.deepEqual(named.pageInfo(1), {
-      width: 792,
-      height: 612,
-      rotate: 180,
+      width: 612,
+      height: 792,
+      rotate: 90,
       pageNumber: 1,
     });
     named.endPDF();
@@ -142,7 +142,7 @@ describe("Create", () => {
     explicit.endPDF();
 
     [
-      [namedOutput, 180],
+      [namedOutput, 90],
       [explicitOutput, 90],
     ].forEach(([output, rotation]) => {
       const reader = muhammara.createReader(output);

--- a/packages/native-with-source/tests/recipe/prototype.js
+++ b/packages/native-with-source/tests/recipe/prototype.js
@@ -97,6 +97,7 @@ describe("Recipe prototype", function () {
       "registerFont",
       "replaceText",
       "resumeContext",
+      "rotate",
       "setPageBox",
       "split",
       "star",

--- a/packages/native-with-source/tests/types/types.test.ts
+++ b/packages/native-with-source/tests/types/types.test.ts
@@ -39,6 +39,7 @@ recipe
 var textWidth: number = recipe.textDimensions("text").width;
 recipe.textDimensions("text", { size: 12 }).width;
 var pages: number = recipe.metadata.pages;
+recipe.createPage(595, 842).rotate(90).endPage();
 void textWidth;
 void pages;
 

--- a/packages/native/docs/recipe/pages-and-positioning.md
+++ b/packages/native/docs/recipe/pages-and-positioning.md
@@ -11,10 +11,13 @@ pdfDoc
 ```
 
 The second argument for a named page is rotation. A 90- or 270-degree rotation
-swaps its width and height. Use `pageInfo(pageNumber)` before adding
-size-dependent content to an existing page. Rectangles use a top-left anchor;
-circles and ellipses use center coordinates. `rotationOrigin` selects the point
-used for transformations.
+swaps its width and height. `rotate(degrees)` sets the PDF `/Rotate` value on
+the current page, including a page created with an explicit width and height.
+When both are used on a named page, `rotate()` is the last rotation setting and
+wins; the named size's swapped dimensions remain unchanged. Use
+`pageInfo(pageNumber)` before adding size-dependent content to an existing
+page. Rectangles use a top-left anchor; circles and ellipses use center
+coordinates. `rotationOrigin` selects the point used for transformations.
 
 See [`tests/recipe/create.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/create.js), [`tests/recipe/positioning.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/positioning.js), and
 [`tests/recipe/rotation.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/rotation.js).

--- a/packages/native/tests/types/types.test.ts
+++ b/packages/native/tests/types/types.test.ts
@@ -48,6 +48,7 @@ recipe.createPage(595, 842, { left: 36 }).margins({ top: 36 });
 var pageBox: muhammara.PDFPageBoxType = muhammara.ePDFPageBoxCropBox;
 recipe.setPageBox(pageBox, 10, 20, 585, 822);
 recipe.setPageBox(muhammara.ePDFPageBoxMediaBox, 0, 0, 595, 842);
+recipe.rotate(90).endPage();
 var margins: Required<muhammara.Recipe.RecipeMargins> = recipe.margins();
 var title: string = recipe.getPageInfo().title;
 var textWidth: number = recipe.textDimensions("text").width;

--- a/packages/wasm/docs/recipe.md
+++ b/packages/wasm/docs/recipe.md
@@ -27,6 +27,10 @@ the Recipe output state. `endPDF()` is idempotent and returns the same cached
 Recipe provides pages, text, shapes, images, tables, composition, annotations,
 metadata, and byte-safe splitting. `setPageBox()` uses PDF bottom-left
 coordinates even though the high-level drawing API uses top-left coordinates.
+The rotation argument to `createPage("letter", 90)` swaps named-page dimensions;
+`rotate(degrees)` sets `/Rotate` on the current page, including explicitly sized
+pages. When both are used, `rotate()` is the last rotation setting and wins,
+while the named size's swapped dimensions remain unchanged.
 
 Recipe `text()` and `textDimensions()` default to 14 points when both `size`
 and `fontSize` are omitted, matching native Recipe. Pass `{ size: 12 }` (or

--- a/packages/wasm/tests/recipe/create.test.mjs
+++ b/packages/wasm/tests/recipe/create.test.mjs
@@ -58,19 +58,19 @@ describe("Recipe create", function () {
   });
 
   it("tracks current-page rotation for named and explicit sizes", function () {
-    var named = new Recipe().createPage("letter", 90).rotate(180);
+    var named = new Recipe().createPage("letter").rotate(90);
     assert.deepEqual(named.pageInfo(1), {
       pageNumber: 1,
-      mediaBox: [0, 0, 792, 612],
-      rotate: 180,
-      width: 792,
-      height: 612,
-      layout: "landscape",
+      mediaBox: [0, 0, 612, 792],
+      rotate: 90,
+      width: 612,
+      height: 792,
+      layout: "portrait",
       size: [612, 792],
       offsetX: 0,
       offsetY: 0,
     });
-    assert.equal(named.read(named.endPage().endPDF())[1].rotate, 180);
+    assert.equal(named.read(named.endPage().endPDF())[1].rotate, 90);
 
     var explicit = new Recipe().createPage(100, 200).rotate(90);
     assert.equal(explicit.getCurrentPageInfo().rotate, 90);

--- a/packages/wasm/tests/recipe/create.test.mjs
+++ b/packages/wasm/tests/recipe/create.test.mjs
@@ -56,4 +56,26 @@ describe("Recipe create", function () {
     recipe.rotate(90).endPage().endPDF();
     assert.equal(recipe.getCurrentPageInfo().rotate, 90);
   });
+
+  it("tracks current-page rotation for named and explicit sizes", function () {
+    var named = new Recipe().createPage("letter", 90).rotate(180);
+    assert.deepEqual(named.pageInfo(1), {
+      pageNumber: 1,
+      mediaBox: [0, 0, 792, 612],
+      rotate: 180,
+      width: 792,
+      height: 612,
+      layout: "landscape",
+      size: [612, 792],
+      offsetX: 0,
+      offsetY: 0,
+    });
+    assert.equal(named.read(named.endPage().endPDF())[1].rotate, 180);
+
+    var explicit = new Recipe().createPage(100, 200).rotate(90);
+    assert.equal(explicit.getCurrentPageInfo().rotate, 90);
+    assert.equal(explicit.pageInfo(1).width, 100);
+    assert.equal(explicit.pageInfo(1).height, 200);
+    assert.equal(explicit.read(explicit.endPage().endPDF())[1].rotate, 90);
+  });
 });


### PR DESCRIPTION
## Summary
- add native `Recipe.rotate()` with current-page metadata tracking
- cover named and explicit page sizes on native and Wasm
- document that `rotate()` wins over named-size rotation settings

## Validation
- `npx mocha packages/native-with-source/tests/recipe/create.js --timeout 15000`
- `node scripts/run-mocha.mjs tests/recipe/create.test.mjs`
- `npm run native:test:types`
- `npm run native-with-source:test:types`
- `npm run wasm:test:types`
- `npm run test:codestyle`
- `npm run docs:check`
- `npm run docs:check --workspace=@muhammara/wasm`

Closes #620