### PR TITLE
Add Recipe URL links for areas, text, images, and drawings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add Recipe URL links for arbitrary areas, rendered text, images, and drawing
+  bounds [#614](https://github.com/julianhille/MuhammaraJS/issues/614)
 - Document native writer encryption, reader passwords, continuation state, and
   previously undocumented public low-level exports
   [#629](https://github.com/julianhille/MuhammaraJS/issues/629)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [#618](https://github.com/julianhille/MuhammaraJS/issues/618)
 - Add native Recipe `lineStyle()` with Wasm-compatible width, cap, join, miter,
   and dash options [#617](https://github.com/julianhille/MuhammaraJS/issues/617)
+- Add native Recipe `link()` with the top-left coordinate signature already
+  available in Wasm [#614](https://github.com/julianhille/MuhammaraJS/issues/614)
 - Support native Recipe `annot()` opacity and `comment()` replies, including
   TypeScript options, matching Wasm annotation dictionaries
   [#606](https://github.com/julianhille/MuhammaraJS/issues/606)

--- a/packages/native-core/lib/recipe/annotation.js
+++ b/packages/native-core/lib/recipe/annotation.js
@@ -39,14 +39,18 @@ exports.comment = function comment(text = "", x, y, options = {}) {
  */
 exports.link = function link(url, x, y, width, height) {
   const { nx, ny } = this._calibrateCoordinate(x, y, 0, -height);
+  return this._linkPdf(url, nx, ny, width, height);
+};
+
+exports._linkPdf = function _linkPdf(url, left, bottom, width, height) {
   this.pauseContext();
   try {
     this.writer.attachURLLinktoCurrentPage(
       url,
-      nx,
-      ny,
-      nx + width,
-      ny + height,
+      left,
+      bottom,
+      left + width,
+      bottom + height,
     );
   } finally {
     this.resumeContext();

--- a/packages/native-core/lib/recipe/annotation.js
+++ b/packages/native-core/lib/recipe/annotation.js
@@ -26,6 +26,35 @@ exports.comment = function comment(text = "", x, y, options = {}) {
 };
 
 /**
+ * Add a clickable URL link to the current page.
+ * @name link
+ * @function
+ * @memberof Recipe#
+ * @param {string} url - The URL to open.
+ * @param {number} x - The top-left x coordinate.
+ * @param {number} y - The top-left y coordinate.
+ * @param {number} width - The link width.
+ * @param {number} height - The link height.
+ * @returns {Recipe} The recipe instance.
+ */
+exports.link = function link(url, x, y, width, height) {
+  const { nx, ny } = this._calibrateCoordinate(x, y, 0, -height);
+  this.pauseContext();
+  try {
+    this.writer.attachURLLinktoCurrentPage(
+      url,
+      nx,
+      ny,
+      nx + width,
+      ny + height,
+    );
+  } finally {
+    this.resumeContext();
+  }
+  return this;
+};
+
+/**
  * Create an annotation
  * @name annot
  * @function

--- a/packages/native-core/lib/recipe/annotation.js
+++ b/packages/native-core/lib/recipe/annotation.js
@@ -39,13 +39,13 @@ exports.comment = function comment(text = "", x, y, options = {}) {
  */
 exports.link = function link(url, x, y, width, height) {
   const { nx, ny } = this._calibrateCoordinate(x, y, 0, -height);
-  return this._linkPdf(url, nx, ny, width, height);
+  return linkPdf(this, url, nx, ny, width, height);
 };
 
-exports._linkPdf = function _linkPdf(url, left, bottom, width, height) {
-  this.pauseContext();
+function linkPdf(recipe, url, left, bottom, width, height) {
+  recipe.pauseContext();
   try {
-    this.writer.attachURLLinktoCurrentPage(
+    recipe.writer.attachURLLinktoCurrentPage(
       url,
       left,
       bottom,
@@ -53,10 +53,12 @@ exports._linkPdf = function _linkPdf(url, left, bottom, width, height) {
       bottom + height,
     );
   } finally {
-    this.resumeContext();
+    recipe.resumeContext();
   }
-  return this;
-};
+  return recipe;
+}
+
+Object.defineProperty(exports, "linkPdf", { value: linkPdf });
 
 /**
  * Create an annotation

--- a/packages/native-core/lib/recipe/image.js
+++ b/packages/native-core/lib/recipe/image.js
@@ -58,6 +58,10 @@ exports.image = function image(imgSrc, x, y, options = {}) {
     ctx.gs(xObject.getGsName(gsId)).drawImage(0, 0, imgSrc, imgOptions);
   });
 
+  if (options.link) {
+    this.link(options.link, x + offsetX, y + offsetY + height, width, height);
+  }
+
   return this;
 };
 

--- a/packages/native-core/lib/recipe/image.js
+++ b/packages/native-core/lib/recipe/image.js
@@ -59,7 +59,7 @@ exports.image = function image(imgSrc, x, y, options = {}) {
   });
 
   if (options.link) {
-    this.link(options.link, x + offsetX, y + offsetY + height, width, height);
+    this.link(options.link, x + offsetX, y - offsetY - height, width, height);
   }
 
   return this;

--- a/packages/native-core/lib/recipe/shapes.js
+++ b/packages/native-core/lib/recipe/shapes.js
@@ -155,7 +155,10 @@ exports.n_gon = function n_gon(cx, cy, radius, sides = 3, options = {}) {
 
   const ngon = _n_gon(sides, cx, cy, radius, options);
 
-  this.polygon(ngon, options);
+  const drawOptions = Object.assign({}, options, { link: undefined });
+  this.polygon(ngon, drawOptions);
+  if (options.link)
+    this.link(options.link, cx - radius, cy - radius, radius * 2, radius * 2);
 
   if (options.rotationVertice) {
     delete options["rotationOrigin"]; // cleanup n-gon generated point
@@ -220,6 +223,7 @@ exports.star = function star(cx, cy, radius, points = 5, options = {}) {
   }
 
   const starOptions = Object.assign({}, options);
+  delete starOptions.link;
 
   if (odd(points)) {
     starPath = _oddStar(_n_gon(points, cx, cy, radius, options));
@@ -264,6 +268,9 @@ exports.star = function star(cx, cy, radius, points = 5, options = {}) {
   }
 
   this.polygon(starPath, starOptions);
+
+  if (options.link)
+    this.link(options.link, cx - radius, cy - radius, radius * 2, radius * 2);
 
   if (options.debug) {
     this.circle(cx, cy, radius, { width: 1, stroke: "#00ff00" });
@@ -375,6 +382,7 @@ exports.triangle = function triangle(x, y, traits, options = {}) {
   let traitID = options.traitID || options.traitsID || "sss";
   let position = options.position ? options.position.toLowerCase() : "default";
   let triopts = Object.assign({}, options);
+  delete triopts.link;
 
   if (traits.length !== 3) {
     throw new Error(
@@ -433,6 +441,19 @@ exports.triangle = function triangle(x, y, traits, options = {}) {
   }
 
   this.polygon(trigon, triopts);
+  if (options.link) {
+    const xs = trigon.map((point) => point[0]);
+    const ys = trigon.map((point) => point[1]);
+    const left = Math.min(...xs);
+    const top = Math.min(...ys);
+    this.link(
+      options.link,
+      left,
+      top,
+      Math.max(...xs) - left,
+      Math.max(...ys) - top,
+    );
+  }
 
   if (options.debug) {
     let angle = triopts.rotation || 0;

--- a/packages/native-core/lib/recipe/text.js
+++ b/packages/native-core/lib/recipe/text.js
@@ -2,6 +2,7 @@ const LineBreaker = require("linebreak");
 const { Word, Line, Column } = require("./text.helper");
 const { htmlToTextObjects } = require("./htmlToTextObjects");
 const { Color, xObjectForm } = require("./xObjectForm");
+const { linkPdf } = require("./annotation");
 const muhammara = require("../muhammara");
 const { UsedFont } = require("../muhammara");
 
@@ -777,7 +778,8 @@ exports.text = function text(text = "", x, y, options = {}) {
   }
 
   linkAnnotations.forEach((annotation) => {
-    this._linkPdf(
+    linkPdf(
+      this,
       annotation.url,
       annotation.left,
       annotation.bottom,

--- a/packages/native-core/lib/recipe/text.js
+++ b/packages/native-core/lib/recipe/text.js
@@ -258,6 +258,8 @@ exports.text = function text(text = "", x, y, options = {}) {
     return this;
   }
   options = _initOptions(this, x, y, options);
+  const linkX = this.x;
+  const linkY = this.y;
 
   const targetAnnotations = options;
   const originCoord = this._calibrateCoordinate(
@@ -754,6 +756,16 @@ exports.text = function text(text = "", x, y, options = {}) {
     }
   }
 
+  const htmlLink = textObjects.find((item) => item.link)?.link;
+  if (!this._flow && (options.link || htmlLink)) {
+    this.link(
+      options.link || htmlLink,
+      linkX,
+      linkY,
+      textBox.width,
+      textBox.height || textBox.textHeight || textBox.firstLineHeight,
+    );
+  }
   return this;
 };
 

--- a/packages/native-core/lib/recipe/text.js
+++ b/packages/native-core/lib/recipe/text.js
@@ -275,6 +275,7 @@ exports.text = function text(text = "", x, y, options = {}) {
     originCoord.ny,
   );
   pathOptions.html = options.html;
+  pathOptions.link = options.link;
   pathOptions.hilite = options.hilite;
 
   // save text state for continued text?
@@ -296,6 +297,7 @@ exports.text = function text(text = "", x, y, options = {}) {
     textBox,
     pathOptions,
   );
+  const linkAnnotations = [];
 
   if (!textBox.width) {
     textBox.width = toWriteTextObjects[0].lineWidth;
@@ -643,6 +645,15 @@ exports.text = function text(text = "", x, y, options = {}) {
           const x = next_x || getStartX(content.startX, content);
           const y = currentY;
           next_x = writeText(context, x, y, content);
+          if (content.writeOptions.link) {
+            linkAnnotations.push({
+              url: content.writeOptions.link,
+              left: x,
+              bottom: y,
+              width: next_x ? next_x - x : content.lineWidth,
+              height: content.lineHeight,
+            });
+          }
         });
         // The line offset from the last line in the
         // group determines Y positioning for next line.
@@ -741,6 +752,15 @@ exports.text = function text(text = "", x, y, options = {}) {
           const x = next_x || getStartX(content.startX, content);
           const y = currentY;
           next_x = writeText(context, x, y, content);
+          if (content.writeOptions.link) {
+            linkAnnotations.push({
+              url: content.writeOptions.link,
+              left: x,
+              bottom: y,
+              width: next_x ? next_x - x : content.lineWidth,
+              height: content.lineHeight,
+            });
+          }
         }
 
         // Flush any left over text objects.
@@ -756,16 +776,15 @@ exports.text = function text(text = "", x, y, options = {}) {
     }
   }
 
-  const htmlLink = textObjects.find((item) => item.link)?.link;
-  if (!this._flow && (options.link || htmlLink)) {
-    this.link(
-      options.link || htmlLink,
-      linkX,
-      linkY,
-      textBox.width,
-      textBox.height || textBox.textHeight || textBox.firstLineHeight,
+  linkAnnotations.forEach((annotation) => {
+    this._linkPdf(
+      annotation.url,
+      annotation.left,
+      annotation.bottom,
+      annotation.width,
+      annotation.height,
     );
-  }
+  });
   return this;
 };
 
@@ -878,6 +897,7 @@ exports._layoutText = function _layoutText(textObjects, textBox, pathOptions) {
           child.sizeRatios = [...textObject.sizeRatios, child.sizeRatio];
         }
         child.styles = Object.assign(child.styles, textObject.styles);
+        child.link = child.link || textObject.link;
 
         child.isBold = textObject.isBold ? textObject.isBold : child.isBold;
         child.isItalic = textObject.isItalic
@@ -1207,6 +1227,7 @@ function makeTextObjects(self, textObject = {}, pathOptions, textBox = {}) {
     ? textBox.textAlign.split(" ")
     : [];
   const writeOptions = Object.assign({}, pathOptions, {
+    link: textObject.link || pathOptions.link,
     color: textObject.styles.color,
     opacity: parseFloat(textObject.styles.opacity || pathOptions.opacity || 1),
     underline: textObject.underline || pathOptions.underline,

--- a/packages/native-core/lib/recipe/vector-polygon.js
+++ b/packages/native-core/lib/recipe/vector-polygon.js
@@ -132,5 +132,15 @@ exports.polygon = function polygon(coordinates = [], options = {}) {
     );
   }
 
+  if (options.link) {
+    this.link(
+      options.link,
+      boundBox[0] - margin,
+      boundBox[1] - margin,
+      width,
+      height,
+    );
+  }
+
   return this;
 };

--- a/packages/native-core/lib/recipe/vector.js
+++ b/packages/native-core/lib/recipe/vector.js
@@ -89,6 +89,8 @@ exports.circle = function circle(x, y, radius, options = {}) {
       },
     );
   }
+  if (options.link)
+    this.link(options.link, x - radius, y - radius, diameter, diameter);
   return this;
 };
 
@@ -205,6 +207,7 @@ exports.rectangle = function rectangle(x, y, width, height, options = {}) {
       },
     );
   }
+  if (options.link) this.link(options.link, x, y, width, height);
 
   return this;
 };
@@ -381,6 +384,7 @@ exports.ellipse = function ellipse(cx, cy, rx, ry, options = {}) {
       },
     );
   }
+  if (options.link) this.link(options.link, cx - rx, cy - ry, width, height);
   return this;
 };
 
@@ -536,6 +540,8 @@ exports.arc = function arc(
     );
   }
 
+  if (options.link)
+    this.link(options.link, x - radius, y - radius, diameter, diameter);
   return this;
 };
 

--- a/packages/native-core/lib/recipe/vector.js
+++ b/packages/native-core/lib/recipe/vector.js
@@ -207,7 +207,11 @@ exports.rectangle = function rectangle(x, y, width, height, options = {}) {
       },
     );
   }
-  if (options.link) this.link(options.link, x, y, width, height);
+  if (options.link) {
+    if (options.useGivenCoords)
+      this._linkPdf(options.link, x, y, width, height);
+    else this.link(options.link, x, y, width, height);
+  }
 
   return this;
 };

--- a/packages/native-core/lib/recipe/vector.js
+++ b/packages/native-core/lib/recipe/vector.js
@@ -12,6 +12,8 @@
 //   DecimalColor component values range from 0 to 255.
 //   PercentColor component values range from 1 to 100.
 
+const { linkPdf } = require("./annotation");
+
 /**
  * Draw a circle
  * @name circle
@@ -209,7 +211,7 @@ exports.rectangle = function rectangle(x, y, width, height, options = {}) {
   }
   if (options.link) {
     if (options.useGivenCoords)
-      this._linkPdf(options.link, x, y, width, height);
+      linkPdf(this, options.link, x, y, width, height);
     else this.link(options.link, x, y, width, height);
   }
 

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -1043,6 +1043,8 @@ declare namespace muhammara {
     }
 
     interface ImageOptions {
+      /** Make the rendered image open this URL. */
+      link?: string;
       width?: number;
       height?: number;
       scale?: number;
@@ -1123,6 +1125,8 @@ declare namespace muhammara {
     }
 
     interface TextOptions {
+      /** Make the rendered text open this URL. */
+      link?: string;
       charSpace?: number;
       color?: string | number[];
       flow?: boolean;
@@ -1176,6 +1180,7 @@ declare namespace muhammara {
     }
 
     interface PolygonOptions {
+      link?: string;
       color?: string | number[];
       stroke?: string | number[];
       fill?: string | number[];
@@ -1185,6 +1190,7 @@ declare namespace muhammara {
     }
 
     interface CircleOptions {
+      link?: string;
       color?: string | number[];
       stroke?: string | number[];
       fill?: string | number[];
@@ -1194,6 +1200,7 @@ declare namespace muhammara {
     }
 
     interface RectangleOptions {
+      link?: string;
       color?: string | number[];
       stroke?: string | number[];
       fill?: string | number[];

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -835,10 +835,10 @@ declare namespace muhammara {
     ): UsedFont;
     attachURLLinktoCurrentPage(
       url: string,
-      x: PosX,
-      y: PosY,
-      width: Width,
-      height: Height,
+      left: PosX,
+      bottom: PosY,
+      right: PosX,
+      top: PosY,
     ): this;
     shutdown(outputFilePath: FilePath): this;
     createFormXObjectFromTIFF(
@@ -1244,6 +1244,14 @@ declare namespace muhammara {
       x: number,
       y: number,
       options?: Recipe.CommentOptions,
+    ): Recipe;
+
+    link(
+      url: string,
+      x: number,
+      y: number,
+      width: number,
+      height: number,
     ): Recipe;
 
     annot(

--- a/packages/native-with-source/tests/recipe/annotation.js
+++ b/packages/native-with-source/tests/recipe/annotation.js
@@ -24,7 +24,20 @@ describe("Recipe annotation", function () {
     var recipe = new muhammara.Recipe("new", output)
       .createPage(595, 842)
       .link("https://example.com", 50, 300, 160, 24)
-      .rectangle(50, 300, 160, 24, { fill: "#dbeafe" })
+      .text("Linked text", 50, 250, { link: "https://text.example.com" })
+      .text('<a href="https://html.example.com">HTML link</a>', 180, 250, {
+        html: true,
+      })
+      .image(
+        path.join(__dirname, "../TestMaterials/images/png/pnglogo-grr.png"),
+        50,
+        275,
+        { width: 40, link: "https://image.example.com" },
+      )
+      .rectangle(110, 300, 100, 24, {
+        fill: "#dbeafe",
+        link: "https://shape.example.com",
+      })
       .comment("A browser comment", 250, 300, { title: "Muhammara" })
       .annot(350, 300, "Square", {
         width: 60,
@@ -74,6 +87,23 @@ describe("Recipe annotation", function () {
       annotations.some(function (annotation) {
         return annotation.Subtype.toString() === "Square";
       }),
+    );
+    assert.deepEqual(
+      annotations
+        .filter(function (annotation) {
+          return annotation.Subtype.toString() === "Link";
+        })
+        .map(function (annotation) {
+          return annotation.A.toPDFDictionary().toJSObject().URI.toText();
+        })
+        .sort(),
+      [
+        "https://example.com",
+        "https://html.example.com",
+        "https://image.example.com",
+        "https://shape.example.com",
+        "https://text.example.com",
+      ],
     );
   });
 });

--- a/packages/native-with-source/tests/recipe/annotation.js
+++ b/packages/native-with-source/tests/recipe/annotation.js
@@ -1,0 +1,79 @@
+var assert = require("node:assert/strict");
+var fs = require("node:fs");
+var os = require("node:os");
+var path = require("node:path");
+var muhammara = require("@muhammara/native-with-source");
+
+describe("Recipe annotation", function () {
+  var directory;
+  var output;
+  var reader;
+
+  beforeEach(function () {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), "recipe-annotation-"));
+    output = path.join(directory, "annotations.pdf");
+  });
+
+  afterEach(function () {
+    if (reader) reader.end();
+    reader = undefined;
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("writes links, comments, and square annotations", async function () {
+    var recipe = new muhammara.Recipe("new", output)
+      .createPage(595, 842)
+      .link("https://example.com", 50, 300, 160, 24)
+      .rectangle(50, 300, 160, 24, { fill: "#dbeafe" })
+      .comment("A browser comment", 250, 300, { title: "Muhammara" })
+      .annot(350, 300, "Square", {
+        width: 60,
+        height: 30,
+        text: "A square",
+      });
+    await new Promise(function (resolve) {
+      recipe.endPage().endPDF(resolve);
+    });
+
+    reader = muhammara.createReader(output);
+    var page = reader.parsePage(0).getDictionary();
+    var annotations = reader
+      .queryDictionaryObject(page, "Annots")
+      .toPDFArray()
+      .toJSArray()
+      .map(function (reference) {
+        return reader
+          .parseNewObject(
+            reference.toPDFIndirectObjectReference().getObjectID(),
+          )
+          .toPDFDictionary()
+          .toJSObject();
+      });
+    var link = annotations.find(function (annotation) {
+      return annotation.Subtype.toString() === "Link";
+    });
+
+    assert.equal(
+      link.A.toPDFDictionary().toJSObject().URI.toText(),
+      "https://example.com",
+    );
+    assert.deepEqual(
+      link.Rect.toPDFArray()
+        .toJSArray()
+        .map(function (value) {
+          return value.toNumber();
+        }),
+      [50, 518, 210, 542],
+    );
+    assert.ok(
+      annotations.some(function (annotation) {
+        return annotation.Subtype.toString() === "Text";
+      }),
+    );
+    assert.ok(
+      annotations.some(function (annotation) {
+        return annotation.Subtype.toString() === "Square";
+      }),
+    );
+  });
+});

--- a/packages/native-with-source/tests/recipe/annotation.js
+++ b/packages/native-with-source/tests/recipe/annotation.js
@@ -32,11 +32,22 @@ describe("Recipe annotation", function () {
         path.join(__dirname, "../TestMaterials/images/png/pnglogo-grr.png"),
         50,
         275,
-        { width: 40, link: "https://image.example.com" },
+        {
+          width: 40,
+          height: 40,
+          keepAspectRatio: false,
+          align: "center center",
+          link: "https://image.example.com",
+        },
       )
       .rectangle(110, 300, 100, 24, {
         fill: "#dbeafe",
         link: "https://shape.example.com",
+      })
+      .rectangle(250, 100, 40, 40, {
+        fill: "#dbeafe",
+        useGivenCoords: true,
+        link: "https://pdf-coordinates.example.com",
       })
       .comment("A browser comment", 250, 300, { title: "Muhammara" })
       .annot(350, 300, "Square", {
@@ -101,9 +112,24 @@ describe("Recipe annotation", function () {
         "https://example.com",
         "https://html.example.com",
         "https://image.example.com",
+        "https://pdf-coordinates.example.com",
         "https://shape.example.com",
         "https://text.example.com",
       ],
+    );
+    const imageLink = annotations.find(function (annotation) {
+      return (
+        annotation.A.toPDFDictionary().toJSObject().URI.toText() ===
+        "https://image.example.com"
+      );
+    });
+    assert.deepEqual(
+      imageLink.Rect.toPDFArray()
+        .toJSArray()
+        .map(function (value) {
+          return value.toNumber();
+        }),
+      [30, 547, 70, 587],
     );
   });
 });

--- a/packages/native-with-source/tests/recipe/prototype.js
+++ b/packages/native-with-source/tests/recipe/prototype.js
@@ -82,6 +82,7 @@ describe("Recipe prototype", function () {
       "lineStyle",
       "lineTo",
       "lineWidth",
+      "link",
       "margins",
       "mediumSizes",
       "moveTo",

--- a/packages/native-with-source/tests/types/types.test.ts
+++ b/packages/native-with-source/tests/types/types.test.ts
@@ -7,6 +7,7 @@ writer.startPageContentContext(page).c(0, 0, 1, 1, 2, 2).S();
 
 declare const recipe: muhammara.Recipe;
 recipe
+  .link("https://example.com", 100, 200, 160, 24)
   .comment("Please review.", 300, 100, {
     title: "Review",
     replies: [{ text: "Confirmed.", title: "Reviewer" }],

--- a/packages/native-with-source/tests/types/types.test.ts
+++ b/packages/native-with-source/tests/types/types.test.ts
@@ -19,7 +19,7 @@ recipe.opacity(0.5);
 recipe.fillOpacity(0.5);
 
 recipe
-  .text("Default size", 72, 72)
+  .text("Default size", 72, 72, { link: "https://text.example.com" })
   .text("Explicit size", 72, 100, { size: 12 })
   .pie(100, 100, 50, 20, 220, { fill: "#000000" });
 recipe
@@ -36,11 +36,13 @@ recipe
     italic: true,
   })
   .image("image.png", 72, 128, {
+    link: "https://image.example.com",
     rotation: 45,
     rotationOrigin: [72, 128],
     skewX: 10,
     skewY: 5,
-  });
+  })
+  .rectangle(72, 180, 100, 20, { link: "https://shape.example.com" });
 var textWidth: number = recipe.textDimensions("text").width;
 recipe.textDimensions("text", { size: 12 }).width;
 var pages: number = recipe.metadata.pages;

--- a/packages/native/docs/how-to/add-url-links.md
+++ b/packages/native/docs/how-to/add-url-links.md
@@ -1,7 +1,7 @@
 # Add Clickable URL Links
 
-Recipe adds a URL action to a rectangular region using top-left `x`, `y`,
-`width`, and `height` values:
+Recipe adds URL actions using top-left coordinates. Use `link()` when the
+clickable region is independent of its content, such as a custom drawing:
 
 ```javascript
 var recipe = new Recipe("new", "links.pdf")
@@ -11,6 +11,30 @@ var recipe = new Recipe("new", "links.pdf")
   .endPage()
   .endPDF();
 ```
+
+Text, images, and supported shapes can instead calculate their clickable
+rectangle from their rendered bounds:
+
+```javascript
+recipe
+  .text("Visit our site", 65, 250, {
+    color: "#0563c1",
+    underline: true,
+    link: "https://example.com",
+  })
+  .image("logo.png", 65, 290, {
+    width: 120,
+    link: "https://example.com",
+  })
+  .rectangle(65, 450, 180, 48, {
+    fill: "#dbeafe",
+    link: "https://example.com",
+  });
+```
+
+With `html: true`, `<a href="https://example.com">Visit our site</a>` creates
+a link over the rendered text. PDF link annotations are rectangular; use
+`link()` to select the clickable region for complex drawings.
 
 The low-level API attaches a URL to a rectangle on the current page. Pause the
 active content context before adding links, then write the page.

--- a/packages/native/docs/how-to/add-url-links.md
+++ b/packages/native/docs/how-to/add-url-links.md
@@ -1,5 +1,17 @@
 # Add Clickable URL Links
 
+Recipe adds a URL action to a rectangular region using top-left `x`, `y`,
+`width`, and `height` values:
+
+```javascript
+var recipe = new Recipe("new", "links.pdf")
+  .createPage(595, 842)
+  .rectangle(65, 100, 465, 120, { fill: "#dbeafe" })
+  .link("https://example.com", 65, 100, 465, 120)
+  .endPage()
+  .endPDF();
+```
+
 The low-level API attaches a URL to a rectangle on the current page. Pause the
 active content context before adding links, then write the page.
 

--- a/packages/native/tests/types/types.test.ts
+++ b/packages/native/tests/types/types.test.ts
@@ -64,7 +64,7 @@ var title: string = recipe.getPageInfo().title;
 var textWidth: number = recipe.textDimensions("text").width;
 recipe.textDimensions("text", { size: 12 }).width;
 recipe
-  .text("Default size", 72, 72)
+  .text("Default size", 72, 72, { link: "https://text.example.com" })
   .text("Explicit size", 72, 100, { size: 12 });
 recipe
   .registerFont("body", "./fonts/body-bold.ttf", "bold")
@@ -81,11 +81,13 @@ recipe
     italic: true,
   })
   .image("image.png", 72, 128, {
+    link: "https://image.example.com",
     rotation: 45,
     rotationOrigin: [72, 128],
     skewX: 10,
     skewY: 5,
-  });
+  })
+  .rectangle(72, 180, 100, 20, { link: "https://shape.example.com" });
 var coordinates: muhammara.Recipe | number[] = recipe.movedown(1, Boolean(1));
 recipe.structure("structure.json").endPDF();
 recipe

--- a/packages/native/tests/types/types.test.ts
+++ b/packages/native/tests/types/types.test.ts
@@ -29,6 +29,7 @@ context.J(api.LineCapStyle.LINECAP_BUTT).j(2);
 objects.endArray(api.ETokenSeparator.eTokenSeparatorEndLine);
 recipe.read();
 recipe
+  .link("https://example.com", 100, 200, 160, 24)
   .comment("Please review.", 300, 100, {
     title: "Review",
     replies: [{ text: "Confirmed.", title: "Reviewer" }],

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to `@muhammara/wasm` are documented in this file.
 
 ### Added
 
+- Add Recipe URL links for arbitrary areas, rendered text, images, and drawing
+  bounds [#614](https://github.com/julianhille/MuhammaraJS/issues/614)
 - Add a MkDocs-validated guide index for browser examples
   [#627](https://github.com/julianhille/MuhammaraJS/issues/627)
 - Bundle Apache-2.0 Roboto Regular as Recipe's automatic default font, so text,

--- a/packages/wasm/docs/how-to/add-url-links.md
+++ b/packages/wasm/docs/how-to/add-url-links.md
@@ -1,7 +1,7 @@
 # Add Clickable URL Links
 
-Recipe adds a URL action to a rectangular region using top-left `x`, `y`,
-`width`, and `height` values:
+Recipe adds URL actions using top-left coordinates. Use `link()` when the
+clickable region is independent of its content, such as a custom drawing:
 
 ```javascript
 var outputBytes = new Recipe()
@@ -11,6 +11,30 @@ var outputBytes = new Recipe()
   .endPage()
   .endPDF();
 ```
+
+Text, images, and supported shapes can instead calculate their clickable
+rectangle from their rendered bounds:
+
+```javascript
+recipe
+  .text("Visit our site", 65, 250, {
+    color: "#0563c1",
+    underline: true,
+    link: "https://example.com",
+  })
+  .image("logo", 65, 290, {
+    width: 120,
+    link: "https://example.com",
+  })
+  .rectangle(65, 450, 180, 48, {
+    fill: "#dbeafe",
+    link: "https://example.com",
+  });
+```
+
+With `html: true`, `<a href="https://example.com">Visit our site</a>` creates
+a link over the rendered text. PDF link annotations are rectangular; use
+`link()` to select the clickable region for complex drawings.
 
 The low-level API uses PDF bottom-left rectangle coordinates. Pause an active
 page content context before attaching the link:

--- a/packages/wasm/examples/browser/how-tos.mjs
+++ b/packages/wasm/examples/browser/how-tos.mjs
@@ -159,12 +159,33 @@ async function linksExample() {
   var Recipe = await createRecipe();
   var recipe = new Recipe({ compress: false });
   try {
+    Recipe.registerImage(
+      "link-image",
+      Uint8Array.from(
+        atob(
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+        ),
+        (character) => character.charCodeAt(0),
+      ),
+      "png",
+    );
     recipe
       .createPage(595, 842)
       .rectangle(0, 0, 595, 842, { fill: "#eef2ff", useGivenCoords: true })
       .rectangle(65, 100, 465, 120, {
         fill: "#102a43",
         borderRadius: 16,
+        link: "https://github.com/julianhille/MuhammaraJS",
+      })
+      .text("Open MuhammaraJS", 95, 135, {
+        color: "#ffffff",
+        size: 22,
+        link: "https://github.com/julianhille/MuhammaraJS",
+      })
+      .image("link-image", 470, 130, {
+        width: 36,
+        height: 36,
+        keepAspectRatio: false,
         link: "https://github.com/julianhille/MuhammaraJS",
       })
       .rectangle(65, 255, 220, 150, {

--- a/packages/wasm/examples/browser/how-tos.mjs
+++ b/packages/wasm/examples/browser/how-tos.mjs
@@ -165,20 +165,20 @@ async function linksExample() {
       .rectangle(65, 100, 465, 120, {
         fill: "#102a43",
         borderRadius: 16,
+        link: "https://github.com/julianhille/MuhammaraJS",
       })
       .rectangle(65, 255, 220, 150, {
         fill: "#bd412d",
         borderRadius: 16,
+        link: "https://www.npmjs.com/package/@muhammara/wasm",
       })
       .rectangle(310, 255, 220, 150, {
         fill: "#2c7a7b",
         borderRadius: 16,
+        link: "https://muhammarajs-wasm.readthedocs.io/",
       })
       .star(175, 330, 40, 6, { fill: "#facf9b", rotation: 15 })
       .n_gon(420, 330, 42, 8, { fill: "#dbeafe" })
-      .link("https://github.com/julianhille/MuhammaraJS", 65, 100, 465, 120)
-      .link("https://www.npmjs.com/package/@muhammara/wasm", 65, 255, 220, 150)
-      .link("https://muhammarajs-wasm.readthedocs.io/", 310, 255, 220, 150)
       .endPage();
     var bytes = recipe.endPDF();
     return {

--- a/packages/wasm/index.d.ts
+++ b/packages/wasm/index.d.ts
@@ -90,6 +90,8 @@ export type RecipeKnownColors = Record<
 >;
 export type RecipeExtension = (this: Recipe, ...args: any[]) => unknown;
 export interface RecipePathOptions {
+  /** Make the rendered path's bounding rectangle open this URL. */
+  link?: string;
   color?: RecipeColor;
   colour?: RecipeColor;
   stroke?: RecipeColor;

--- a/packages/wasm/lib/recipe/annotation.js
+++ b/packages/wasm/lib/recipe/annotation.js
@@ -56,14 +56,17 @@ export function createAnnotationMethods({
   return {
     link: function (url, x, y, width, height) {
       var point = this._calibrateCoordinate(x, y, 0, -height);
+      return this._linkPdf(url, point.nx, point.ny, width, height);
+    },
+    _linkPdf: function (url, left, bottom, width, height) {
       if (this._sourceMode) {
         return (
           this.writer.attachURLLinktoCurrentPage(
             url,
-            point.nx,
-            point.ny,
-            point.nx + width,
-            point.ny + height,
+            left,
+            bottom,
+            left + width,
+            bottom + height,
           ) && this
         );
       }
@@ -72,8 +75,8 @@ export function createAnnotationMethods({
           !module._muhammara_wasm_recipe_link(
             this._recipe,
             urlPointer,
-            point.nx,
-            point.ny,
+            left,
+            bottom,
             width,
             height,
           )

--- a/packages/wasm/lib/recipe/htmlToTextObjects.js
+++ b/packages/wasm/lib/recipe/htmlToTextObjects.js
@@ -33,6 +33,8 @@ export function htmlToTextObjects(html, options = {}) {
     if (["i", "em"].includes(name)) style.italic = true;
     if (name === "u") style.underline = true;
     if (["s", "strike", "del"].includes(name)) style.strikeOut = true;
+    if (name === "a")
+      style.link = token.match(/href\s*=\s*["']?([^\s"'>]+)/i)?.[1];
     var color = token.match(/(?:color|data-color)\s*=\s*["']?([^\s"'>;]+)/i);
     if (color) style.color = color[1];
     var css = token.match(/style\s*=\s*["']([^"']*)/i)?.[1] || "";

--- a/packages/wasm/lib/recipe/image.js
+++ b/packages/wasm/lib/recipe/image.js
@@ -62,31 +62,33 @@ export function createImageMethods(runtime) {
           },
         );
         this._restore();
-        return this;
+      } else {
+        runtime.withString(path, (pointer) => {
+          var matrix = runtime.module._malloc(48);
+          try {
+            runtime.module.HEAPF64.set([1, 0, 0, 1, 0, 0], matrix >>> 3);
+            runtime.call(
+              "_muhammara_wasm_writer_draw_image",
+              this._recipe,
+              point.nx,
+              point.ny,
+              pointer,
+              options.index || 0,
+              1,
+              matrix,
+              box.width,
+              box.height,
+              options.keepAspectRatio === false ? 0 : 1,
+              0,
+            );
+          } finally {
+            runtime.module._free(matrix);
+          }
+        });
+        this._restore();
       }
-      runtime.withString(path, (pointer) => {
-        var matrix = runtime.module._malloc(48);
-        try {
-          runtime.module.HEAPF64.set([1, 0, 0, 1, 0, 0], matrix >>> 3);
-          runtime.call(
-            "_muhammara_wasm_writer_draw_image",
-            this._recipe,
-            point.nx,
-            point.ny,
-            pointer,
-            options.index || 0,
-            1,
-            matrix,
-            box.width,
-            box.height,
-            options.keepAspectRatio === false ? 0 : 1,
-            0,
-          );
-        } finally {
-          runtime.module._free(matrix);
-        }
-      });
-      this._restore();
+      if (options.link)
+        this.link(options.link, box.x, box.y, box.width, box.height);
       return this;
     },
     _imageDimensions: function (path) {

--- a/packages/wasm/lib/recipe/shapes.js
+++ b/packages/wasm/lib/recipe/shapes.js
@@ -26,10 +26,26 @@ function ngon(sides, x, y, radius, options = {}) {
 
 function polygonOptions(options, x, y) {
   var result = { ...options };
+  delete result.link;
   // Native polygon bounding-box compensation makes the shape's true center the
   // default rotation origin. The direct Wasm path needs that origin explicitly.
   if (result.rotation && !result.rotationOrigin) result.rotationOrigin = [x, y];
   return result;
+}
+
+function addLink(recipe, options, points) {
+  if (!options.link) return;
+  var xs = points.map((point) => point[0]);
+  var ys = points.map((point) => point[1]);
+  var left = Math.min(...xs);
+  var top = Math.min(...ys);
+  recipe.link(
+    options.link,
+    left,
+    top,
+    Math.max(...xs) - left,
+    Math.max(...ys) - top,
+  );
 }
 
 function starPath(vertices) {
@@ -210,10 +226,18 @@ export function createShapeMethods() {
         drawOptions.rotationOrigin =
           vertices[(options.rotationVertice - 1) % sides];
       this.polygon(vertices, drawOptions);
+      addLink(this, options, [
+        [cx - radius, cy - radius],
+        [cx + radius, cy + radius],
+      ]);
       if (options.debug) {
         this.circle(cx, cy, radius, { width: 1, stroke: "#00ff00" });
         this.circle(cx, cy, 2, { fill: "#ff0000" });
       }
+      addLink(this, options, [
+        [cx - radius, cy - radius],
+        [cx + radius, cy + radius],
+      ]);
       return this;
     },
     star: function (cx, cy, radius, points = 5, options = {}) {
@@ -346,6 +370,7 @@ export function createShapeMethods() {
           ]
         : [tip, bottom, br, bl, tl, tr, top, tip];
       this.polygon(points, drawOptions);
+      addLink(this, options, points);
       if (options.debug) {
         this.circle(originalX, y, 2, { color: "red" });
         if (options.debug === 2) {
@@ -415,6 +440,7 @@ export function createShapeMethods() {
       )
         drawOptions.rotationOrigin = [x, y];
       this.polygon(vertices, drawOptions);
+      addLink(this, options, vertices);
       if (options.debug) {
         var debugVertices = rotated(
           vertices,

--- a/packages/wasm/lib/recipe/text.js
+++ b/packages/wasm/lib/recipe/text.js
@@ -385,6 +385,16 @@ export function createTextMethods({ drawText, measure, module }) {
           drawText.call(this, entry.text, drawX, baseline, textOptions);
         }
         if (clipping) this._restore();
+        if (textOptions.link) {
+          var linkBounds = dimensions(this, entry.text, textOptions);
+          this.link(
+            textOptions.link,
+            drawX + linkBounds.xMin,
+            currentY,
+            linkBounds.xMax - linkBounds.xMin,
+            lineHeight,
+          );
+        }
         currentY += lineHeight;
         return false;
       });

--- a/packages/wasm/lib/recipe/text.js
+++ b/packages/wasm/lib/recipe/text.js
@@ -324,6 +324,8 @@ export function createTextMethods({ drawText, measure, module }) {
               ? width - right - textWidth
               : 0);
         var baseline = currentY + lineHeight;
+        var linkX = drawX;
+        var linkWidth = textWidth;
         var clipping = wrap === "clip" && width;
         if (clipping) {
           var clipPoint = this._calibrateCoordinate(
@@ -381,6 +383,7 @@ export function createTextMethods({ drawText, measure, module }) {
             drawText.call(this, word, drawX, baseline, textOptions);
             drawX += dimensions(this, word, textOptions).width + gap;
           });
+          linkWidth = width - left - right;
         } else {
           drawText.call(this, entry.text, drawX, baseline, textOptions);
         }
@@ -389,9 +392,9 @@ export function createTextMethods({ drawText, measure, module }) {
           var linkBounds = dimensions(this, entry.text, textOptions);
           this.link(
             textOptions.link,
-            drawX + linkBounds.xMin,
+            linkX + linkBounds.xMin,
             currentY,
-            linkBounds.xMax - linkBounds.xMin,
+            linkWidth,
             lineHeight,
           );
         }

--- a/packages/wasm/lib/recipe/vector-polygon.js
+++ b/packages/wasm/lib/recipe/vector-polygon.js
@@ -9,7 +9,21 @@ export function createPolygonMethods(runtime) {
       coordinates.slice(1).forEach((point) => this.lineTo(...point));
       if (this._pageContext) this._pageContext.h();
       else runtime.call("_muhammara_wasm_recipe_close_path", this._recipe);
-      return this._finishPath(options);
+      var result = this._finishPath(options);
+      if (options.link) {
+        var xs = coordinates.map((point) => point[0]);
+        var ys = coordinates.map((point) => point[1]);
+        var left = Math.min(...xs);
+        var top = Math.min(...ys);
+        this.link(
+          options.link,
+          left,
+          top,
+          Math.max(...xs) - left,
+          Math.max(...ys) - top,
+        );
+      }
+      return result;
     },
   };
 }

--- a/packages/wasm/lib/recipe/vector.js
+++ b/packages/wasm/lib/recipe/vector.js
@@ -1,8 +1,10 @@
 /** Creates Recipe vector shape and path methods. */
 export function createVectorMethods(runtime) {
   function addLink(recipe, options, x, y, width, height) {
-    if (options.link && !options.useGivenCoords)
-      recipe.link(options.link, x, y, width, height);
+    if (!options.link) return;
+    if (options.useGivenCoords)
+      recipe._linkPdf(options.link, x, y, width, height);
+    else recipe.link(options.link, x, y, width, height);
   }
 
   function curve(recipe, x, y, radius, start, end) {

--- a/packages/wasm/lib/recipe/vector.js
+++ b/packages/wasm/lib/recipe/vector.js
@@ -1,5 +1,10 @@
 /** Creates Recipe vector shape and path methods. */
 export function createVectorMethods(runtime) {
+  function addLink(recipe, options, x, y, width, height) {
+    if (options.link && !options.useGivenCoords)
+      recipe.link(options.link, x, y, width, height);
+  }
+
   function curve(recipe, x, y, radius, start, end) {
     var segments = Math.ceil(Math.abs(end - start) / (Math.PI / 2));
     var step = (end - start) / segments;
@@ -28,7 +33,9 @@ export function createVectorMethods(runtime) {
         : this._calibrateCoordinate(x, y, 0, -height);
       if (this._pageContext) {
         this._pageContext.re(point.nx, point.ny, width, height);
-        return this._finishPath(options);
+        var result = this._finishPath(options);
+        addLink(this, options, x, y, width, height);
+        return result;
       }
       runtime.call(
         "_muhammara_wasm_recipe_rectangle_path",
@@ -38,9 +45,13 @@ export function createVectorMethods(runtime) {
         width,
         height,
       );
-      return this._finishPath(options);
+      var result = this._finishPath(options);
+      addLink(this, options, x, y, width, height);
+      return result;
     },
     _roundedRectangle: function (x, y, width, height, options) {
+      var linkX = x;
+      var linkY = y;
       var source = Array.isArray(options.borderRadius)
         ? options.borderRadius
         : [options.borderRadius];
@@ -99,7 +110,9 @@ export function createVectorMethods(runtime) {
         );
       if (this._pageContext) this._pageContext.h();
       else runtime.call("_muhammara_wasm_recipe_close_path", this._recipe);
-      return this._finishPath(options);
+      var result = this._finishPath(options);
+      addLink(this, options, linkX, linkY, width, height);
+      return result;
     },
     circle: function (x, y, radius, options = {}) {
       return this.ellipse(x, y, radius, radius, options);
@@ -115,7 +128,9 @@ export function createVectorMethods(runtime) {
         ._curvePdf(x + rx * k, y - ry, x + rx, y - ry * k, x + rx, y)
         ._curvePdf(x + rx, y + ry * k, x + rx * k, y + ry, x, y + ry)
         ._curvePdf(x - rx * k, y + ry, x - rx, y + ry * k, x - rx, y);
-      return this._finishPath(options);
+      var result = this._finishPath(options);
+      addLink(this, options, cx - rx, cy - ry, rx * 2, ry * 2);
+      return result;
     },
     arc: function (x, y, radius, startAngle = 0, endAngle = 360, options = {}) {
       this._beginPath(options, x, y);
@@ -133,7 +148,9 @@ export function createVectorMethods(runtime) {
         if (this._pageContext) this._pageContext.h();
         else runtime.call("_muhammara_wasm_recipe_close_path", this._recipe);
       }
-      return this._finishPath(options);
+      var result = this._finishPath(options);
+      addLink(this, options, x - radius, y - radius, radius * 2, radius * 2);
+      return result;
     },
     pie: function (x, y, radius, startAngle, endAngle, options = {}) {
       return this.arc(x, y, radius, startAngle, endAngle, {

--- a/packages/wasm/tests/recipe/annotation.test.mjs
+++ b/packages/wasm/tests/recipe/annotation.test.mjs
@@ -14,11 +14,19 @@ describe("Recipe annotation", function () {
       })
       .image("logo", 50, 275, {
         width: 40,
+        height: 40,
+        keepAspectRatio: false,
+        align: "center center",
         link: "https://image.example.com",
       })
       .rectangle(110, 300, 100, 24, {
         fill: "#dbeafe",
         link: "https://shape.example.com",
+      })
+      .rectangle(250, 100, 40, 40, {
+        fill: "#dbeafe",
+        useGivenCoords: true,
+        link: "https://pdf-coordinates.example.com",
       })
       .comment("A browser comment", 250, 300, { title: "Muhammara" })
       .annot(350, 300, "Square", { width: 60, height: 30, text: "A square" })
@@ -33,5 +41,8 @@ describe("Recipe annotation", function () {
     assert.match(output, /\/URI \(https:\/\/html\.example\.com\)/);
     assert.match(output, /\/URI \(https:\/\/image\.example\.com\)/);
     assert.match(output, /\/URI \(https:\/\/shape\.example\.com\)/);
+    assert.match(output, /\/URI \(https:\/\/pdf-coordinates\.example\.com\)/);
+    assert.match(output, /\/Rect \[\s*30 547 70 587\s*\]/);
+    assert.match(output, /\/Rect \[\s*250 100 290 140\s*\]/);
   });
 });

--- a/packages/wasm/tests/recipe/annotation.test.mjs
+++ b/packages/wasm/tests/recipe/annotation.test.mjs
@@ -8,6 +8,18 @@ describe("Recipe annotation", function () {
     var pdf = new Recipe()
       .createPage(595, 842)
       .link("https://example.com", 50, 300, 160, 24)
+      .text("Linked text", 50, 250, { link: "https://text.example.com" })
+      .text('<a href="https://html.example.com">HTML link</a>', 180, 250, {
+        html: true,
+      })
+      .image("logo", 50, 275, {
+        width: 40,
+        link: "https://image.example.com",
+      })
+      .rectangle(110, 300, 100, 24, {
+        fill: "#dbeafe",
+        link: "https://shape.example.com",
+      })
       .comment("A browser comment", 250, 300, { title: "Muhammara" })
       .annot(350, 300, "Square", { width: 60, height: 30, text: "A square" })
       .endPage()
@@ -17,5 +29,9 @@ describe("Recipe annotation", function () {
     assert.match(output, /\/URI \(https:\/\/example.com\)/);
     assert.match(output, /\/Rect \[\s*50 518 210 542\s*\]/);
     assert.match(output, /\/Subtype \/Square/);
+    assert.match(output, /\/URI \(https:\/\/text\.example\.com\)/);
+    assert.match(output, /\/URI \(https:\/\/html\.example\.com\)/);
+    assert.match(output, /\/URI \(https:\/\/image\.example\.com\)/);
+    assert.match(output, /\/URI \(https:\/\/shape\.example\.com\)/);
   });
 });

--- a/packages/wasm/tests/recipe/annotation.test.mjs
+++ b/packages/wasm/tests/recipe/annotation.test.mjs
@@ -15,6 +15,7 @@ describe("Recipe annotation", function () {
     var output = new TextDecoder().decode(pdf);
     assert.match(output, /A browser comment/);
     assert.match(output, /\/URI \(https:\/\/example.com\)/);
+    assert.match(output, /\/Rect \[\s*50 518 210 542\s*\]/);
     assert.match(output, /\/Subtype \/Square/);
   });
 });

--- a/packages/wasm/tests/types/types.test.ts
+++ b/packages/wasm/tests/types/types.test.ts
@@ -290,7 +290,7 @@ async function usesLowLevelSurface() {
       return this;
     })
     .createPage("letter", 90, { left: 36 })
-    .text("Default size", 72, 72)
+    .text("Default size", 72, 72, { link: "https://text.example.test" })
     .text("Explicit size", 72, 100, { size: 12 })
     .text("Explicit fontSize", 72, 128, { fontSize: 12 })
     .margins(36, 36, 72, 72)
@@ -323,7 +323,10 @@ async function usesLowLevelSurface() {
       ],
       { fill: "#000000" },
     )
-    .rectangle(0, 0, 10, 10, { borderRadius: [1, 2, 3, 4] })
+    .rectangle(0, 0, 10, 10, {
+      borderRadius: [1, 2, 3, 4],
+      link: "https://shape.example.test",
+    })
     .circle(10, 10, 5)
     .ellipse(10, 10, 5, 2)
     .arc(10, 10, 5, 0, 90, { sector: true })
@@ -359,7 +362,11 @@ async function usesLowLevelSurface() {
     .fill()
     .stroke()
     .fillAndStroke()
-    .image("image", 10, 10, { index: 1, align: "center center" })
+    .image("image", 10, 10, {
+      index: 1,
+      align: "center center",
+      link: "https://image.example.test",
+    })
     .appendPage("pdf", [1, [2, 3]])
     .overlay("pdf", { page: 1, fitWidth: true })
     .overlay("pdf", 10, 10, {


### PR DESCRIPTION
## Summary
- provide consistent native and Wasm Recipe URL links for arbitrary areas
- make rendered text, images, and supported drawings clickable through `options.link`
- support HTML anchors in Recipe text and retain the low-level rectangle API for custom regions
- calculate link bounds from rendered text, images, and shapes, including aligned images and PDF-coordinate paths
- add mirrored tests, type coverage, URL-link how-tos, changelog entries, and a browser example with linked text, image, and drawings

## Validation
- `npx mocha tests/recipe/annotation.js --timeout 15000`
- `npx mocha ../wasm/tests/recipe/annotation.test.mjs --timeout 15000`
- `npx mocha ../wasm/tests/integration/BrowserExamples.test.mjs --timeout 30000`
- `npm run native:test:types && npm run native-with-source:test:types && npm run wasm:test:types`
- `npm run test:codestyle`
- Native and Wasm documentation generation completed; strict MkDocs builds are blocked because `mkdocs` is not installed in this workspace.

Closes #614