### PR TITLE
Document RPM Perl prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Document the complete set of Perl packages RPM-based distributions need for a
+  source build. The list grew from `perl-FindBin` and `perl-IPC-Cmd` to also
+  cover `perl-lib`, `perl-File-Compare`, `perl-File-Copy`, `perl-Time-Piece`,
+  and `perl-Digest-SHA`, each verified as blocking on a clean Fedora container.
+  The development guide now states the prerequisites where it tells contributors
+  to run `npm ci`, and the source-capable package README links to the
+  installation page instead of repeating a list that had already drifted
+  [#596](https://github.com/julianhille/MuhammaraJS/issues/596)
 - Document that native writer events have no WebAssembly equivalent
   [#624](https://github.com/julianhille/MuhammaraJS/issues/624)
 - Declare documented native Recipe metadata and call forms in TypeScript,

--- a/packages/native-with-source/README.md
+++ b/packages/native-with-source/README.md
@@ -24,10 +24,9 @@ and Visual Studio Build Tools on Windows; no separate OpenSSL installation is
 required.
 
 RPM-based distributions such as Fedora, RHEL, and openSUSE split the Perl core
-library into separate packages, and OpenSSL's `./Configure` needs some of them.
-Install them alongside `perl` with `dnf install perl-FindBin perl-IPC-Cmd`.
-Without them the build stops while configuring OpenSSL with `Can't locate
-FindBin.pm in @INC`. Debian and Ubuntu ship these modules with `perl` itself.
+library into separate packages, and a source build needs several of them. See
+[Perl Packages On RPM Distributions](https://muhammarajs.readthedocs.io/en/latest/getting-started/installation.html#perl-packages-on-rpm-distributions)
+for the current list. Debian and Ubuntu ship these modules with `perl` itself.
 
 Windows builds use `OPENSSL_VS_INSTALL_PATH`, `GYP_MSVS_OVERRIDE_PATH`,
 `VSINSTALLDIR`, or `npm_config_msbuild_path` when set, then fall back to

--- a/packages/native/docs/development.md
+++ b/packages/native/docs/development.md
@@ -4,6 +4,18 @@ Run these commands from the repository root unless a section says otherwise.
 
 ## Repository Setup
 
+`npm ci` runs the native installation hook, which builds the bundled OpenSSL
+source when no prebuild matches. That build needs the platform C/C++ toolchain,
+Perl, and `make` on Unix-like systems, or Perl, NMake, and Visual Studio Build
+Tools on Windows.
+
+RPM-based distributions such as Fedora, RHEL, and openSUSE need several
+separate Perl core packages installed first, or `npm ci` fails while configuring
+OpenSSL. Install them before the first `npm ci`; see
+[Perl Packages On RPM Distributions](getting-started/installation.md#perl-packages-on-rpm-distributions)
+for the list and what each package is needed for. Debian and Ubuntu ship these
+modules with `perl` itself.
+
 Install the Node.js workspaces and build the native addon when needed:
 
 ```sh

--- a/packages/native/docs/getting-started/installation.md
+++ b/packages/native/docs/getting-started/installation.md
@@ -45,19 +45,47 @@ Perl and `make` on Unix-like systems or Perl, NMake, and Visual Studio Build
 Tools on Windows; no `OPENSSL_LIB_DIR`, `CPPFLAGS`, or separate OpenSSL
 installation is required.
 
+### Perl Packages On RPM Distributions
+
 RPM-based distributions such as Fedora, RHEL, and openSUSE split the Perl core
-library into separate packages, and OpenSSL's `./Configure` needs some of them.
+library into separate packages. OpenSSL's `./Configure` and the generated
+makefile need several of them, and `scripts/build-openssl.sh` needs one more.
 Install them alongside `perl`:
 
 ```sh
-dnf install perl-FindBin perl-IPC-Cmd
+dnf install perl-FindBin perl-lib perl-IPC-Cmd perl-File-Compare \
+  perl-File-Copy perl-Time-Piece perl-Digest-SHA
 ```
 
-Without them the build stops while configuring OpenSSL:
+| Package             | Needed by                                                |
+| ------------------- | -------------------------------------------------------- |
+| `perl-FindBin`      | OpenSSL `./Configure`                                    |
+| `perl-lib`          | OpenSSL `./Configure`                                    |
+| `perl-IPC-Cmd`      | OpenSSL `./Configure`                                    |
+| `perl-File-Compare` | OpenSSL configuration and build file generation          |
+| `perl-File-Copy`    | OpenSSL configuration and build file generation          |
+| `perl-Time-Piece`   | OpenSSL's generated `Makefile`                           |
+| `perl-Digest-SHA`   | `shasum`, used by `build-openssl.sh` for its build stamp |
+
+Every package in this list was verified as blocking on a clean Fedora 44
+container with only `perl-interpreter` installed: each was added in turn as the
+build reported it missing, and with all of them installed the bundled OpenSSL
+3.5.4 configures and builds `libcrypto.a` to completion.
+
+Install the whole list at once. OpenSSL's `./Configure` reports only the first
+module it cannot find, so a single error message is not the whole requirement
+and fixing one error simply reveals the next:
 
 ```
 Can't locate FindBin.pm in @INC (you may need to install the FindBin module) at ./Configure line 15.
 ```
+
+```
+Can't locate Time/Piece.pm in @INC (you may need to install the Time::Piece module) at Makefile.in line 37.
+```
+
+Missing `perl-Digest-SHA` fails differently, in `build-openssl.sh` rather than
+in OpenSSL, because the script calls `shasum` before it configures anything.
 
 Debian and Ubuntu ship these modules with `perl` itself, so no extra packages
 are needed there.


### PR DESCRIPTION
## Summary

- document the complete Fedora/RPM Perl prerequisites for native source builds
- explain the separate `shasum` requirement from `scripts/build-openssl.sh`
- keep one authoritative package list and link to it from contributor/package guidance

## Verification

- strict native documentation build
- Prettier
- `git diff --check`

Closes #596