### PR TITLE
Add native Recipe rotateContent parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `Recipe.rotate()` to set `/Rotate` on the current native Recipe page,
   including pages created with explicit dimensions, matching Wasm Recipe
   [#620](https://github.com/julianhille/MuhammaraJS/issues/620)
+- Add native Recipe `rotateContent()` for rotating subsequent drawing around a
+  point, matching Wasm [#616](https://github.com/julianhille/MuhammaraJS/issues/616)
 - Add native Recipe `pie()` for closed, fillable arc wedges, matching Wasm
   [#615](https://github.com/julianhille/MuhammaraJS/issues/615)
 - Add `Recipe.getCurrentPageInfo()` for the geometry of the active native

--- a/packages/native-core/lib/recipe/graphics-state.js
+++ b/packages/native-core/lib/recipe/graphics-state.js
@@ -1,0 +1,20 @@
+/**
+ * Rotate subsequent content around a point in Recipe coordinates.
+ * @name rotateContent
+ * @function
+ * @memberof Recipe#
+ * @param {number} degrees - Clockwise rotation in degrees.
+ * @param {number} [x=0] - Rotation origin x coordinate.
+ * @param {number} [y=0] - Rotation origin y coordinate.
+ * @returns {Recipe} The recipe instance.
+ */
+exports.rotateContent = function rotateContent(degrees, x = 0, y = 0) {
+  const radians = (degrees * Math.PI) / 180;
+  const cosine = Math.cos(radians);
+  const sine = Math.sin(radians);
+  const point = this._calibrateCoordinate(x, y);
+  this.pageContext.cm(1, 0, 0, 1, point.nx, point.ny);
+  this.pageContext.cm(cosine, sine, -sine, cosine, 0, 0);
+  this.pageContext.cm(1, 0, 0, 1, -point.nx, -point.ny);
+  return this;
+};

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -1344,6 +1344,7 @@ declare namespace muhammara {
     getPageInfo(): InfoDictionary;
     pauseContext(): void;
     resumeContext(): void;
+    rotateContent(degrees: number, x?: number, y?: number): Recipe;
     split(outputDir?: string, prefix?: string): Recipe;
 
     text(text: string, options?: Recipe.TextOptions): Recipe;

--- a/packages/native-with-source/tests/recipe/graphics-state.js
+++ b/packages/native-with-source/tests/recipe/graphics-state.js
@@ -1,0 +1,51 @@
+const assert = require("chai").assert;
+const muhammara = require("@muhammara/native-with-source");
+const Recipe = muhammara.Recipe;
+
+describe("Recipe graphics state", () => {
+  it("rotates subsequent content around a Recipe coordinate", (done) => {
+    const recipe = new Recipe(Buffer.from("new"), null, { compress: false });
+    recipe
+      .createPage(200, 300)
+      .rotateContent(90, 30, 40)
+      .rectangle(0, 0, 10, 10, { fill: "#000000" })
+      .endPage()
+      .endPDF((bytes) => {
+        const reader = muhammara.createReader(
+          new muhammara.PDFRStreamForBuffer(bytes),
+        );
+        const page = reader.parsePage(0).getDictionary();
+        const contents = reader.queryDictionaryObject(page, "Contents");
+        const contentObjects =
+          contents.getType() === muhammara.ePDFObjectArray
+            ? Array.from(
+                { length: contents.toPDFArray().getLength() },
+                (_, index) => contents.toPDFArray().queryObject(index),
+              )
+            : [contents];
+        const content = contentObjects
+          .map((contentObject) => {
+            if (
+              contentObject.getType() ===
+              muhammara.ePDFObjectIndirectObjectReference
+            ) {
+              contentObject = reader.parseNewObject(
+                contentObject.toPDFIndirectObjectReference().getObjectID(),
+              );
+            }
+            const stream = reader.startReadingFromStream(
+              contentObject.toPDFStream(),
+            );
+            const chunks = [];
+            while (stream.notEnded())
+              chunks.push(Buffer.from(stream.read(4096)));
+            return Buffer.concat(chunks).toString("latin1");
+          })
+          .join("");
+        reader.end();
+        assert.match(content, /1 0 0 1 30 260 cm/);
+        assert.match(content, /0 1 -1 0 0 0 cm/);
+        done();
+      });
+  });
+});

--- a/packages/native-with-source/tests/recipe/prototype.js
+++ b/packages/native-with-source/tests/recipe/prototype.js
@@ -103,6 +103,7 @@ describe("Recipe prototype", function () {
       "replaceText",
       "resumeContext",
       "rotate",
+      "rotateContent",
       "setPageBox",
       "split",
       "star",

--- a/packages/native-with-source/tests/types/types.test.ts
+++ b/packages/native-with-source/tests/types/types.test.ts
@@ -73,6 +73,7 @@ void pageBox;
 recipe.replaceText("Before", "After", 1);
 // @ts-expect-error replaceText requires a one-based page number.
 recipe.replaceText("Before", "After");
+recipe.rotateContent(45, 10, 20);
 recipe.lineStyle({
   width: 1,
   lineWidth: 2,

--- a/packages/native/docs/recipe/pages-and-positioning.md
+++ b/packages/native/docs/recipe/pages-and-positioning.md
@@ -22,5 +22,8 @@ active page, including after `endPage()`. Despite its similar name,
 use a top-left anchor; circles and ellipses use center coordinates.
 `rotationOrigin` selects the point used for transformations.
 
+`rotateContent(degrees, x, y)` rotates subsequent drawing around a point in
+Recipe's top-left coordinates.
+
 See [`tests/recipe/create.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/create.js), [`tests/recipe/positioning.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/positioning.js), and
 [`tests/recipe/rotation.js`](https://github.com/julianhille/MuhammaraJS/blob/develop/packages/native-with-source/tests/recipe/rotation.js).

--- a/packages/wasm/docs/recipe.md
+++ b/packages/wasm/docs/recipe.md
@@ -139,6 +139,9 @@ map to the source characters, is not replaced. Pages with more than one content
 stream are rejected with an error. When nothing matches, the page is left
 unchanged.
 
+`rotateContent(degrees, x, y)` rotates subsequent drawing around a point in
+Recipe's top-left coordinates.
+
 Use `lineStyle({ width, lineWidth, cap, join, miterLimit, dash, dashPhase })`
 to set PDF stroke style operators for the current page context. `lineWidth` is
 an alias for `width`; omitted properties leave the existing style unchanged:

--- a/packages/wasm/tests/recipe/graphics-state.test.mjs
+++ b/packages/wasm/tests/recipe/graphics-state.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { createRecipe } from "../../index.js";
+
+describe("Recipe graphics state", function () {
+  it("rotates subsequent content around a Recipe coordinate", async function () {
+    var Recipe = await createRecipe();
+    var bytes = new Recipe({ compress: false })
+      .createPage(200, 300)
+      .rotateContent(90, 30, 40)
+      .rectangle(0, 0, 10, 10, { fill: "#000000" })
+      .endPage()
+      .endPDF();
+    var content = new TextDecoder().decode(bytes);
+    assert.match(content, /1 0 0 1 30 260 cm/);
+    assert.match(content, /0 1 -1 0 0 0 cm/);
+  });
+});


### PR DESCRIPTION
## Summary
- add native Recipe `rotateContent(degrees, x, y)` matching Wasm coordinate behavior
- cover generated transforms in mirrored native and Wasm Recipe tests plus strict native types
- document the established Recipe convenience in both package guides

## Validation
- `npx mocha packages/native-with-source/tests/recipe/graphics-state.js --timeout 15000`
- `npx mocha packages/wasm/tests/recipe/graphics-state.test.mjs --timeout 15000`
- `npm run native:test:types && npm run native-with-source:test:types && npm run wasm:test:types`
- `npm run docs:generate`
- `npm run docs:generate --workspace=@muhammara/wasm`

Closes #616