### PR TITLE
Document Wasm Recipe methods

### DIFF
--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to `@muhammara/wasm` are documented in this file.
 
 - Add Recipe URL links for arbitrary areas, rendered text, images, and drawing
   bounds [#614](https://github.com/julianhille/MuhammaraJS/issues/614)
+- Add generated behavioral API reference documentation from JSDoc on every
+  public Recipe method, with named TypeScript option and result types
+  [#652](https://github.com/julianhille/MuhammaraJS/issues/652)
 - Add a MkDocs-validated guide index for browser examples
   [#627](https://github.com/julianhille/MuhammaraJS/issues/627)
 - Bundle Apache-2.0 Roboto Regular as Recipe's automatic default font, so text,

--- a/packages/wasm/docs/contributing.md
+++ b/packages/wasm/docs/contributing.md
@@ -26,6 +26,13 @@ before opening a pull request. The command generates `docs/reference.md` and
 writes the generated site to `packages/wasm/site/`; both are generated output
 and ignored by Git.
 
+The generated reference combines public Recipe method JSDoc from
+`packages/wasm/lib/recipe.js` and `packages/wasm/lib/recipe/*.js` with the
+package's TypeScript declarations. Public Recipe methods use `@name`,
+`@function`, and `@memberof Recipe#` (or `Recipe` for static methods). Mark
+underscore-prefixed implementation helpers with `@private` so they stay out of
+the public reference.
+
 ## Examples
 
 Copyable browser examples belong in `packages/wasm/examples/browser/`. Add a

--- a/packages/wasm/index.d.ts
+++ b/packages/wasm/index.d.ts
@@ -55,6 +55,19 @@ export interface PDFRecryptOptions {
 export type RecipeFontStyle =
   "regular" | "bold" | "italic" | "bold-italic" | "r" | "b" | "i" | "bi";
 export type RecipeCoordinate = number | "center";
+export type RecipePosition = [number, number];
+export type RecipeColorSpace = "rgb" | "gray" | "cmyk" | "separation";
+export type RecipePermissionName =
+  | "print"
+  | "modify"
+  | "copy"
+  | "edit"
+  | "fillform"
+  | "extract"
+  | "assemble"
+  | "printbest";
+/** Known permission names with string compatibility for composed flag lists. */
+export type RecipePermission = RecipePermissionName | (string & {});
 export interface RecipeMargins {
   left?: number;
   right?: number;
@@ -70,7 +83,7 @@ export interface RecipeOptions {
   title?: string;
   subject?: string;
   keywords?: string | string[];
-  colorspace?: "rgb" | "gray" | "cmyk";
+  colorspace?: Exclude<RecipeColorSpace, "separation">;
   password?: string;
   ownerPassword?: string;
   userPassword?: string;
@@ -85,7 +98,7 @@ export interface RecipeEncryptOptions {
 }
 export type RecipeColor = string | number[];
 export type RecipeKnownColors = Record<
-  "rgb" | "gray" | "cmyk" | "separation",
+  RecipeColorSpace,
   Record<string, string>
 >;
 export type RecipeExtension = (this: Recipe, ...args: any[]) => unknown;
@@ -96,7 +109,7 @@ export interface RecipePathOptions {
   colour?: RecipeColor;
   stroke?: RecipeColor;
   fill?: RecipeColor;
-  colorspace?: "rgb" | "gray" | "cmyk" | "separation";
+  colorspace?: RecipeColorSpace;
   colorName?: string;
   width?: number;
   lineWidth?: number;
@@ -122,6 +135,48 @@ export interface RecipeImageOptions extends RecipePathOptions {
   keepAspectRatio?: boolean;
   align?: string;
   index?: number;
+}
+export interface RecipeRectangleOptions extends RecipePathOptions {
+  borderRadius?:
+    | number
+    | [number]
+    | [number, number]
+    | [number, number, number]
+    | [number, number, number, number];
+}
+export interface RecipeArcOptions extends RecipePathOptions {
+  sector?: boolean;
+}
+export interface RecipeNGonOptions extends RecipePathOptions {
+  rotationVertice?: number;
+}
+export type RecipeArrowType = number | "triangle" | "dart" | "kite";
+export type RecipeArrowAnchor = "head" | "tail";
+export interface RecipeArrowOptions extends RecipePathOptions {
+  head?: number | number[];
+  shaft?: number | number[];
+  double?: boolean;
+  type?: RecipeArrowType;
+  at?: RecipeArrowAnchor;
+}
+export type RecipeTriangleTrait = "sss" | "sas" | "asa" | "vtx";
+export type RecipeTrianglePosition =
+  "a" | "b" | "c" | "A" | "B" | "C" | "centroid" | "circumcenter" | "incenter";
+export interface RecipeTriangleOptions extends RecipePathOptions {
+  traitID?: RecipeTriangleTrait;
+  traitsID?: RecipeTriangleTrait;
+  position?: RecipeTrianglePosition;
+  flipX?: boolean;
+  flipY?: boolean;
+}
+export interface RecipeLineStyleOptions {
+  width?: number;
+  lineWidth?: number;
+  cap?: number;
+  join?: number;
+  miterLimit?: number;
+  dash?: number[];
+  dashPhase?: number;
 }
 export interface RecipeAnnotationOptions {
   text?: string;
@@ -230,6 +285,7 @@ export interface RecipeTableColumn extends Omit<RecipeTextOptions, "font"> {
     row: number,
   ) => RecipeTextOptions | void;
 }
+export type RecipeTableRow = Record<string, unknown>;
 export interface RecipeTableOptions extends Omit<
   RecipeTextOptions,
   "overflow"
@@ -248,6 +304,22 @@ export interface RecipeTableOptions extends Omit<
     row: number,
   ) => boolean | { position?: [number, number] } | void;
 }
+export interface RecipeLayoutOptions {
+  columns?: number | RecipeTableColumn[];
+  gap?: number;
+  reset?: boolean;
+}
+export type RecipePageSelection = number | (number | [number, number])[];
+export interface RecipeSplitResult {
+  name: string;
+  bytes: Uint8Array;
+}
+export interface RecipeStructure {
+  pages: number;
+  encrypted: boolean;
+  objects: number;
+}
+export type RecipeStructureFormat = "string" | "json" | { json?: boolean };
 export interface RecipePageInfo {
   pageNumber: number;
   mediaBox: PDFRectangle;
@@ -260,6 +332,16 @@ export interface RecipePageInfo {
   size: [number, number];
   offsetX: number;
   offsetY: number;
+}
+export interface RecipeMetadata {
+  pages: number;
+  [page: number]: RecipePageInfo;
+}
+export interface RecipePdfInspection {
+  pages: number;
+  level: number;
+  encrypted: boolean;
+  [page: number]: RecipePageInfo;
 }
 export interface Recipe {
   readonly options: RecipeOptions;
@@ -296,10 +378,8 @@ export interface Recipe {
   /** Returns geometry for the current Recipe page. */
   getCurrentPageInfo(): RecipePageInfo | null;
   /** Inspects PDF metadata without changing this Recipe's output state. Blob/File input requires readAsync. */
-  read(source: ByteSource): { pages: number; [page: number]: RecipePageInfo };
-  readAsync(
-    source: AsyncByteSource,
-  ): Promise<{ pages: number; [page: number]: RecipePageInfo }>;
+  read(source: ByteSource): RecipeMetadata;
+  readAsync(source: AsyncByteSource): Promise<RecipeMetadata>;
   /** Starts a prepend-safe editing context for an existing one-based page number. */
   editPage(pageNumber: number): this;
   /** Replaces literal `(...) Tj` operands in an existing page's single content stream. */
@@ -315,11 +395,7 @@ export interface Recipe {
   ): this;
   rotate(rotation: number): this;
   rotateContent(degrees: number, x?: number, y?: number): this;
-  chroma(
-    name: string,
-    value: RecipeColor,
-    colorspace?: "rgb" | "gray" | "cmyk" | "separation",
-  ): this;
+  chroma(name: string, value: RecipeColor, colorspace?: RecipeColorSpace): this;
   line(coordinates: [number, number][], options?: RecipePathOptions): this;
   line(
     startX: number,
@@ -336,14 +412,7 @@ export interface Recipe {
     y: number,
     width: number,
     height: number,
-    options?: RecipePathOptions & {
-      borderRadius?:
-        | number
-        | [number]
-        | [number, number]
-        | [number, number, number]
-        | [number, number, number, number];
-    },
+    options?: RecipeRectangleOptions,
   ): this;
   circle(
     x: number,
@@ -364,7 +433,7 @@ export interface Recipe {
     radius: number,
     startAngle?: number,
     endAngle?: number,
-    options?: RecipePathOptions & { sector?: boolean },
+    options?: RecipeArcOptions,
   ): this;
   pie(
     x: number,
@@ -378,14 +447,14 @@ export interface Recipe {
     cx: number,
     cy: number,
     radius: number,
-    options?: RecipePathOptions & { rotationVertice?: number },
+    options?: RecipeNGonOptions,
   ): this;
   n_gon(
     cx: number,
     cy: number,
     radius: number,
     sides?: number,
-    options?: RecipePathOptions & { rotationVertice?: number },
+    options?: RecipeNGonOptions,
   ): this;
   star(
     cx: number,
@@ -400,47 +469,14 @@ export interface Recipe {
     points?: number,
     options?: RecipePathOptions,
   ): this;
-  arrow(
-    x: number,
-    y: number,
-    options?: RecipePathOptions & {
-      head?: number | number[];
-      shaft?: number | number[];
-      double?: boolean;
-      type?: number | "triangle" | "dart" | "kite";
-      at?: "head" | "tail";
-    },
-  ): this;
+  arrow(x: number, y: number, options?: RecipeArrowOptions): this;
   triangle(
     x: number,
     y: number,
     traits: number[] | [number, number][],
-    options?: RecipePathOptions & {
-      traitID?: "sss" | "sas" | "asa" | "vtx";
-      traitsID?: "sss" | "sas" | "asa" | "vtx";
-      position?:
-        | "a"
-        | "b"
-        | "c"
-        | "A"
-        | "B"
-        | "C"
-        | "centroid"
-        | "circumcenter"
-        | "incenter";
-      flipX?: boolean;
-      flipY?: boolean;
-    },
+    options?: RecipeTriangleOptions,
   ): this;
-  lineStyle(options?: {
-    width?: number;
-    lineWidth?: number;
-    cap?: number;
-    join?: number;
-    miterLimit?: number;
-    dash?: number[];
-    dashPhase?: number;
-  }): this;
+  lineStyle(options?: RecipeLineStyleOptions): this;
   lineWidth(width: number): this;
   opacity(value: number): this;
   fill(): this;
@@ -450,31 +486,25 @@ export interface Recipe {
   text(value: string, x: number, y: number, options?: RecipeTextOptions): this;
   textDimensions(value: string, options?: RecipeTextOptions): TextDimensions;
   movedown(lines?: number, returnCoords?: false): this;
-  movedown(lines: number, returnCoords: true): [number, number];
+  movedown(lines: number, returnCoords: true): RecipePosition;
   layout(
     id: string | number,
     x?: number,
     y?: number,
     width?: number,
     height?: number,
-    options?: {
-      columns?: number | RecipeTableColumn[];
-      gap?: number;
-      reset?: boolean;
-    },
+    options?: RecipeLayoutOptions,
   ): this;
   table(
     x: number,
     y: number,
-    contents: Record<string, unknown>[],
+    contents: RecipeTableRow[],
     options?: RecipeTableOptions,
   ): this;
   image(name: string, x: number, y: number, options?: RecipeImageOptions): this;
-  appendPage(
-    name: string,
-    pages?: number | [number, number] | (number | [number, number])[],
-  ): this;
+  appendPage(name: string, pages?: RecipePageSelection): this;
   overlay(name: string, options?: RecipeOverlayOptions): this;
+  overlay(name: string, x: number, options?: RecipeOverlayOptions): this;
   overlay(
     name: string,
     x?: number,
@@ -502,11 +532,9 @@ export interface Recipe {
     name: string,
     sourcePageNumber: number,
   ): this;
-  split(prefix?: string): { name: string; bytes: Uint8Array }[];
-  structure(
-    format?: "string" | "json" | { json?: boolean },
-  ): string | { pages: number; encrypted: boolean; objects: number };
-  permission(flags?: string): number;
+  split(prefix?: string): RecipeSplitResult[];
+  structure(format?: RecipeStructureFormat): string | RecipeStructure;
+  permission(flags?: RecipePermission): number;
   encrypt(options?: RecipeEncryptOptions): this;
   endPDF(callback?: (bytes: Uint8Array) => void): Uint8Array;
   dispose(): void;
@@ -532,17 +560,9 @@ export interface RecipeConstructor {
   unregisterImage(name: string): boolean;
   unregisterPdf(name: string): boolean;
   disposeAssets(): void;
-  splitPdf(
-    name: string,
-    prefix?: string,
-  ): { name: string; bytes: Uint8Array }[];
-  inspectPdf(name: string): {
-    pages: number;
-    level: number;
-    encrypted: boolean;
-    [page: number]: RecipePageInfo;
-  };
-  permission(flags?: string): number;
+  splitPdf(name: string, prefix?: string): RecipeSplitResult[];
+  inspectPdf(name: string): RecipePdfInspection;
+  permission(flags?: RecipePermission): number;
 }
 export interface TextOptions {
   encoding?: TextEncoding;

--- a/packages/wasm/lib/recipe.js
+++ b/packages/wasm/lib/recipe.js
@@ -70,6 +70,17 @@ export function createRecipeFactory({
   }
 
   class Recipe {
+    /**
+     * Creates a byte-first high-level PDF Recipe.
+     * Pass PDF bytes as the first argument to modify an existing document, or
+     * pass only options to create a new document. For Blob or File input, await
+     * `arrayBuffer()` and pass the resulting bytes to the constructor.
+     *
+     * @param {ByteSource|RecipeOptions} [sourceOrOptions={}] Source PDF bytes or creation options.
+     * @param {RecipeOptions} [options={}] Options used when modifying source bytes.
+     * @throws {TypeError} If Recipe options are not an object.
+     * @throws {Error} If password-protected input is requested or the PDF cannot be created.
+     */
     constructor(sourceOrOptions = {}, options = {}) {
       var hasSource =
         sourceOrOptions instanceof Uint8Array ||
@@ -116,20 +127,57 @@ export function createRecipeFactory({
       if (Object.keys(info).length) this.info(info);
     }
 
+    /** The last high-level moveTo, lineTo, or text position in Recipe coordinates. */
     get position() {
       return { ...this._cursor };
     }
 
+    /**
+     * Asynchronously inspects PDF bytes without changing this Recipe's output.
+     * Blob and File inputs are accepted in addition to synchronous byte sources.
+     *
+     * @name readAsync
+     * @function
+     * @memberof Recipe#
+     * @param {AsyncByteSource} bytes - PDF bytes or a blob-like source.
+     * @returns {Promise<RecipeMetadata>} One-based page geometry and the page count.
+     * @throws {TypeError} If the source cannot be normalized to bytes.
+     * @throws {Error} If the bytes cannot be opened as a PDF.
+     */
     async readAsync(bytes) {
       return this.read(await normalizeBytesAsync(bytes, "PDF input"));
     }
 
+    /**
+     * Releases this Recipe's writer and native WebAssembly state.
+     * The instance must not be used after disposal. Registered static assets
+     * remain available until {@link Recipe.disposeAssets} is called.
+     *
+     * @name dispose
+     * @function
+     * @memberof Recipe#
+     * @returns {void}
+     */
     dispose() {
       if (this.writer?.dispose) this.writer.dispose();
       if (this._recipe) module._muhammara_wasm_recipe_destroy(this._recipe);
       this._recipe = 0;
     }
 
+    /**
+     * Adds a named extension method to all Recipe instances.
+     * The callback executes with the Recipe as `this`. Existing Recipe methods
+     * cannot be replaced through this API.
+     *
+     * @name register
+     * @function
+     * @memberof Recipe#
+     * @param {string|RecipeExtension} key - Method name, or a named callback.
+     * @param {RecipeExtension} [callback] - Extension implementation when a name is supplied.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {TypeError} If no method name or callback is available.
+     * @throws {Error} If the method name already exists.
+     */
     register(key, callback) {
       if (typeof key !== "string") {
         callback = key;
@@ -145,10 +193,37 @@ export function createRecipeFactory({
       return this;
     }
 
+    /**
+     * Converts supported DOM-free HTML into styled Recipe text fragments.
+     * This helper does not draw content or alter Recipe state.
+     *
+     * @name htmlToTextObjects
+     * @function
+     * @memberof Recipe#
+     * @param {string} html - HTML source to convert.
+     * @param {Partial<RecipeTextOptions>} [options] - Initial text options.
+     * @returns {RecipeHtmlTextObject[]} Styled fragments in source order.
+     */
     htmlToTextObjects(html, options = {}) {
       return htmlToTextObjects(html, options);
     }
 
+    /**
+     * Sets a page boundary using native PDF bottom-left coordinates.
+     * Changing the media box also updates active Recipe page dimensions.
+     *
+     * @name setPageBox
+     * @function
+     * @memberof Recipe#
+     * @param {PDFPageBoxType} box - Page-box constant.
+     * @param {number} left - Left PDF coordinate.
+     * @param {number} bottom - Bottom PDF coordinate.
+     * @param {number} right - Right PDF coordinate.
+     * @param {number} top - Top PDF coordinate.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {RangeError} If `box` is not a supported page-box constant.
+     * @throws {Error} If the underlying PDF operation fails.
+     */
     setPageBox(box, left, bottom, right, top) {
       if (!Object.values(pageBoxes).includes(box)) {
         throw new RangeError(`Unknown page box: ${box}`);
@@ -168,6 +243,18 @@ export function createRecipeFactory({
       return this;
     }
 
+    /**
+     * Sets the active page's rotation in degrees.
+     * The page metadata is updated so later Recipe-coordinate operations account
+     * for the rotation.
+     *
+     * @name rotate
+     * @function
+     * @memberof Recipe#
+     * @param {number} rotation - Page rotation in degrees.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {Error} If the underlying PDF operation fails.
+     */
     rotate(rotation) {
       call("_muhammara_wasm_recipe_set_page_rotation", this._recipe, rotation);
       var page = this._pages[this._pages.length - 1];
@@ -177,18 +264,30 @@ export function createRecipeFactory({
       return this;
     }
 
+    /**
+     * Saves the active PDF graphics state.
+     * @private
+     */
     _save() {
       if (this._pageContext) return this._pageContext.q() && this;
       call("_muhammara_wasm_recipe_save", this._recipe);
       return this;
     }
 
+    /**
+     * Restores the active PDF graphics state.
+     * @private
+     */
     _restore() {
       if (this._pageContext) return this._pageContext.Q() && this;
       call("_muhammara_wasm_recipe_restore", this._recipe);
       return this;
     }
 
+    /**
+     * Applies a PDF transformation matrix to the active context.
+     * @private
+     */
     _transform(a, b, c, d, e, f) {
       if (this._pageContext)
         return this._pageContext.cm(a, b, c, d, e, f) && this;
@@ -196,6 +295,21 @@ export function createRecipeFactory({
       return this;
     }
 
+    /**
+     * Rotates subsequent content around a point in Recipe coordinates.
+     * Positive angles rotate clockwise because Recipe's y axis points downward.
+     * The transformation remains active until the current graphics state is
+     * restored or the page ends.
+     *
+     * @name rotateContent
+     * @function
+     * @memberof Recipe#
+     * @param {number} degrees - Rotation angle in degrees.
+     * @param {number} [x=0] - Horizontal rotation origin.
+     * @param {number} [y=0] - Vertical rotation origin.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {Error} If there is no active page or the PDF operation fails.
+     */
     rotateContent(degrees, x = 0, y = 0) {
       var radians = (degrees * Math.PI) / 180;
       var cosine = Math.cos(radians);
@@ -206,6 +320,19 @@ export function createRecipeFactory({
         ._transform(1, 0, 0, 1, -point.nx, -point.ny);
     }
 
+    /**
+     * Sets defaults for subsequent line and shape drawing.
+     * When a page context is active, supplied values are applied immediately;
+     * omitted values preserve the stored style.
+     *
+     * @name lineStyle
+     * @function
+     * @memberof Recipe#
+     * @param {RecipeLineStyleOptions} [options] - Width, cap, join, miter, and dash settings.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {TypeError} If a dash pattern containing non-finite values is applied to an active page context.
+     * @throws {Error} If the underlying PDF operation fails.
+     */
     lineStyle(options = {}) {
       this._lineStyle = this._lineStyle || {};
       if (options.width !== undefined || options.lineWidth !== undefined)
@@ -224,6 +351,10 @@ export function createRecipeFactory({
       return this._setLineStyle(options);
     }
 
+    /**
+     * Applies line style values to the active PDF context.
+     * @private
+     */
     _setLineStyle(options = {}) {
       if (this._pageContext) {
         if (options.width !== undefined || options.lineWidth !== undefined)
@@ -264,6 +395,17 @@ export function createRecipeFactory({
       }
     }
 
+    /**
+     * Sets fill and stroke opacity for subsequent drawing.
+     *
+     * @name opacity
+     * @function
+     * @memberof Recipe#
+     * @param {number} value - Opacity from 0 (transparent) through 1 (opaque).
+     * @returns {Recipe} The Recipe instance.
+     * @throws {RangeError} If the value is not finite or outside 0 through 1.
+     * @throws {Error} If the underlying PDF operation fails.
+     */
     opacity(value) {
       if (!Number.isFinite(value) || value < 0 || value > 1) {
         throw new RangeError("Opacity must be a finite number between 0 and 1");
@@ -272,24 +414,40 @@ export function createRecipeFactory({
       return this._setOpacity(value);
     }
 
+    /**
+     * Applies opacity to the active PDF context.
+     * @private
+     */
     _setOpacity(value) {
       if (this._pageContext) this._pageContext.setOpacity(value);
       else call("_muhammara_wasm_recipe_set_opacity", this._recipe, value);
       return this;
     }
 
+    /**
+     * Moves the active native PDF path.
+     * @private
+     */
     _movePdf(x, y) {
       if (this._pageContext) return this._pageContext.m(x, y) && this;
       call("_muhammara_wasm_recipe_move_to", this._recipe, x, y);
       return this;
     }
 
+    /**
+     * Adds a line to the active native PDF path.
+     * @private
+     */
     _linePdf(x, y) {
       if (this._pageContext) return this._pageContext.l(x, y) && this;
       call("_muhammara_wasm_recipe_line_to", this._recipe, x, y);
       return this;
     }
 
+    /**
+     * Adds a cubic curve to the active native PDF path.
+     * @private
+     */
     _curvePdf(x1, y1, x2, y2, x3, y3) {
       if (this._pageContext)
         return this._pageContext.c(x1, y1, x2, y2, x3, y3) && this;
@@ -306,6 +464,10 @@ export function createRecipeFactory({
       return this;
     }
 
+    /**
+     * Draws one text run after coordinate and style normalization.
+     * @private
+     */
     _drawText(value, x, y, options = {}) {
       var point = this._calibrateCoordinate(x, y);
       if (this._pageContext) {
@@ -480,10 +642,35 @@ export function createRecipeFactory({
     }),
   });
   Object.assign(Recipe.prototype, {
+    /**
+     * Registers font bytes globally and makes them available to this Recipe.
+     *
+     * @name registerFont
+     * @function
+     * @memberof Recipe#
+     * @param {string} name - Non-empty font family name.
+     * @param {ByteSource} bytes - Font bytes.
+     * @param {RecipeFontStyle} [type="regular"] - Font family style.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {TypeError} If the name or bytes are invalid.
+     */
     registerFont: function (name, bytes, type) {
       Recipe.registerFont(name, bytes, type);
       return this;
     },
+    /**
+     * Asynchronously registers font bytes and makes them available to this Recipe.
+     *
+     * @name registerFontAsync
+     * @function
+     * @memberof Recipe#
+     * @async
+     * @param {string} name - Non-empty font family name.
+     * @param {AsyncByteSource} bytes - Font bytes or a blob-like source.
+     * @param {RecipeFontStyle} [type="regular"] - Font family style.
+     * @returns {Promise<Recipe>} The Recipe instance after registration.
+     * @throws {TypeError} If the name or bytes are invalid.
+     */
     registerFontAsync: async function (name, bytes, type) {
       await Recipe.registerFontAsync(name, bytes, type);
       return this;
@@ -514,6 +701,17 @@ export function createRecipeFactory({
         createRecipe: (options) => new Recipe(options),
         recrypt,
       }),
+      /**
+       * Finishes this Recipe and splits it into one-page PDF byte arrays.
+       * Calling this method ends the Recipe; result names use one-based page numbers.
+       *
+       * @name split
+       * @function
+       * @memberof Recipe#
+       * @param {string} [prefix="page"] - Prefix for each output filename.
+       * @returns {RecipeSplitResult[]} One result per page in source order.
+       * @throws {Error} If the Recipe cannot be finished or split.
+       */
       split: function (prefix = "page") {
         var name = `split-${state.nextPdf++}`;
         Recipe.registerPdf(name, this.endPDF());

--- a/packages/wasm/lib/recipe/annotation.js
+++ b/packages/wasm/lib/recipe/annotation.js
@@ -54,10 +54,33 @@ export function createAnnotationMethods({
   }
 
   return {
+    /**
+     * Adds a clickable URL link rectangle to the active page.
+     * Coordinates use Recipe's top-left origin.
+     *
+     * @name link
+     * @function
+     * @memberof Recipe#
+     * @param {string} url URL to open.
+     * @param {number} x Left coordinate in Recipe coordinates.
+     * @param {number} y Top coordinate in Recipe coordinates.
+     * @param {number} width Link width.
+     * @param {number} height Link height.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {Error} If the underlying PDF operation fails.
+     */
     link: function (url, x, y, width, height) {
       var point = this._calibrateCoordinate(x, y, 0, -height);
       return this._linkPdf(url, point.nx, point.ny, width, height);
     },
+    /**
+     * Adds a URL link using native PDF coordinates.
+     *
+     * @name _linkPdf
+     * @function
+     * @memberof Recipe#
+     * @private
+     */
     _linkPdf: function (url, left, bottom, width, height) {
       if (this._sourceMode) {
         return (
@@ -87,9 +110,40 @@ export function createAnnotationMethods({
         return this;
       });
     },
+    /**
+     * Queues a text comment annotation on the active page.
+     * Coordinates use Recipe's top-left origin.
+     *
+     * @name comment
+     * @function
+     * @memberof Recipe#
+     * @param {string} text Comment contents.
+     * @param {RecipeCoordinate} x Left coordinate in Recipe coordinates.
+     * @param {RecipeCoordinate} y Top coordinate in Recipe coordinates.
+     * @param {RecipeAnnotationOptions} [options={}] Annotation options. The
+     * `text` argument supplies the contents and the default icon is `Comment`.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {Error} If there is no active page.
+     */
     comment: function (text = "", x, y, options = {}) {
       return this.annot(x, y, "Text", { icon: "Comment", ...options, text });
     },
+    /**
+     * Queues an annotation on the active page.
+     * Coordinates use Recipe's top-left origin; `center` centers that axis.
+     *
+     * @name annot
+     * @function
+     * @memberof Recipe#
+     * @param {RecipeCoordinate} x Left coordinate in Recipe coordinates.
+     * @param {RecipeCoordinate} y Top coordinate in Recipe coordinates.
+     * @param {string} subtype PDF annotation subtype.
+     * @param {RecipeAnnotationOptions} [options={}] Annotation appearance,
+     * contents, replies, dimensions, flags, and rotation handling.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {Error} If there is no active page.
+     * @throws {TypeError} If `subtype` is not a non-empty string.
+     */
     annot: function (x, y, subtype, options = {}) {
       if (!this._pageHeight)
         throw new Error("Annotations require an active page");
@@ -98,6 +152,14 @@ export function createAnnotationMethods({
       this._annotations.push({ x, y, subtype, options: { ...options } });
       return this;
     },
+    /**
+     * Writes and clears annotations queued for the active page.
+     *
+     * @name _flushAnnotations
+     * @function
+     * @memberof Recipe#
+     * @private
+     */
     _flushAnnotations: function () {
       var annotations = this._annotations;
       this._annotations = [];

--- a/packages/wasm/lib/recipe/colors.js
+++ b/packages/wasm/lib/recipe/colors.js
@@ -75,6 +75,24 @@ export function colorModel(recipe, value, options = {}) {
 /** Creates Recipe color registration methods. */
 export function createColorMethods() {
   return {
+    /**
+     * Registers a named color for later use by Recipe drawing methods.
+     *
+     * Array components use values from 0 through 255. Hex strings may start
+     * with `#`, and percentage strings may start with `%`. An empty name is a
+     * no-op. WebAssembly does not support loading color files or Separation
+     * color resources.
+     *
+     * @name chroma
+     * @function
+     * @memberof Recipe#
+     * @param {string} name - The name to register.
+     * @param {RecipeColor} value - A gray, RGB, or CMYK color value.
+     * @param {RecipeColorSpace} [colorspace] - The color space, inferred from the value when omitted.
+     * @returns {Recipe} The recipe instance.
+     * @throws {TypeError} If the color value has an invalid size or the color space is unknown.
+     * @throws {Error} If `name` is `!load` or the Separation color space is requested.
+     */
     chroma: function (name, value, colorspace = "") {
       if (!name) return this;
       if (name === "!load")

--- a/packages/wasm/lib/recipe/composition.js
+++ b/packages/wasm/lib/recipe/composition.js
@@ -9,6 +9,24 @@ export function createCompositionMethods({
   inspectPdf,
 }) {
   return {
+    /**
+     * Appends selected pages from a registered PDF.
+     * Page numbers and inclusive range endpoints are one-based. Omit `pages`
+     * to append every page; out-of-bounds endpoints are clamped to the source.
+     * Appended pages immediately become part of the output and page metadata.
+     *
+     * @name appendPage
+     * @function
+     * @memberof Recipe#
+     * @param {string} name Registered PDF name.
+     * @param {RecipePageSelection} [pages=[]] A one-based page number or an
+     * array of page numbers and inclusive ranges. Ranges must be nested, so
+     * `[1, 3]` selects pages 1 and 3 while `[[1, 3]]` selects pages 1 through 3.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {Error} If no PDF is registered under `name` or appending fails.
+     * @throws {RangeError} If a selection is not an integer range in ascending
+     * order after endpoint clamping.
+     */
     appendPage: function (name, pages = []) {
       var path = pdfs.get(name);
       if (!path) throw new Error(`Unknown PDF: ${name}`);
@@ -78,6 +96,24 @@ export function createCompositionMethods({
       });
     },
 
+    /**
+     * Draws a page from a registered PDF over the active page.
+     * Coordinates use Recipe's top-left origin. The overlay is written into the
+     * active page content.
+     *
+     * @name overlay
+     * @function
+     * @memberof Recipe#
+     * @param {string} name Registered PDF name.
+     * @param {number|RecipeOverlayOptions} [x=0] Left coordinate in Recipe
+     * coordinates, or options for the two-argument form.
+     * @param {number|RecipeOverlayOptions} [y=0] Top coordinate in Recipe
+     * coordinates, or options when `x` is supplied.
+     * @param {RecipeOverlayOptions} [options={}] Source page, scale, aspect
+     * ratio, and page-fitting options. Source page numbers are one-based.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {Error} If no PDF is registered under `name` or drawing fails.
+     */
     overlay: function (name, x = 0, y = 0, options = {}) {
       if (typeof x === "object") {
         options = x;
@@ -144,6 +180,23 @@ export function createCompositionMethods({
       });
     },
 
+    /**
+     * Schedules a page from a registered PDF for insertion in the output.
+     * `afterPageNumber` is zero to insert before the first page, or a one-based
+     * output page number. `sourcePageNumber` is one-based. The insertion is
+     * deferred until `endPDF()` rebuilds the output.
+     *
+     * @name insertPage
+     * @function
+     * @memberof Recipe#
+     * @param {number} afterPageNumber Output position after which to insert.
+     * @param {string} name Registered source PDF name.
+     * @param {number} sourcePageNumber One-based source page number.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {Error} If `afterPageNumber` is not a non-negative integer.
+     * @throws {TypeError} If the PDF is not registered or the source page is
+     * not a positive integer.
+     */
     insertPage: function (afterPageNumber, name, sourcePageNumber) {
       if (!Number.isInteger(afterPageNumber) || afterPageNumber < 0)
         throw new Error("The afterPageNumber is inValid.");
@@ -174,6 +227,20 @@ export function createEndPDF({
   createRecipe,
   recrypt,
 }) {
+  /**
+   * Finishes the Recipe and returns its PDF bytes.
+   * Deferred page insertions rebuild the document and configured encryption is
+   * applied. Repeated calls return cached finished bytes.
+   *
+   * @name endPDF
+   * @function
+   * @memberof Recipe#
+   * @param {function(Uint8Array): void} [callback] Callback invoked with the
+   * same finished bytes that are returned.
+   * @returns {Uint8Array} Finished PDF bytes.
+   * @throws {TypeError} If `callback` is supplied but is not a function.
+   * @throws {Error} If a page is still active or a PDF operation fails.
+   */
   return function (callback) {
     if (callback !== undefined && typeof callback !== "function") {
       throw new TypeError("endPDF callback must be a function");
@@ -231,6 +298,21 @@ export function createSplitPdf({
   call,
   createRecipe,
 }) {
+  /**
+   * Splits a registered PDF into one-page PDF byte arrays.
+   * Output names and source page traversal use one-based page numbers.
+   * This does not modify an existing Recipe; each result is separately built
+   * and finished.
+   *
+   * @name splitPdf
+   * @function
+   * @memberof Recipe
+   * @param {string} name Registered PDF name.
+   * @param {string} [prefix="page"] Prefix used for each output filename.
+   * @returns {RecipeSplitResult[]} One result per source page, in page order.
+   * @throws {Error} If no PDF is registered under `name`, the PDF cannot be
+   * parsed, or an output PDF cannot be created.
+   */
   return function splitPdf(name, prefix = "page") {
     var path = pdfs.get(name);
     if (!path) throw new Error(`Unknown PDF: ${name}`);
@@ -267,6 +349,18 @@ export function createSplitPdf({
 
 /** Creates a function that reports basic structure for the finished PDF. */
 export function createStructure() {
+  /**
+   * Reports basic structure for the finished PDF.
+   * Calling this method finishes the Recipe via `endPDF()`.
+   *
+   * @name structure
+   * @function
+   * @memberof Recipe#
+   * @param {RecipeStructureFormat} [format="string"] Output format.
+   * @returns {string|RecipeStructure} A text summary, or structured page,
+   * encryption, and indirect-object counts for JSON output.
+   * @throws {Error} If the Recipe cannot be finished.
+   */
   return function (format = "string") {
     var bytes = this.endPDF();
     var text = new TextDecoder().decode(bytes);

--- a/packages/wasm/lib/recipe/coordinate.js
+++ b/packages/wasm/lib/recipe/coordinate.js
@@ -1,5 +1,9 @@
 /** Recipe coordinate conversion methods. */
 export var coordinateMethods = {
+  /**
+   * Resolves centered Recipe coordinates against the target page.
+   * @private
+   */
   _centrify: function (x, y, pageNumber) {
     var page = this.pageInfo(
       pageNumber || this._activePageNumber || this._pages.length,
@@ -14,6 +18,7 @@ export var coordinateMethods = {
   /**
    * Converts top-left Recipe coordinates to bottom-left PDF coordinates.
    *
+   * @private
    * @returns {{nx: number, ny: number}} Coordinates with the Y axis flipped.
    * @throws {Error} When no target page is available.
    */
@@ -29,6 +34,10 @@ export var coordinateMethods = {
     };
   },
 
+  /**
+   * Converts bottom-left PDF coordinates to top-left Recipe coordinates.
+   * @private
+   */
   _reverseCoordinate: function (x, y, offsetX = 0, offsetY = 0, pageNumber) {
     var page = this.pageInfo(
       pageNumber || this._activePageNumber || this._pages.length,
@@ -40,6 +49,10 @@ export var coordinateMethods = {
     };
   },
 
+  /**
+   * Converts Recipe coordinates for annotations on rotated pages.
+   * @private
+   */
   _calibrateCoordinateForAnnots: function (
     x,
     y,

--- a/packages/wasm/lib/recipe/htmlToTextObjects.js
+++ b/packages/wasm/lib/recipe/htmlToTextObjects.js
@@ -1,5 +1,15 @@
 // Deliberately small, DOM-free HTML subset so Recipe also works in Workers.
-/** Converts supported HTML into styled Recipe text objects. */
+/**
+ * Converts supported HTML into styled objects consumed by Recipe text layout.
+ * This DOM-free parser recognizes basic emphasis, links, colors, and line-break
+ * elements. It does not draw or change Recipe state, and therefore does not
+ * interpret page coordinates.
+ *
+ * @private
+ * @param {string} html - HTML source to convert.
+ * @param {Partial<RecipeTextOptions>} [options] - Initial text options, including the inherited font.
+ * @returns {RecipeHtmlTextObject[]} Styled text fragments in source order.
+ */
 export function htmlToTextObjects(html, options = {}) {
   var objects = [];
   var styles = [];

--- a/packages/wasm/lib/recipe/image.js
+++ b/packages/wasm/lib/recipe/image.js
@@ -25,6 +25,24 @@ export function createImageMethods(runtime) {
     return { x, y, width, height };
   }
   return {
+    /**
+     * Places a previously registered image on the active page.
+     *
+     * `(x, y)` uses Recipe's top-left coordinate system. Width and height default
+     * to the source dimensions; specifying one dimension preserves aspect ratio,
+     * and specifying both fits within that box unless disabled. A link option
+     * covers the final image bounds.
+     *
+     * @name image
+     * @function
+     * @memberof Recipe#
+     * @param {string} name - The name used when the image bytes were registered.
+     * @param {number} x - The horizontal placement coordinate in points.
+     * @param {number} y - The vertical placement coordinate in points.
+     * @param {RecipeImageOptions} [options] - Image sizing, alignment, page-index, and transformation options.
+     * @returns {Recipe} The recipe instance.
+     * @throws {Error} If the image name is unknown or no target page is available.
+     */
     image: function (name, x, y, options = {}) {
       var path = runtime.images.get(name);
       if (!path) throw new Error(`Unknown image: ${name}`);
@@ -91,6 +109,10 @@ export function createImageMethods(runtime) {
         this.link(options.link, box.x, box.y, box.width, box.height);
       return this;
     },
+    /**
+     * Reads the dimensions of an image in the virtual filesystem.
+     * @private
+     */
     _imageDimensions: function (path) {
       if (this._sourceMode) {
         return this.writer.getImageDimensions(runtime.module.FS.readFile(path));

--- a/packages/wasm/lib/recipe/info.js
+++ b/packages/wasm/lib/recipe/info.js
@@ -10,6 +10,19 @@ export function createInfoMethods({ call, withString }) {
   }
 
   return {
+    /**
+     * Gets the document information dictionary or sets information entries.
+     * Array values are written as comma-and-space-separated text; custom key
+     * spelling is preserved.
+     *
+     * @name info
+     * @function
+     * @memberof Recipe#
+     * @param {Record<string, unknown>} [options] Information entries to set.
+     * Omit this argument to return a copy of the current information.
+     * @returns {Recipe|Record<string, unknown>} The Recipe instance when
+     * setting entries, otherwise a copy of the current information.
+     */
     info: function (options = {}) {
       if (arguments.length === 0) return { ...this._info };
       Object.entries(options).forEach(([key, value]) => {
@@ -39,10 +52,28 @@ export function createInfoMethods({ call, withString }) {
       return this;
     },
 
+    /**
+     * Sets a custom document information entry.
+     *
+     * @name custom
+     * @function
+     * @memberof Recipe#
+     * @param {string} key Information dictionary key.
+     * @param {unknown} value Value converted to text for the PDF.
+     * @returns {Recipe} The Recipe instance.
+     */
     custom: function (key, value) {
       return this.info({ [key]: value });
     },
 
+    /**
+     * Writes canonical creation and modification information.
+     *
+     * @name _writeCanonicalInfo
+     * @function
+     * @memberof Recipe#
+     * @private
+     */
     _writeCanonicalInfo: function () {
       var info = this._sourceMode
         ? this.writer.getDocumentContext().getInfoDictionary()

--- a/packages/wasm/lib/recipe/inspection.js
+++ b/packages/wasm/lib/recipe/inspection.js
@@ -1,5 +1,20 @@
 /** Creates a function that inspects a registered PDF's metadata and pages. */
 export function createInspectPdf({ module, withString, pdfs }) {
+  /**
+   * Inspects metadata and page geometry for a registered PDF.
+   * Numeric page records are keyed by one-based page numbers. Page dimensions
+   * use Recipe's top-left coordinate orientation and account for page rotation.
+   * Inspection does not change any Recipe output state.
+   *
+   * @name inspectPdf
+   * @function
+   * @memberof Recipe
+   * @param {string} name Registered PDF name.
+   * @returns {RecipePdfInspection} PDF level, encryption status, page count,
+   * and one-based page records.
+   * @throws {Error} If no PDF is registered under `name`, the PDF cannot be
+   * parsed, or page information cannot be read.
+   */
   return function inspectPdf(name) {
     var path = pdfs.get(name);
     if (!path) throw new Error(`Unknown PDF: ${name}`);

--- a/packages/wasm/lib/recipe/page.js
+++ b/packages/wasm/lib/recipe/page.js
@@ -7,6 +7,22 @@ export function createPageMethods(
   { createReader, createWriterToModify, module },
 ) {
   return {
+    /**
+     * Creates and activates a page, using dimensions in PDF points.
+     * Named sizes are case-insensitive and fall back to the configured default;
+     * a rotation not divisible by 180 swaps the named size's width and height.
+     * The new page uses Recipe's top-left coordinate system, with x increasing
+     * rightward and y increasing downward, and resets the cursor to `(0, 0)`.
+     *
+     * @name createPage
+     * @function
+     * @memberof Recipe#
+     * @param {number|string} [width] - Page width, or a named page size.
+     * @param {number} [height] - Page height, or rotation for a named size.
+     * @param {RecipeMargins} [margins] - Margins for the new page.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {Error} If the PDF has already been ended.
+     */
     createPage: function (width, height, margins) {
       if (this._endedBytes)
         throw new Error("Cannot create a page after endPDF");
@@ -51,6 +67,16 @@ export function createPageMethods(
       return this;
     },
 
+    /**
+     * Finishes the active new or edited page and flushes its annotations.
+     * Calling this method without an active page has no effect. The active page
+     * dimensions are cleared, so page drawing must resume on another active page.
+     *
+     * @name endPage
+     * @function
+     * @memberof Recipe#
+     * @returns {Recipe} The Recipe instance.
+     */
     endPage: function () {
       if (this._editingPage) {
         this._flushAnnotations();
@@ -83,6 +109,20 @@ export function createPageMethods(
       return this;
     },
 
+    /**
+     * Gets or updates the margins used by implicit positioning and layout.
+     * Margins are measured inward in PDF points from the page edges in Recipe's
+     * top-left coordinate system. Omitted values retain their current settings.
+     *
+     * @name margins
+     * @function
+     * @memberof Recipe#
+     * @param {number|RecipeMargins} [left] - Left margin, or margins to update.
+     * @param {number} [right] - Right margin.
+     * @param {number} [top] - Top margin.
+     * @param {number} [bottom] - Bottom margin.
+     * @returns {Recipe|Required<RecipeMargins>} The Recipe instance when a margin changes; otherwise a copy of the current margins.
+     */
     margins: function (left, right, top, bottom) {
       if (left && typeof left === "object")
         ({ left, right, top, bottom } = left);
@@ -97,6 +137,17 @@ export function createPageMethods(
       return changed ? this : { ...this._margin };
     },
 
+    /**
+     * Returns geometry for a one-based page number without changing active state.
+     * Width and height follow Recipe's rotated, top-left coordinate space;
+     * `mediaBox` remains the page's native PDF rectangle.
+     *
+     * @name pageInfo
+     * @function
+     * @memberof Recipe#
+     * @param {number} pageNumber - One-based page number.
+     * @returns {RecipePageInfo|null} A defensive copy of the page geometry, or null when the page does not exist.
+     */
     pageInfo: function (pageNumber) {
       var page = this._pages[pageNumber - 1];
       return page
@@ -104,17 +155,40 @@ export function createPageMethods(
         : null;
     },
 
+    /**
+     * Returns the document information dictionary without changing page state.
+     * This method reports PDF metadata, not Recipe-coordinate page geometry;
+     * use {@link Recipe#pageInfo} or {@link Recipe#getCurrentPageInfo} for geometry.
+     *
+     * @name getPageInfo
+     * @function
+     * @memberof Recipe#
+     * @returns {Record<string, unknown>|InfoDictionary} The current document information dictionary.
+     */
     getPageInfo: function () {
       return this._sourceMode
         ? this.writer.getDocumentContext().getInfoDictionary()
         : this.info();
     },
 
-    /** Returns Recipe's page geometry for the active page, unlike getPageInfo(). */
+    /**
+     * Returns geometry for the active or most recently known Recipe page.
+     * Width and height follow Recipe's rotated, top-left coordinate space;
+     * `mediaBox` remains the page's native PDF rectangle. No state is changed.
+     *
+     * @name getCurrentPageInfo
+     * @function
+     * @memberof Recipe#
+     * @returns {RecipePageInfo|null} A defensive copy of the page geometry, or null when no page is known.
+     */
     getCurrentPageInfo: function () {
       return this.pageInfo(this._activePageNumber || this._pages.length);
     },
 
+    /**
+     * Inspects source bytes and closes the temporary reader.
+     * @private
+     */
     _inspectBytes: function (bytes) {
       var reader = createReader(bytes);
       var pages = [];
@@ -156,11 +230,27 @@ export function createPageMethods(
       return { pages, metadata, sourceInfo };
     },
 
+    /**
+     * Inspects a PDF without replacing or otherwise changing this Recipe's output state.
+     * Reported page width and height use Recipe's rotated, top-left coordinate
+     * space, while each `mediaBox` is the native PDF rectangle.
+     *
+     * @name read
+     * @function
+     * @memberof Recipe#
+     * @param {ByteSource} bytes - PDF bytes to inspect synchronously.
+     * @returns {RecipeMetadata} Page count and one-based page geometry records.
+     * @throws {Error} If the bytes cannot be opened as a PDF.
+     */
     read: function (bytes) {
       // Like Node Recipe.read(externalSource), inspection must not replace output state.
       return this._inspectBytes(bytes).metadata;
     },
 
+    /**
+     * Opens bytes as this Recipe's modification source and replaces output state.
+     * @private
+     */
     _openSource: function (bytes) {
       var { pages, metadata, sourceInfo } = this._inspectBytes(bytes);
       if (this._recipe) {
@@ -181,6 +271,20 @@ export function createPageMethods(
       return metadata;
     },
 
+    /**
+     * Starts a prepend-safe content context for an existing one-based page.
+     * Drawing uses Recipe's top-left coordinates, including the page's rotation;
+     * the cursor moves to the configured left and top margins. The edit remains
+     * active until {@link Recipe#endPage} is called.
+     *
+     * @name editPage
+     * @function
+     * @memberof Recipe#
+     * @param {number} pageNumber - One-based page number to edit.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {Error} If the Recipe was not constructed from PDF bytes or another page is active.
+     * @throws {RangeError} If `pageNumber` does not identify an existing page.
+     */
     editPage: function (pageNumber) {
       if (!this._sourceMode) {
         throw new Error(
@@ -209,6 +313,17 @@ export function createPageMethods(
       return this;
     },
 
+    /**
+     * Writes and pauses the active edited-page content context.
+     * Page editing remains active, and a later resume restores the page's
+     * rotated, top-left Recipe coordinate transform.
+     *
+     * @name pauseContext
+     * @function
+     * @memberof Recipe#
+     * @returns {Recipe} The Recipe instance.
+     * @throws {Error} If there is no active edited-page content context.
+     */
     pauseContext: function () {
       if (!this._editingPage || !this._pageContext) {
         throw new Error("No active page content context to pause");
@@ -220,6 +335,17 @@ export function createPageMethods(
       return this;
     },
 
+    /**
+     * Resumes a paused edited-page content context.
+     * The page rotation transform is reapplied so subsequent drawing continues
+     * in Recipe's top-left coordinate system.
+     *
+     * @name resumeContext
+     * @function
+     * @memberof Recipe#
+     * @returns {Recipe} The Recipe instance.
+     * @throws {Error} If no edited page is paused, or its context is already active.
+     */
     resumeContext: function () {
       if (!this._editingPage || this._pageContext) {
         throw new Error("No paused page content context to resume");
@@ -233,6 +359,10 @@ export function createPageMethods(
       return this;
     },
 
+    /**
+     * Restores the active page's Recipe coordinate transform after resuming.
+     * @private
+     */
     _resumePageRotation: function () {
       var page = this.getCurrentPageInfo();
       if (!page || !page.rotate) return this;

--- a/packages/wasm/lib/recipe/registration.js
+++ b/packages/wasm/lib/recipe/registration.js
@@ -13,6 +13,19 @@ export function createRegistrationMethods({
   removeFile,
 }) {
   return {
+    /**
+     * Registers font bytes under a name and style for future Recipe instances.
+     * Registering the same name and style replaces and removes the prior asset.
+     *
+     * @name registerFont
+     * @function
+     * @memberof Recipe
+     * @param {string} name Non-empty font family name used by Recipe text.
+     * @param {ByteSource} bytes Font bytes.
+     * @param {RecipeFontStyle} [type="regular"] Font family style.
+     * @returns {void}
+     * @throws {TypeError} If the name is empty or the bytes are unsupported.
+     */
     registerFont: function (name, bytes) {
       if (typeof name !== "string" || !name) {
         throw new TypeError("Font names must be non-empty strings");
@@ -29,6 +42,20 @@ export function createRegistrationMethods({
         removeFile(previous);
       }
     },
+    /**
+     * Asynchronously registers a font for future Recipe instances.
+     * Registering the same name and style replaces and removes the prior asset.
+     *
+     * @name registerFontAsync
+     * @function
+     * @memberof Recipe
+     * @async
+     * @param {string} name Non-empty font family name used by Recipe text.
+     * @param {AsyncByteSource} bytes Font bytes or an asynchronous byte source.
+     * @param {RecipeFontStyle} [type="regular"] Font family style.
+     * @returns {Promise<void>} Resolves after the font is registered.
+     * @throws {TypeError} If the name is empty or the bytes are unsupported.
+     */
     registerFontAsync: async function (name, bytes, type) {
       return this.registerFont(
         name,
@@ -36,6 +63,20 @@ export function createRegistrationMethods({
         type,
       );
     },
+    /**
+     * Registers image bytes under a name for future Recipe instances.
+     * Registering the same name replaces and removes the prior asset.
+     *
+     * @name registerImage
+     * @function
+     * @memberof Recipe
+     * @param {string} name Image name used by `Recipe#image`.
+     * @param {ByteSource} bytes Image bytes.
+     * @param {string} extension Image filename extension.
+     * @returns {void}
+     * @throws {TypeError} If the bytes are unsupported or the extension is not
+     * a supported JPEG, PNG, or TIFF extension.
+     */
     registerImage: function (name, bytes, extension) {
       bytes = normalizeBytes(bytes, "Image bytes");
       if (!/^(jpe?g|png|tiff?)$/i.test(extension || ""))
@@ -47,6 +88,21 @@ export function createRegistrationMethods({
       images.set(name, path);
       if (previous) removeFile(previous);
     },
+    /**
+     * Asynchronously registers an image for future Recipe instances.
+     * Registering the same name replaces and removes the prior asset.
+     *
+     * @name registerImageAsync
+     * @function
+     * @memberof Recipe
+     * @async
+     * @param {string} name Image name used by `Recipe#image`.
+     * @param {AsyncByteSource} bytes Image bytes or an asynchronous byte source.
+     * @param {string} extension Image filename extension.
+     * @returns {Promise<void>} Resolves after the image is registered.
+     * @throws {TypeError} If the bytes are unsupported or the extension is not
+     * a supported JPEG, PNG, or TIFF extension.
+     */
     registerImageAsync: async function (name, bytes, extension) {
       return this.registerImage(
         name,
@@ -54,6 +110,18 @@ export function createRegistrationMethods({
         extension,
       );
     },
+    /**
+     * Registers PDF bytes under a name for composition and inspection.
+     * Registering the same name replaces and removes the prior asset.
+     *
+     * @name registerPdf
+     * @function
+     * @memberof Recipe
+     * @param {string} name PDF name used by composition and inspection methods.
+     * @param {ByteSource} bytes PDF bytes.
+     * @returns {void}
+     * @throws {TypeError} If the bytes are unsupported.
+     */
     registerPdf: function (name, bytes) {
       bytes = normalizeBytes(bytes, "PDF bytes");
       var path = `/recipe-pdfs/${state.nextPdf++}.pdf`;
@@ -63,12 +131,35 @@ export function createRegistrationMethods({
       pdfs.set(name, path);
       if (previous) removeFile(previous);
     },
+    /**
+     * Asynchronously registers a PDF for composition and inspection.
+     * Registering the same name replaces and removes the prior asset.
+     *
+     * @name registerPdfAsync
+     * @function
+     * @memberof Recipe
+     * @async
+     * @param {string} name PDF name used by composition and inspection methods.
+     * @param {AsyncByteSource} bytes PDF bytes or an asynchronous byte source.
+     * @returns {Promise<void>} Resolves after the PDF is registered.
+     * @throws {TypeError} If the bytes are unsupported.
+     */
     registerPdfAsync: async function (name, bytes) {
       return this.registerPdf(
         name,
         await normalizeBytesAsync(bytes, "PDF bytes"),
       );
     },
+    /**
+     * Removes one registered font style.
+     *
+     * @name unregisterFont
+     * @function
+     * @memberof Recipe
+     * @param {string} name Registered font family name.
+     * @param {RecipeFontStyle} [type="regular"] Font family style to remove.
+     * @returns {boolean} Whether a matching registered style was removed.
+     */
     unregisterFont: function (name, type = "regular") {
       var key = String(name).toLowerCase();
       var family = fonts.get(key);
@@ -90,6 +181,15 @@ export function createRegistrationMethods({
       removeFile(path);
       return true;
     },
+    /**
+     * Removes a registered image.
+     *
+     * @name unregisterImage
+     * @function
+     * @memberof Recipe
+     * @param {string} name Registered image name.
+     * @returns {boolean} Whether a matching image was removed.
+     */
     unregisterImage: function (name) {
       var path = images.get(name);
       if (!path) return false;
@@ -97,6 +197,15 @@ export function createRegistrationMethods({
       removeFile(path);
       return true;
     },
+    /**
+     * Removes a registered PDF.
+     *
+     * @name unregisterPdf
+     * @function
+     * @memberof Recipe
+     * @param {string} name Registered PDF name.
+     * @returns {boolean} Whether a matching PDF was removed.
+     */
     unregisterPdf: function (name) {
       var path = pdfs.get(name);
       if (!path) return false;
@@ -104,6 +213,14 @@ export function createRegistrationMethods({
       removeFile(path);
       return true;
     },
+    /**
+     * Removes all globally registered Recipe assets.
+     *
+     * @name disposeAssets
+     * @function
+     * @memberof Recipe
+     * @returns {void}
+     */
     disposeAssets: function () {
       fonts.forEach((family) =>
         Object.values(family).forEach((path) => {

--- a/packages/wasm/lib/recipe/replace-text.js
+++ b/packages/wasm/lib/recipe/replace-text.js
@@ -15,11 +15,18 @@ export function createReplaceTextMethods(encoder) {
   return {
     /**
      * Replaces literal text-showing operands in a page's single content stream.
+     * Matching content is replaced in the output; no match leaves it unchanged.
      *
+     * @name replaceText
+     * @function
+     * @memberof Recipe#
      * @param {string} text Text to replace.
      * @param {string} replacement Replacement text.
      * @param {number} pageNumber One-based page number.
-     * @returns {this}
+     * @returns {Recipe} The Recipe instance.
+     * @throws {TypeError} If text or replacement is not a string, or if the
+     * page number is not a positive integer.
+     * @throws {Error} If the page does not have one indirect content stream.
      */
     replaceText: function (text, replacement, pageNumber) {
       if (typeof text !== "string" || typeof replacement !== "string") {

--- a/packages/wasm/lib/recipe/security.js
+++ b/packages/wasm/lib/recipe/security.js
@@ -1,4 +1,14 @@
-/** Converts comma-separated PDF permission names to a bitmask. */
+/**
+ * Converts comma-separated PDF permission names to a user-protection bitmask.
+ *
+ * @name permission
+ * @function
+ * @memberof Recipe
+ * @param {RecipePermission} [flags="print"] Permission names separated by
+ * commas.
+ * @returns {number} Numeric PDF user-protection flags.
+ * @throws {Error} If a permission name is unknown.
+ */
 export function permission(flags = "print") {
   var bits = {
     print: 4,
@@ -46,8 +56,40 @@ export function createSecurityMethods() {
     return encryptOptions;
   }
   return {
+    /**
+     * Converts comma-separated PDF permission names to a user-protection bitmask.
+     *
+     * @name permission
+     * @function
+     * @memberof Recipe#
+     * @param {RecipePermission} [flags="print"] Permission names separated by
+     * commas.
+     * @returns {number} Numeric PDF user-protection flags.
+     * @throws {Error} If a permission name is unknown.
+     */
     permission,
+    /**
+     * Normalizes Recipe encryption options.
+     *
+     * @name _getEncryptOptions
+     * @function
+     * @memberof Recipe#
+     * @private
+     */
     _getEncryptOptions: getEncryptOptions,
+    /**
+     * Configures encryption for the finished PDF.
+     *
+     * @name encrypt
+     * @function
+     * @memberof Recipe#
+     * @param {RecipeEncryptOptions} [options={}] Owner and user passwords and
+     * numeric user-protection flags. Supplying only an owner password permits
+     * printing by default.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {TypeError} If `options` is not a non-array object.
+     * @throws {Error} If the Recipe has already been finished.
+     */
     encrypt: function (options = {}) {
       if (!options || typeof options !== "object" || Array.isArray(options)) {
         throw new TypeError("encrypt options must be an object");

--- a/packages/wasm/lib/recipe/shapes.js
+++ b/packages/wasm/lib/recipe/shapes.js
@@ -217,6 +217,25 @@ function debugTriangle(recipe, x, y, vertices, sides, position, options) {
 /** Creates Recipe methods for geometric shapes. */
 export function createShapeMethods() {
   return {
+    /**
+     * Draws a regular polygon centered at `(cx, cy)`.
+     *
+     * Coordinates use Recipe's top-left origin and require an active page. The
+     * side count is clamped to at least three. Passing options in place of
+     * `sides` draws a triangle.
+     *
+     * @name n_gon
+     * @function
+     * @memberof Recipe#
+     * @param {number} cx - The center X coordinate in points.
+     * @param {number} cy - The center Y coordinate in points.
+     * @param {number} radius - The center-to-vertex radius in points.
+     * @param {number|RecipeNGonOptions} [sides=3] - The side count, or options for a triangle.
+     * @param {RecipeNGonOptions} [options] - Polygon and rotation-vertex options.
+     * @returns {Recipe} The recipe instance.
+     * @throws {Error} If no target page is available or an unsupported color is requested.
+     * @throws {TypeError} If the requested color space is unknown.
+     */
     n_gon: function (cx, cy, radius, sides = 3, options = {}) {
       if (typeof sides === "object") [options, sides] = [sides, 3];
       sides = Math.max(3, Math.floor(sides));
@@ -240,6 +259,25 @@ export function createShapeMethods() {
       ]);
       return this;
     },
+    /**
+     * Draws a star centered at `(cx, cy)`.
+     *
+     * Coordinates use Recipe's top-left origin and require an active page. The
+     * point count is clamped to at least five. Passing options in place of
+     * `points` draws a five-pointed star.
+     *
+     * @name star
+     * @function
+     * @memberof Recipe#
+     * @param {number} cx - The center X coordinate in points.
+     * @param {number} cy - The center Y coordinate in points.
+     * @param {number} radius - The center-to-point radius in points.
+     * @param {number|RecipePathOptions} [points=5] - The point count, or path options for a five-pointed star.
+     * @param {RecipePathOptions} [options] - Path painting and transformation options.
+     * @returns {Recipe} The recipe instance.
+     * @throws {Error} If no target page is available or an unsupported color is requested.
+     * @throws {TypeError} If the requested color space is unknown.
+     */
     star: function (cx, cy, radius, points = 5, options = {}) {
       if (typeof points === "object") [options, points] = [points, 5];
       points = Math.max(5, Math.floor(points));
@@ -297,6 +335,23 @@ export function createShapeMethods() {
       }
       return this;
     },
+    /**
+     * Draws an arrow positioned at `(x, y)`.
+     *
+     * Coordinates use Recipe's top-left origin and require an active page. By
+     * default the position identifies the arrow's center; `at` can anchor it at
+     * its head or tail. Rotation uses `(x, y)` as its origin when anchored.
+     *
+     * @name arrow
+     * @function
+     * @memberof Recipe#
+     * @param {number} x - The horizontal anchor coordinate in points.
+     * @param {number} y - The vertical anchor coordinate in points.
+     * @param {RecipeArrowOptions} [options] - Arrow geometry and path options.
+     * @returns {Recipe} The recipe instance.
+     * @throws {Error} If no target page is available or an unsupported color is requested.
+     * @throws {TypeError} If the requested color space is unknown.
+     */
     arrow: function (x, y, options = {}) {
       var originalX = x;
       var headLength = 10,
@@ -404,6 +459,25 @@ export function createShapeMethods() {
       }
       return this;
     },
+    /**
+     * Draws a triangle from three defining traits.
+     *
+     * Coordinates use Recipe's top-left origin and require an active page.
+     * Traits can describe three sides, side-angle-side, angle-side-angle, or
+     * three vertices as selected by `traitID`. Angles are expressed in degrees.
+     *
+     * @name triangle
+     * @function
+     * @memberof Recipe#
+     * @param {number} x - The horizontal position coordinate in points.
+     * @param {number} y - The vertical position coordinate in points.
+     * @param {Array.<number>|Array.<Array.<number>>} traits - Three side/angle values or three coordinate pairs.
+     * @param {RecipeTriangleOptions} [options] - Triangle definition, positioning, and path options.
+     * @returns {Recipe} The recipe instance.
+     * @throws {Error} If traits do not contain three values or do not define a valid triangle.
+     * @throws {Error} If no target page is available or an unsupported color is requested.
+     * @throws {TypeError} If the requested color space is unknown.
+     */
     triangle: function (x, y, traits, options = {}) {
       if (!Array.isArray(traits) || traits.length !== 3)
         throw new Error(

--- a/packages/wasm/lib/recipe/table.js
+++ b/packages/wasm/lib/recipe/table.js
@@ -17,6 +17,24 @@ function cellOptions(options = {}, name = "cell") {
 /** Creates Recipe table layout methods. */
 export function createTableMethods() {
   return {
+    /**
+     * Draws records as a table on the active page.
+     * x and y are PDF points in Recipe's top-left coordinate system, where x
+     * increases rightward and y increases downward. Rows are measured before
+     * drawing, optional overflow handling can continue at another Recipe
+     * position, and the cursor finishes at the table's left edge and bottom.
+     * Empty contents leave the Recipe unchanged.
+     *
+     * @name table
+     * @function
+     * @memberof Recipe#
+     * @param {number} x - Left table coordinate.
+     * @param {number} y - Top table coordinate.
+     * @param {RecipeTableRow[]} contents - Records to render as rows.
+     * @param {RecipeTableOptions} [options] - Column, row, header, border, text, and overflow options.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {Error} If table text cannot be measured or drawn, including when a requested font cannot be loaded.
+     */
     table(x, y, contents, options = {}) {
       if (!Array.isArray(contents) || !contents.length) return this;
       var fields = options.order

--- a/packages/wasm/lib/recipe/text.js
+++ b/packages/wasm/lib/recipe/text.js
@@ -98,7 +98,20 @@ export function createTextMethods({ drawText, measure, module }) {
   }
 
   return {
-    /** Measures text using the configured Recipe default unless a font is selected. */
+    /**
+     * Measures text in PDF points using the selected font and character spacing.
+     * The configured Recipe font is used when `options.font` is omitted. This
+     * method does not draw text or change the cursor; returned bounds use font
+     * metric coordinates rather than Recipe page coordinates.
+     *
+     * @name textDimensions
+     * @function
+     * @memberof Recipe#
+     * @param {string} value - Text to measure.
+     * @param {RecipeTextOptions} [options] - Font and measurement options.
+     * @returns {TextDimensions} Text bounds and dimensions in PDF points.
+     * @throws {Error} If the requested font is not registered or cannot be loaded.
+     */
     textDimensions(value, options = {}) {
       return dimensions(this, value, {
         ...options,
@@ -106,6 +119,10 @@ export function createTextMethods({ drawText, measure, module }) {
       });
     },
 
+    /**
+     * Measures the height required by an internal text box.
+     * @private
+     */
     _measureTextBoxHeight(value, options = {}) {
       var box = options.textBox || options.cell || {};
       var [top, right, bottom, left] = padding(box.padding);
@@ -130,6 +147,24 @@ export function createTextMethods({ drawText, measure, module }) {
       );
     },
 
+    /**
+     * Defines named columns for flowing text or table placement.
+     * Coordinates and dimensions are PDF points in Recipe's top-left coordinate
+     * system, where x increases rightward and y increases downward. Zero values
+     * use the corresponding page margin or available page extent. The layout is
+     * stored under `id`; `options.reset` discards columns previously stored there.
+     *
+     * @name layout
+     * @function
+     * @memberof Recipe#
+     * @param {string|number} id - Layout identifier used by text flow.
+     * @param {number} [x=0] - Left position; zero uses the left margin.
+     * @param {number} [y=0] - Top position; zero uses the top margin.
+     * @param {number} [width=0] - Layout width; zero uses the available width.
+     * @param {number} [height=0] - Layout height; zero uses the available height.
+     * @param {RecipeLayoutOptions} [options] - Column definitions and reset behavior.
+     * @returns {Recipe} The Recipe instance.
+     */
     layout(id, x = 0, y = 0, width = 0, height = 0, options = {}) {
       this._layouts ||= {};
       if (options.reset || !this._layouts[id]) this._layouts[id] = [];
@@ -166,13 +201,43 @@ export function createTextMethods({ drawText, measure, module }) {
       return this;
     },
 
+    /**
+     * Moves the text cursor downward by a number of line heights.
+     * Movement is in Recipe's top-left coordinate system and resets x to the
+     * current text box origin when one exists. The current line height defaults
+     * to 14 points until text has established another value.
+     *
+     * @name movedown
+     * @function
+     * @memberof Recipe#
+     * @param {number} [count=1] - Number of line heights to move.
+     * @param {boolean} [returnCoords=false] - Return the new coordinates instead of the Recipe instance.
+     * @returns {Recipe|RecipePosition} The Recipe instance, or the new `[x, y]` coordinates.
+     */
     movedown(count = 1, returnCoords = false) {
       this._cursor.x = this._textBoxOrigin?.x ?? this._cursor.x;
       this._cursor.y += count * (this._lastLineHeight || 14);
       return returnCoords ? [this._cursor.x, this._cursor.y] : this;
     },
 
-    /** Draws text using the configured Recipe default unless a font is selected. */
+    /**
+     * Draws text on the active page and advances the Recipe text cursor.
+     * Explicit x and y values are PDF points in Recipe's top-left coordinate
+     * system, where x increases rightward and y increases downward. When they
+     * are omitted, drawing starts at the cursor or margins. Text boxes, flow,
+     * HTML styling, links, highlighting, clipping, and named layouts are
+     * controlled by `RecipeTextOptions`.
+     *
+     * @name text
+     * @function
+     * @memberof Recipe#
+     * @param {string} [value=''] - Text or supported HTML source to draw.
+     * @param {number|RecipeTextOptions} [x] - Left coordinate, or options when coordinates are omitted.
+     * @param {number} [y] - Top coordinate.
+     * @param {RecipeTextOptions} [options] - Text and layout options.
+     * @returns {Recipe} The Recipe instance.
+     * @throws {Error} If a requested overflow layout is undefined, text clipping cannot be applied, or a requested font cannot be loaded.
+     */
     text(value = "", x, y, options = {}) {
       if (typeof x === "object" || x === undefined) {
         options = x || {};

--- a/packages/wasm/lib/recipe/vector-line.js
+++ b/packages/wasm/lib/recipe/vector-line.js
@@ -1,11 +1,41 @@
 /** Creates Recipe line and path methods. */
 export function createLineMethods(runtime) {
   return {
+    /**
+     * Moves the current path position without drawing.
+     *
+     * Coordinates use Recipe's top-left origin and require an active page.
+     *
+     * @name moveTo
+     * @function
+     * @memberof Recipe#
+     * @param {number} x - The horizontal coordinate in points.
+     * @param {number} y - The vertical coordinate in points.
+     * @returns {Recipe} The recipe instance.
+     * @throws {Error} If no target page is available.
+     */
     moveTo: function (x, y) {
       var point = this._calibrateCoordinate(x, y);
       this._cursor = { x, y };
       return this._movePdf(point.nx, point.ny);
     },
+    /**
+     * Adds a line from the current path position to a point.
+     *
+     * Coordinates use Recipe's top-left origin and require an active page. If
+     * options are supplied, the line is painted immediately; otherwise it is
+     * appended to the current path. The current path position becomes `(x, y)`.
+     *
+     * @name lineTo
+     * @function
+     * @memberof Recipe#
+     * @param {number} x - The destination horizontal coordinate in points.
+     * @param {number} y - The destination vertical coordinate in points.
+     * @param {RecipePathOptions} [options] - Path painting and transformation options.
+     * @returns {Recipe} The recipe instance.
+     * @throws {Error} If no target page is available or an unsupported color is requested.
+     * @throws {TypeError} If the requested color space is unknown.
+     */
     lineTo: function (x, y, options) {
       var point = this._calibrateCoordinate(x, y);
       this._cursor = { x, y };
@@ -16,6 +46,25 @@ export function createLineMethods(runtime) {
       }
       return this._linePdf(point.nx, point.ny);
     },
+    /**
+     * Draws a line through two or more points.
+     *
+     * Pass either an array of coordinate pairs followed by options, or four
+     * coordinates followed by options. Coordinates use Recipe's top-left
+     * origin and require an active page. Lines are always stroked, never filled.
+     *
+     * @name line
+     * @function
+     * @memberof Recipe#
+     * @param {number|Array.<Array.<number>>} startX - The start X coordinate, or all coordinate pairs.
+     * @param {number|RecipePathOptions} startY - The start Y coordinate, or options for the array form.
+     * @param {number} [endX] - The end X coordinate in the numeric form.
+     * @param {number} [endY] - The end Y coordinate in the numeric form.
+     * @param {RecipePathOptions} [options] - Path painting and transformation options.
+     * @returns {Recipe} The recipe instance.
+     * @throws {TypeError} If fewer than two coordinate pairs are supplied or the color space is unknown.
+     * @throws {Error} If no target page is available or an unsupported color is requested.
+     */
     line: function (startX, startY, endX, endY, options = {}) {
       var points = Array.isArray(startX)
         ? startX

--- a/packages/wasm/lib/recipe/vector-polygon.js
+++ b/packages/wasm/lib/recipe/vector-polygon.js
@@ -1,6 +1,21 @@
 /** Creates Recipe polygon drawing methods. */
 export function createPolygonMethods(runtime) {
   return {
+    /**
+     * Draws a closed polygon through the supplied points.
+     *
+     * Coordinates use Recipe's top-left origin and require an active page. A
+     * link option creates an annotation over the polygon's bounding rectangle.
+     *
+     * @name polygon
+     * @function
+     * @memberof Recipe#
+     * @param {Array.<Array.<number>>} coordinates - Two or more `[x, y]` coordinate pairs.
+     * @param {RecipePathOptions} [options] - Path painting and transformation options.
+     * @returns {Recipe} The recipe instance.
+     * @throws {TypeError} If fewer than two coordinate pairs are supplied or the color space is unknown.
+     * @throws {Error} If no target page is available or an unsupported color is requested.
+     */
     polygon: function (coordinates, options = {}) {
       if (!Array.isArray(coordinates) || coordinates.length < 2)
         throw new TypeError("A polygon needs at least two coordinate pairs");

--- a/packages/wasm/lib/recipe/vector.helper.js
+++ b/packages/wasm/lib/recipe/vector.helper.js
@@ -32,6 +32,10 @@ export function createVectorHelpers(runtime) {
     else operator(recipe, stroke ? 29 : 28, ...model.values);
   }
   return {
+    /**
+     * Normalizes path options against the current Recipe graphics state.
+     * @private
+     */
     _pathOptions: function (options = {}) {
       var lineStyle = this._lineStyle || {};
       var opacity =
@@ -66,6 +70,10 @@ export function createVectorHelpers(runtime) {
         opacity,
       };
     },
+    /**
+     * Saves graphics state and applies path styles and transformations.
+     * @private
+     */
     _beginPath: function (options = {}, x = 0, y = 0) {
       var style = this._pathOptions(options);
       this._save();
@@ -94,6 +102,10 @@ export function createVectorHelpers(runtime) {
       });
       this._setOpacity(style.opacity);
     },
+    /**
+     * Paints the current path and restores the saved graphics state.
+     * @private
+     */
     _finishPath: function (options = {}) {
       var fill = options.fill;
       var stroke = options.stroke || options.color || options.colour;

--- a/packages/wasm/lib/recipe/vector.js
+++ b/packages/wasm/lib/recipe/vector.js
@@ -26,6 +26,25 @@ export function createVectorMethods(runtime) {
     }
   }
   return {
+    /**
+     * Draws a rectangle.
+     *
+     * `(x, y)` is the top-left corner in Recipe coordinates. Set
+     * `useGivenCoords` to use native PDF bottom-left coordinates instead. An
+     * active page is required.
+     *
+     * @name rectangle
+     * @function
+     * @memberof Recipe#
+     * @param {number} x - The horizontal corner coordinate in points.
+     * @param {number} y - The vertical corner coordinate in points.
+     * @param {number} width - The rectangle width in points.
+     * @param {number} height - The rectangle height in points.
+     * @param {RecipeRectangleOptions} [options] - Rectangle path, rounded-corner, and transformation options.
+     * @returns {Recipe} The recipe instance.
+     * @throws {Error} If no target page is available or an unsupported color is requested.
+     * @throws {TypeError} If the requested color space is unknown.
+     */
     rectangle: function (x, y, width, height, options = {}) {
       if (options.borderRadius)
         return this._roundedRectangle(x, y, width, height, options);
@@ -51,6 +70,10 @@ export function createVectorMethods(runtime) {
       addLink(this, options, x, y, width, height);
       return result;
     },
+    /**
+     * Draws a rectangle with normalized corner radii.
+     * @private
+     */
     _roundedRectangle: function (x, y, width, height, options) {
       var linkX = x;
       var linkY = y;
@@ -116,9 +139,42 @@ export function createVectorMethods(runtime) {
       addLink(this, options, linkX, linkY, width, height);
       return result;
     },
+    /**
+     * Draws a circle centered at `(x, y)` in Recipe's top-left coordinate system.
+     *
+     * An active page is required. A link option covers the circle's bounding box.
+     *
+     * @name circle
+     * @function
+     * @memberof Recipe#
+     * @param {number} x - The center X coordinate in points.
+     * @param {number} y - The center Y coordinate in points.
+     * @param {number} radius - The radius in points.
+     * @param {RecipePathOptions} [options] - Path painting and transformation options.
+     * @returns {Recipe} The recipe instance.
+     * @throws {Error} If no target page is available or an unsupported color is requested.
+     * @throws {TypeError} If the requested color space is unknown.
+     */
     circle: function (x, y, radius, options = {}) {
       return this.ellipse(x, y, radius, radius, options);
     },
+    /**
+     * Draws an ellipse centered at `(cx, cy)` in Recipe's top-left coordinate system.
+     *
+     * An active page is required. A link option covers the ellipse's bounding box.
+     *
+     * @name ellipse
+     * @function
+     * @memberof Recipe#
+     * @param {number} cx - The center X coordinate in points.
+     * @param {number} cy - The center Y coordinate in points.
+     * @param {number} rx - The horizontal radius in points.
+     * @param {number} ry - The vertical radius in points.
+     * @param {RecipePathOptions} [options] - Path painting and transformation options.
+     * @returns {Recipe} The recipe instance.
+     * @throws {Error} If no target page is available or an unsupported color is requested.
+     * @throws {TypeError} If the requested color space is unknown.
+     */
     ellipse: function (cx, cy, rx, ry, options = {}) {
       var point = this._calibrateCoordinate(cx, cy);
       var x = point.nx;
@@ -134,6 +190,25 @@ export function createVectorMethods(runtime) {
       addLink(this, options, cx - rx, cy - ry, rx * 2, ry * 2);
       return result;
     },
+    /**
+     * Draws a circular arc centered at `(x, y)`.
+     *
+     * Coordinates use Recipe's top-left origin. Angles are degrees measured
+     * clockwise; negative values run counterclockwise. An active page is required.
+     *
+     * @name arc
+     * @function
+     * @memberof Recipe#
+     * @param {number} x - The center X coordinate in points.
+     * @param {number} y - The center Y coordinate in points.
+     * @param {number} radius - The radius in points.
+     * @param {number} [startAngle=0] - The starting angle in degrees.
+     * @param {number} [endAngle=360] - The ending angle in degrees.
+     * @param {RecipeArcOptions} [options] - Arc path, sector, and transformation options.
+     * @returns {Recipe} The recipe instance.
+     * @throws {Error} If no target page is available or an unsupported color is requested.
+     * @throws {TypeError} If the requested color space is unknown.
+     */
     arc: function (x, y, radius, startAngle = 0, endAngle = 360, options = {}) {
       this._beginPath(options, x, y);
       var point = this._calibrateCoordinate(x, y);
@@ -154,21 +229,76 @@ export function createVectorMethods(runtime) {
       addLink(this, options, x - radius, y - radius, radius * 2, radius * 2);
       return result;
     },
+    /**
+     * Draws a closed circular sector centered at `(x, y)`.
+     *
+     * Coordinates use Recipe's top-left origin. Angles are degrees measured
+     * clockwise; negative values run counterclockwise. An active page is required.
+     *
+     * @name pie
+     * @function
+     * @memberof Recipe#
+     * @param {number} x - The center X coordinate in points.
+     * @param {number} y - The center Y coordinate in points.
+     * @param {number} radius - The radius in points.
+     * @param {number} [startAngle=0] - The starting angle in degrees.
+     * @param {number} [endAngle=360] - The ending angle in degrees.
+     * @param {RecipePathOptions} [options] - Path painting and transformation options.
+     * @returns {Recipe} The recipe instance.
+     * @throws {Error} If no target page is available or an unsupported color is requested.
+     * @throws {TypeError} If the requested color space is unknown.
+     */
     pie: function (x, y, radius, startAngle, endAngle, options = {}) {
       return this.arc(x, y, radius, startAngle, endAngle, {
         ...options,
         sector: true,
       });
     },
+    /**
+     * Sets the default line width for subsequent Recipe paths.
+     *
+     * This updates the stored graphics state and applies it immediately when a
+     * page context is active.
+     *
+     * @name lineWidth
+     * @function
+     * @memberof Recipe#
+     * @param {number} width - The line width in points.
+     * @returns {Recipe} The recipe instance.
+     */
     lineWidth: function (width) {
       return this.lineStyle({ width });
     },
+    /**
+     * Compatibility method for filling the current path; currently a no-op.
+     *
+     * @name fill
+     * @function
+     * @memberof Recipe#
+     * @returns {Recipe} The recipe instance.
+     */
     fill: function () {
       return this;
     },
+    /**
+     * Compatibility method for stroking the current path; currently a no-op.
+     *
+     * @name stroke
+     * @function
+     * @memberof Recipe#
+     * @returns {Recipe} The recipe instance.
+     */
     stroke: function () {
       return this;
     },
+    /**
+     * Compatibility method for filling and stroking the current path; currently a no-op.
+     *
+     * @name fillAndStroke
+     * @function
+     * @memberof Recipe#
+     * @returns {Recipe} The recipe instance.
+     */
     fillAndStroke: function () {
       return this;
     },

--- a/packages/wasm/scripts/generate-reference.mjs
+++ b/packages/wasm/scripts/generate-reference.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import jsdoc2md from "jsdoc-to-markdown";
 
 var packageRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -10,6 +11,27 @@ var declarations = fs.readFileSync(
   path.join(packageRoot, "index.d.ts"),
   "utf8",
 );
+var recipeSources = [
+  path.join(packageRoot, "lib/recipe.js"),
+  ...fs
+    .readdirSync(path.join(packageRoot, "lib/recipe"))
+    .filter((file) => file.endsWith(".js"))
+    .sort()
+    .map((file) => path.join(packageRoot, "lib/recipe", file)),
+];
+var templateData = await jsdoc2md.getTemplateData({ files: recipeSources });
+var recipeData = templateData.filter(
+  (item) =>
+    (item.kind === "class" && item.name === "Recipe") ||
+    (item.memberof === "Recipe" && item.access !== "private"),
+);
+var recipeReference = await jsdoc2md.render({
+  data: recipeData,
+  template: '{{#class name="Recipe"}}{{>docs}}{{/class}}',
+  "heading-depth": 2,
+  "param-list-format": "list",
+  separators: true,
+});
 
 fs.writeFileSync(
   path.join(packageRoot, "docs/reference.md"),
@@ -19,6 +41,16 @@ fs.writeFileSync(
     "This generated reference is the public TypeScript contract exported by",
     "`@muhammara/wasm`. It is useful for finding signatures, overloads, and",
     "option fields. Behavioral guidance is covered by the curated API pages.",
+    "",
+    "## Recipe Methods",
+    "",
+    "The high-level Recipe method reference below is generated from the runtime",
+    "JSDoc. Its named parameter and result types refer to the declarations that",
+    "follow it.",
+    "",
+    recipeReference.trim(),
+    "",
+    "## TypeScript Declarations",
     "",
     "```typescript",
     declarations.trim(),

--- a/packages/wasm/tests/recipe/jsdoc.test.mjs
+++ b/packages/wasm/tests/recipe/jsdoc.test.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import jsdoc2md from "jsdoc-to-markdown";
+import { createRecipeFactory } from "../../lib/recipe.js";
+
+var packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+function interfaceBody(declarations, name) {
+  var start = declarations.indexOf(`export interface ${name} {`);
+  assert.notEqual(start, -1, `Missing ${name} declaration`);
+  var open = declarations.indexOf("{", start);
+  var depth = 0;
+  for (var index = open; index < declarations.length; index += 1) {
+    if (declarations[index] === "{") depth += 1;
+    if (declarations[index] === "}") depth -= 1;
+    if (depth === 0) return declarations.slice(open + 1, index);
+  }
+  throw new Error(`Unclosed ${name} declaration`);
+}
+
+function declaredMethods(body) {
+  return new Set(
+    Array.from(body.matchAll(/^  ([A-Za-z]\w*)\(/gm), (match) => match[1]),
+  );
+}
+
+async function recipeSources() {
+  var recipeFiles = (await readdir(path.join(packageRoot, "lib/recipe")))
+    .filter((file) => file.endsWith(".js"))
+    .map((file) => path.join(packageRoot, "lib/recipe", file));
+  return [path.join(packageRoot, "lib/recipe.js"), ...recipeFiles];
+}
+
+describe("Recipe JSDoc", function () {
+  it("keeps declarations aligned with the composed runtime methods", async function () {
+    var declarations = await readFile(
+      path.join(packageRoot, "index.d.ts"),
+      "utf8",
+    );
+    var Recipe = createRecipeFactory({});
+    var runtimeInstance = new Set(
+      Object.entries(Object.getOwnPropertyDescriptors(Recipe.prototype))
+        .filter(
+          ([name, descriptor]) =>
+            name !== "constructor" &&
+            !name.startsWith("_") &&
+            typeof descriptor.value === "function",
+        )
+        .map(([name]) => name),
+    );
+    var runtimeStatic = new Set(
+      Object.getOwnPropertyNames(Recipe).filter(
+        (name) =>
+          !["length", "name", "prototype"].includes(name) &&
+          typeof Recipe[name] === "function",
+      ),
+    );
+    assert.deepEqual(
+      runtimeInstance,
+      declaredMethods(interfaceBody(declarations, "Recipe")),
+    );
+    assert.deepEqual(
+      runtimeStatic,
+      declaredMethods(interfaceBody(declarations, "RecipeConstructor")),
+    );
+  });
+
+  it("documents every public instance and static method", async function () {
+    var declarations = await readFile(
+      path.join(packageRoot, "index.d.ts"),
+      "utf8",
+    );
+    var sources = await Promise.all(
+      (await recipeSources()).map((file) => readFile(file, "utf8")),
+    );
+    var docs = sources.flatMap((source) =>
+      Array.from(source.matchAll(/\/\*\*([\s\S]*?)\*\//g), (match) => match[1]),
+    );
+    var documented = new Set();
+    docs.forEach((doc) => {
+      var name = doc.match(/@name\s+(\w+)/)?.[1];
+      var member = doc.match(/@memberof\s+Recipe(#?)/)?.[1];
+      if (name && member !== undefined && /@function\b/.test(doc)) {
+        documented.add(`${member || "."}${name}`);
+      }
+    });
+
+    var expected = [
+      ...Array.from(
+        declaredMethods(interfaceBody(declarations, "Recipe")),
+        (name) => `#${name}`,
+      ),
+      ...Array.from(
+        declaredMethods(interfaceBody(declarations, "RecipeConstructor")),
+        (name) => `.${name}`,
+      ),
+    ];
+    assert.deepEqual(
+      expected.filter((method) => !documented.has(method)),
+      [],
+      "Every declared Recipe method needs matching runtime JSDoc",
+    );
+  });
+
+  it("renders every public method into the generated Recipe reference", async function () {
+    var declarations = await readFile(
+      path.join(packageRoot, "index.d.ts"),
+      "utf8",
+    );
+    var data = await jsdoc2md.getTemplateData({ files: await recipeSources() });
+    var recipeData = data.filter(
+      (item) =>
+        (item.kind === "class" && item.name === "Recipe") ||
+        (item.memberof === "Recipe" && item.access !== "private"),
+    );
+    var reference = await jsdoc2md.render({
+      data: recipeData,
+      template: '{{#class name="Recipe"}}{{>docs}}{{/class}}',
+    });
+    var expected = [
+      ...Array.from(
+        declaredMethods(interfaceBody(declarations, "Recipe")),
+        (name) => `Recipe+${name}`,
+      ),
+      ...Array.from(
+        declaredMethods(interfaceBody(declarations, "RecipeConstructor")),
+        (name) => `Recipe.${name}`,
+      ),
+    ];
+    assert.deepEqual(
+      expected.filter((anchor) => !reference.includes(`name="${anchor}"`)),
+      [],
+      "Every declared Recipe method must appear in generated documentation",
+    );
+    assert.doesNotMatch(reference, /name="Recipe\+_/);
+  });
+
+  it("marks underscore-prefixed Recipe methods as private", async function () {
+    for (var file of await recipeSources()) {
+      var source = await readFile(file, "utf8");
+      var methods = source.matchAll(
+        /^\s*(_[A-Za-z]\w*)\s*(?:\([^)]*\)|:\s*(?:async\s+)?(?:function\b|[A-Za-z]\w*\b))/gm,
+      );
+      for (var method of methods) {
+        var preceding = source.slice(0, method.index);
+        var doc = preceding.match(/\/\*\*([\s\S]*?)\*\/\s*$/)?.[1];
+        assert.match(
+          doc || "",
+          /@private\b/,
+          `${file}: ${method[1]} must be documented as private`,
+        );
+      }
+    }
+  });
+});

--- a/packages/wasm/tests/types/types.test.ts
+++ b/packages/wasm/tests/types/types.test.ts
@@ -1,5 +1,28 @@
 import { createMuhammaraWasm, createRecipe } from "../../index.js";
-import type { PDFPageContentItemType, RecipePageInfo } from "../../index.js";
+import type {
+  PDFPageContentItemType,
+  RecipeArcOptions,
+  RecipeArrowOptions,
+  RecipeColorSpace,
+  RecipeLayoutOptions,
+  RecipeLineStyleOptions,
+  RecipeMetadata,
+  RecipeNGonOptions,
+  RecipePageInfo,
+  RecipePageSelection,
+  RecipePdfInspection,
+  RecipePermission,
+  RecipePermissionName,
+  RecipePosition,
+  RecipeRectangleOptions,
+  RecipeSplitResult,
+  RecipeStructure,
+  RecipeStructureFormat,
+  RecipeTableRow,
+  RecipeTriangleOptions,
+  RecipeTrianglePosition,
+  RecipeTriangleTrait,
+} from "../../index.js";
 import { PDFPage } from "../../index.js";
 
 // @ts-expect-error PDFPage is available only from a loaded runtime instance.
@@ -249,9 +272,47 @@ async function usesLowLevelSurface() {
   await Recipe.registerImageAsync("image-async", new Blob(), "tiff");
   Recipe.registerPdf("pdf", source);
   await Recipe.registerPdfAsync("pdf-async", sourceBlob);
-  Recipe.inspectPdf("pdf")[1].offsetX;
-  Recipe.splitPdf("pdf", "part")[0].bytes;
-  Recipe.permission("print, copy");
+  var inspection: RecipePdfInspection = Recipe.inspectPdf("pdf");
+  inspection[1].offsetX;
+  var splitResults: RecipeSplitResult[] = Recipe.splitPdf("pdf", "part");
+  splitResults[0].bytes;
+  var permission: RecipePermission = "print, copy";
+  var permissionName: RecipePermissionName = "print";
+  var arbitraryPermissionList: string = "print, copy, edit";
+  Recipe.permission(permission);
+  Recipe.permission(arbitraryPermissionList);
+  var colorSpace: RecipeColorSpace = "rgb";
+  var pageSelection: RecipePageSelection = [1, [2, 3]];
+  var rectangleOptions: RecipeRectangleOptions = { borderRadius: [1, 2] };
+  var arcOptions: RecipeArcOptions = { sector: true };
+  var ngonOptions: RecipeNGonOptions = { rotationVertice: 1 };
+  var arrowOptions: RecipeArrowOptions = { type: "kite", at: "head" };
+  var triangleOptions: RecipeTriangleOptions = {
+    traitID: "sss",
+    position: "centroid",
+  };
+  var lineStyleOptions: RecipeLineStyleOptions = { dash: [1, 2] };
+  var layoutOptions: RecipeLayoutOptions = { columns: 2, gap: 18 };
+  var structureFormat: RecipeStructureFormat = { json: true };
+  var position: RecipePosition = [10, 20];
+  var row: RecipeTableRow = { name: "Ada" };
+  var triangleTrait: RecipeTriangleTrait = "sss";
+  var trianglePosition: RecipeTrianglePosition = "centroid";
+  void permissionName;
+  void colorSpace;
+  void pageSelection;
+  void rectangleOptions;
+  void arcOptions;
+  void ngonOptions;
+  void arrowOptions;
+  void triangleOptions;
+  void lineStyleOptions;
+  void layoutOptions;
+  void structureFormat;
+  void position;
+  void row;
+  void triangleTrait;
+  void trianglePosition;
   var recipe = new Recipe({ version: 1.7, compress: false, title: "Byte PDF" });
   recipe
     .createPage()
@@ -369,6 +430,7 @@ async function usesLowLevelSurface() {
     })
     .appendPage("pdf", [1, [2, 3]])
     .overlay("pdf", { page: 1, fitWidth: true })
+    .overlay("pdf", 10, { page: 1 })
     .overlay("pdf", 10, 10, {
       page: 1,
       fitHeight: true,
@@ -412,8 +474,14 @@ async function usesLowLevelSurface() {
   byteRecipe.getCurrentPageInfo()?.rotate;
   byteRecipe.editPage(1).pauseContext().resumeContext().endPage().endPDF();
   var asyncByteRecipe = new Recipe();
-  await asyncByteRecipe.readAsync(sourceBlob);
+  var metadata: RecipeMetadata = await asyncByteRecipe.readAsync(sourceBlob);
+  metadata[1].width;
   asyncByteRecipe.editPage(1).endPage().endPDF();
+  var structure = recipe.structure("json");
+  if (typeof structure !== "string") {
+    var typedStructure: RecipeStructure = structure;
+    typedStructure.objects;
+  }
 }
 
 void usesLowLevelSurface;


### PR DESCRIPTION
## Summary

- document every public Wasm Recipe method and hide private helpers
- generate Recipe reference content from JSDoc and enforce runtime/type/doc parity
- reuse named TypeScript option and result types; track native cleanup in #654

No browser example is needed for this documentation-only change.

## Tests

- `npm run wasm:test:types`
- `npm run docs:check --workspace=@muhammara/wasm`
- `npm run test:codestyle`

Closes #652