### PR TITLE
Enforce Recipe context transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Breaking Changes
 
+- Native Recipe `pauseContext()` and `resumeContext()` now throw when there is
+  no matching active or paused page content context instead of silently doing
+  nothing. Call `pauseContext()` only after creating or editing a page, and call
+  `resumeContext()` exactly once after a successful pause
+  [#608](https://github.com/julianhille/MuhammaraJS/issues/608)
 - Remove the accidentally exposed native `Recipe` prototype members
   `ANNOTATION_PREFIX`, `appendPDFPageFromPDFWithAnnotations()`, and
   `appendPDFPagesFromPDFWithAnnotations()`. Code that called these undocumented
@@ -120,6 +125,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   to run `npm ci`, and the source-capable package README links to the
   installation page instead of repeating a list that had already drifted
   [#596](https://github.com/julianhille/MuhammaraJS/issues/596)
+- Make native Recipe `register()`, `pauseContext()`, and `resumeContext()`
+  chainable, and track created-page and edited-page context transitions
+  [#608](https://github.com/julianhille/MuhammaraJS/issues/608)
 - Document that native writer events have no WebAssembly equivalent
   [#624](https://github.com/julianhille/MuhammaraJS/issues/624)
 - Declare documented native Recipe metadata and call forms in TypeScript,

--- a/packages/native-core/lib/Recipe.js
+++ b/packages/native-core/lib/Recipe.js
@@ -352,7 +352,7 @@ class Recipe {
    * @throws {string} If the callback function is unnamed when no key is provided.
    * @throws {string} If the key conflicts with an existing Recipe prototype member.
    * @throws {string} If the callback is not a function.
-   * @returns {void}
+   * @returns {Recipe} The recipe instance.
    */
   register(key, callback) {
     // Assume simply registering a function which will have an embedded name
@@ -373,6 +373,7 @@ class Recipe {
     }
 
     this.__proto__[key] = callback;
+    return this;
   }
 }
 

--- a/packages/native-core/lib/recipe/page.js
+++ b/packages/native-core/lib/recipe/page.js
@@ -67,6 +67,7 @@ exports.createPage = function createPage(pageWidth, pageHeight, margins) {
   this.pageNumber = pageNumber;
   this.pageContext = this.writer.startPageContentContext(this.page);
   this.editingPage = false;
+  this.contextState = "active-new";
 
   if (margins) {
     this.margins(margins);
@@ -144,14 +145,16 @@ exports.endPage = function endPage() {
   }
 
   if (this.page.endContext) {
-    this.page.endContext();
+    if (this.contextState === "active-edit") this.page.endContext();
     this.page.writePage();
   } else {
     this.writer.writePage(this.page);
   }
-  // this.page = null;
-  // this.pageContext = null;
-  // this.pageNumber = 0;
+  this.page = null;
+  this.pageContext = null;
+  this.pageNumber = 0;
+  this.editingPage = false;
+  this.contextState = "idle";
 
   return this;
 };
@@ -176,6 +179,7 @@ exports.editPage = function editPage(pageNumber) {
   this.pageNumber = pageNumber;
   this.pageContext = pageModifier.startContext().getContext();
   this.editingPage = true;
+  this.contextState = "active-edit";
 
   this._resumePageRotation(pageNumber);
 
@@ -296,15 +300,21 @@ exports.getCurrentPageInfo = function getCurrentPageInfo() {
  * @name pauseContext
  * @function
  * @memberof Recipe#
- * @returns {void}
+ * @returns {Recipe} The recipe instance.
+ * @throws {Error} If there is no active page content context.
  */
 exports.pauseContext = function pauseContext() {
-  if (this.page && this.page.endContext) {
+  if (this.contextState === "active-edit") {
     this.page.endContext();
-    // this.writer.pausePageContentContext(this.pageContext);
-  } else if (this.pageContext) {
+    this.pageContext = null;
+    this.contextState = "paused-edit";
+  } else if (this.contextState === "active-new") {
     this.writer.pausePageContentContext(this.pageContext);
+    this.contextState = "paused-new";
+  } else {
+    throw new Error("No active page content context to pause");
   }
+  return this;
 };
 
 /**
@@ -312,13 +322,20 @@ exports.pauseContext = function pauseContext() {
  * @name resumeContext
  * @function
  * @memberof Recipe#
- * @returns {void}
+ * @returns {Recipe} The recipe instance.
+ * @throws {Error} If there is no paused page content context.
  */
 exports.resumeContext = function resumeContext() {
-  if (!this.isNewPDF && this.page) {
+  if (this.contextState === "paused-edit") {
     this.pageContext = this.page.startContext().getContext();
     this._resumePageRotation();
+    this.contextState = "active-edit";
+  } else if (this.contextState === "paused-new") {
+    this.contextState = "active-new";
+  } else {
+    throw new Error("No paused page content context to resume");
   }
+  return this;
 };
 
 /**

--- a/packages/native-core/lib/recipe/parameters.js
+++ b/packages/native-core/lib/recipe/parameters.js
@@ -81,6 +81,7 @@ exports._setParameters = function _setParameters() {
   };
 
   this._margin = Object.assign({}, this.default.pageMargin);
+  this.contextState = "idle";
 
   // Object.assign(this, options);
 };

--- a/packages/native-core/muhammara.d.ts
+++ b/packages/native-core/muhammara.d.ts
@@ -1237,8 +1237,8 @@ declare namespace muhammara {
     /** Metadata read from the source PDF, keyed by one-based page number. */
     readonly metadata: Recipe.Metadata;
     read(inSrc?: string | Buffer): { pages: number; [page: number]: object };
-    register(key: string, callback: Function): void;
-    register(callback: Function & { name: string }): void;
+    register(key: string, callback: Function): Recipe;
+    register(callback: Function & { name: string }): Recipe;
 
     constructor(
       buffer: Buffer,
@@ -1342,8 +1342,8 @@ declare namespace muhammara {
       bottom?: number,
     ): Recipe;
     getPageInfo(): InfoDictionary;
-    pauseContext(): void;
-    resumeContext(): void;
+    pauseContext(): Recipe;
+    resumeContext(): Recipe;
     rotateContent(degrees: number, x?: number, y?: number): Recipe;
     split(outputDir?: string, prefix?: string): Recipe;
 

--- a/packages/native-with-source/tests/recipe/create.js
+++ b/packages/native-with-source/tests/recipe/create.js
@@ -179,7 +179,7 @@ describe("Create", () => {
 
   it("chains registered extensions and validates context transitions", () => {
     const output = path.join(__dirname, "../output/chain-context.pdf");
-    const recipe = new Recipe("new", output);
+    let recipe = new Recipe("new", output);
     assert.equal(
       recipe.register("drawMark", function () {
         return this;
@@ -203,5 +203,6 @@ describe("Create", () => {
     assert.throws(() => recipe.pauseContext(), /No active page/);
     assert.throws(() => recipe.resumeContext(), /No paused page/);
     recipe.endPDF();
+    recipe = null;
   });
 });

--- a/packages/native-with-source/tests/recipe/create.js
+++ b/packages/native-with-source/tests/recipe/create.js
@@ -176,4 +176,32 @@ describe("Create", () => {
       }
     });
   });
+
+  it("chains registered extensions and validates context transitions", () => {
+    const output = path.join(__dirname, "../output/chain-context.pdf");
+    const recipe = new Recipe("new", output);
+    assert.equal(
+      recipe.register("drawMark", function () {
+        return this;
+      }),
+      recipe,
+    );
+    assert.equal(
+      recipe.register(function drawNamedMark() {
+        return this;
+      }),
+      recipe,
+    );
+    assert.throws(() => recipe.pauseContext(), /No active page/);
+    assert.throws(() => recipe.resumeContext(), /No paused page/);
+    recipe.createPage().drawMark().rectangle(10, 10, 20, 20);
+    assert.equal(recipe.pauseContext(), recipe);
+    assert.throws(() => recipe.pauseContext(), /No active page/);
+    assert.equal(recipe.resumeContext(), recipe);
+    assert.throws(() => recipe.resumeContext(), /No paused page/);
+    recipe.drawNamedMark().rectangle(40, 40, 20, 20).endPage();
+    assert.throws(() => recipe.pauseContext(), /No active page/);
+    assert.throws(() => recipe.resumeContext(), /No paused page/);
+    recipe.endPDF();
+  });
 });

--- a/packages/native-with-source/tests/recipe/modify.js
+++ b/packages/native-with-source/tests/recipe/modify.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const Recipe = require("@muhammara/native-with-source").Recipe;
+const assert = require("chai").assert;
 
 describe("Modify", () => {
   it("Add something to an existing pdf", (done) => {
@@ -9,11 +10,16 @@ describe("Modify", () => {
       "../output/Add something to an existing.pdf",
     );
     const recipe = new Recipe(src, output);
+    recipe.info({
+      author: "wahaha",
+    });
+    recipe.editPage(1);
+    assert.throws(() => recipe.resumeContext(), /No paused page/);
+    assert.equal(recipe.pauseContext(), recipe);
+    assert.throws(() => recipe.pauseContext(), /No active page/);
+    assert.equal(recipe.resumeContext(), recipe);
+    assert.throws(() => recipe.resumeContext(), /No paused page/);
     recipe
-      .info({
-        author: "wahaha",
-      })
-      .editPage(1)
       .text("Add some texts to an existing pdf file", 150, 300)
       .circle("center", 100, 60, {
         stroke: "#3b7721",

--- a/packages/native-with-source/tests/types/types.test.ts
+++ b/packages/native-with-source/tests/types/types.test.ts
@@ -66,6 +66,15 @@ var info: muhammara.Recipe.InfoOptions = {
 };
 recipe.info(info).custom("ReportId", "X-456").info({ ReportId: "X-789" });
 
+recipe
+  .register("drawMarker", function () {})
+  .pauseContext()
+  .resumeContext();
+recipe
+  .register(function drawNamedMarker() {})
+  .pauseContext()
+  .resumeContext();
+
 var pageBox: muhammara.PDFPageBoxType = muhammara.ePDFPageBoxCropBox;
 recipe.setPageBox(pageBox, 10, 20, 585, 822);
 recipe.setPageBox(muhammara.ePDFPageBoxMediaBox, 0, 0, 595, 842);

--- a/packages/native/docs/breaking-changes.md
+++ b/packages/native/docs/breaking-changes.md
@@ -5,6 +5,11 @@ For release-by-release changes, see the [Changelog](https://github.com/julianhil
 
 ## Version 7.x
 
+- Recipe `pauseContext()` and `resumeContext()` throw when there is no matching
+  active or paused page content context. Calls outside a page lifecycle and
+  repeated pause or resume calls used to do nothing silently; call
+  `pauseContext()` only after creating or editing a page, and call
+  `resumeContext()` exactly once after a successful pause.
 - The undocumented native `Recipe` prototype members `ANNOTATION_PREFIX`,
   `appendPDFPageFromPDFWithAnnotations()`, and
   `appendPDFPagesFromPDFWithAnnotations()` were removed. Code that called them

--- a/packages/native/docs/recipe/invariants.md
+++ b/packages/native/docs/recipe/invariants.md
@@ -5,6 +5,8 @@
   document composition methods.
 - Call `endPage()` before selecting, creating, or editing another page.
 - Call `endPDF()` only after all page and document operations are complete.
+- `pauseContext()` and `resumeContext()` are chainable for valid transitions.
+  They throw when there is no matching active or paused page content context.
 - Buffer output is delivered to the `endPDF` callback; `endPDF()` does not return
   the PDF Buffer.
 - `editPage` requires an existing input PDF and an output target unless using the

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to `@muhammara/wasm` are documented in this file.
 
 ### Added
 
+- Support chainable Recipe `pauseContext()` and `resumeContext()` transitions
+  on newly created pages while retaining errors for unmatched calls
+  [#608](https://github.com/julianhille/MuhammaraJS/issues/608)
 - Add Recipe URL links for arbitrary areas, rendered text, images, and drawing
   bounds [#614](https://github.com/julianhille/MuhammaraJS/issues/614)
 - Add generated behavioral API reference documentation from JSDoc on every

--- a/packages/wasm/docs/recipe/create-pdfs.md
+++ b/packages/wasm/docs/recipe/create-pdfs.md
@@ -32,7 +32,9 @@ var response = new Response(pdfBytes, {
 
 Named sizes include `letter` and `A4`; `createPage(width, height)` accepts
 explicit point dimensions. Call `endPage()` before creating or editing another
-page. Repeated `endPDF()` calls return the same cached byte array. Call
+page. `pauseContext()` and `resumeContext()` split a page into separate content
+contexts and return the Recipe for valid transitions; unmatched calls throw.
+Repeated `endPDF()` calls return the same cached byte array. Call
 `recipe.dispose()` when a long-lived application no longer needs the Recipe's
 WebAssembly allocations.
 

--- a/packages/wasm/docs/recipe/invariants.md
+++ b/packages/wasm/docs/recipe/invariants.md
@@ -10,6 +10,9 @@
   to mean before the first output page.
 - Call `endPage()` before selecting, creating, or editing another page and before
   `endPDF()`.
+- `pauseContext()` and `resumeContext()` are chainable for valid created-page
+  and edited-page transitions. They throw when there is no matching active or
+  paused page content context.
 - `endPDF()` returns an owned `Uint8Array`; repeated calls return the cached
   result. It never writes a path or stream.
 - `read()` and `readAsync()` inspect their argument without replacing Recipe's

--- a/packages/wasm/docs/recipe/modify-and-inspect.md
+++ b/packages/wasm/docs/recipe/modify-and-inspect.md
@@ -30,8 +30,9 @@ var outputBytes = recipe
 
 Editing uses a byte-backed modifier, including for rotated pages and pages with
 non-zero MediaBox origins. `pauseContext()` and `resumeContext()` split an edit
-into separate appended content contexts. Password-protected source editing is
-not available; decrypt first with the low-level byte-first `recrypt()` API.
+into separate appended content contexts. Both return the Recipe for valid
+transitions and throw for unmatched calls. Password-protected source editing
+is not available; decrypt first with the low-level byte-first `recrypt()` API.
 
 ## Inspect Without Replacing Output State
 

--- a/packages/wasm/lib/recipe/page.js
+++ b/packages/wasm/lib/recipe/page.js
@@ -60,6 +60,7 @@ export function createPageMethods(
       this._activePageNumber = page.pageNumber;
       this._pageWidth = width;
       this._pageHeight = height;
+      this._contextState = "active-new";
       this.margins(margins || this.default.pageMargin);
       // Node Recipe initializes pages as if moveTo(0, 0) was called. Implicit
       // text and layout still use their margin fallbacks when the cursor is zero.
@@ -80,7 +81,7 @@ export function createPageMethods(
     endPage: function () {
       if (this._editingPage) {
         this._flushAnnotations();
-        if (this._pageContext) {
+        if (this._contextState === "active-edit") {
           this._page.endContext();
           this._page.writePage();
         }
@@ -89,6 +90,7 @@ export function createPageMethods(
         this._editingPage = false;
         this._pageHeight = 0;
         this._pageWidth = 0;
+        this._contextState = "idle";
         return this;
       }
       if (this._sourceMode) {
@@ -99,6 +101,7 @@ export function createPageMethods(
         this._page = null;
         this._pageHeight = 0;
         this._pageWidth = 0;
+        this._contextState = "idle";
         return this;
       }
       if (!this._recipe || !this._pageHeight) return this;
@@ -106,6 +109,7 @@ export function createPageMethods(
       call("_muhammara_wasm_recipe_end_page", this._recipe);
       this._pageHeight = 0;
       this._pageWidth = 0;
+      this._contextState = "idle";
       return this;
     },
 
@@ -305,6 +309,7 @@ export function createPageMethods(
       this._page = this.writer.createPageModifier(pageNumber - 1, true);
       this._pageContext = this._page.startContext().getContext();
       this._editingPage = true;
+      this._contextState = "active-edit";
       this._activePageNumber = pageNumber;
       this._pageWidth = page.width;
       this._pageHeight = page.height;
@@ -314,48 +319,61 @@ export function createPageMethods(
     },
 
     /**
-     * Writes and pauses the active edited-page content context.
-     * Page editing remains active, and a later resume restores the page's
-     * rotated, top-left Recipe coordinate transform.
+     * Pauses the active created-page or edited-page content context. Page
+     * editing remains active, and a later resume restores the page's rotated,
+     * top-left Recipe coordinate transform.
      *
      * @name pauseContext
      * @function
      * @memberof Recipe#
      * @returns {Recipe} The Recipe instance.
-     * @throws {Error} If there is no active edited-page content context.
+     * @throws {Error} If there is no active page content context.
      */
     pauseContext: function () {
-      if (!this._editingPage || !this._pageContext) {
+      if (this._contextState === "active-edit") {
+        this._page.endContext();
+        this._page.writePage();
+        this._page = null;
+        this._pageContext = null;
+        this._contextState = "paused-edit";
+      } else if (this._contextState === "active-new") {
+        if (this._sourceMode) {
+          this.writer.pausePageContentContext(this._pageContext);
+        } else {
+          call("_muhammara_wasm_recipe_pause_page", this._recipe);
+        }
+        this._contextState = "paused-new";
+      } else {
         throw new Error("No active page content context to pause");
       }
-      this._page.endContext();
-      this._page.writePage();
-      this._page = null;
-      this._pageContext = null;
       return this;
     },
 
     /**
-     * Resumes a paused edited-page content context.
-     * The page rotation transform is reapplied so subsequent drawing continues
-     * in Recipe's top-left coordinate system.
+     * Resumes a paused created-page or edited-page content context. The page
+     * rotation transform is reapplied so subsequent drawing continues in
+     * Recipe's top-left coordinate system.
      *
      * @name resumeContext
      * @function
      * @memberof Recipe#
      * @returns {Recipe} The Recipe instance.
-     * @throws {Error} If no edited page is paused, or its context is already active.
+     * @throws {Error} If there is no paused page content context.
      */
     resumeContext: function () {
-      if (!this._editingPage || this._pageContext) {
+      if (this._contextState === "paused-edit") {
+        this._page = this.writer.createPageModifier(
+          this._activePageNumber - 1,
+          true,
+        );
+        this._pageContext = this._page.startContext().getContext();
+        this._resumePageRotation();
+        this._contextState = "active-edit";
+      } else if (this._contextState === "paused-new") {
+        this._contextState = "active-new";
+      } else {
         throw new Error("No paused page content context to resume");
       }
-      this._page = this.writer.createPageModifier(
-        this._activePageNumber - 1,
-        true,
-      );
-      this._pageContext = this._page.startContext().getContext();
-      this._resumePageRotation();
       return this;
     },
 

--- a/packages/wasm/lib/recipe/parameters.js
+++ b/packages/wasm/lib/recipe/parameters.js
@@ -84,4 +84,5 @@ export function initializeRecipe(recipe, options) {
   recipe._page = null;
   recipe._pageContext = null;
   recipe._activePageNumber = 0;
+  recipe._contextState = "idle";
 }

--- a/packages/wasm/tests/recipe/create.test.mjs
+++ b/packages/wasm/tests/recipe/create.test.mjs
@@ -19,16 +19,22 @@ describe("Recipe create", function () {
     dimensionsRecipe.endPDF();
 
     var extensionRecipe = new Recipe();
-    extensionRecipe.register("drawDot", function (x, y) {
-      return this.circle(x, y, 2, { fill: "#000000" });
-    });
+    assert.equal(
+      extensionRecipe.register("drawDot", function (x, y) {
+        return this.circle(x, y, 2, { fill: "#000000" });
+      }),
+      extensionRecipe,
+    );
     assert.equal(typeof extensionRecipe.drawDot, "function");
     extensionRecipe.createPage(100, 100).drawDot(50, 50).endPage().endPDF();
 
     var namedExtensionRecipe = new Recipe();
-    namedExtensionRecipe.register(function drawSquare(x, y) {
-      return this.rectangle(x, y, 2, 2, { fill: "#000000" });
-    });
+    assert.equal(
+      namedExtensionRecipe.register(function drawSquare(x, y) {
+        return this.rectangle(x, y, 2, 2, { fill: "#000000" });
+      }),
+      namedExtensionRecipe,
+    );
     assert.throws(
       () => namedExtensionRecipe.register("drawSquare", () => {}),
       /already exists/,
@@ -38,6 +44,21 @@ describe("Recipe create", function () {
       .drawSquare(50, 50)
       .endPage()
       .endPDF();
+  });
+
+  it("chains valid context transitions and rejects unmatched calls", function () {
+    var recipe = new Recipe();
+    assert.throws(() => recipe.pauseContext(), /No active page/);
+    assert.throws(() => recipe.resumeContext(), /No paused page/);
+    recipe.createPage().rectangle(10, 10, 20, 20);
+    assert.equal(recipe.pauseContext(), recipe);
+    assert.throws(() => recipe.pauseContext(), /No active page/);
+    assert.equal(recipe.resumeContext(), recipe);
+    assert.throws(() => recipe.resumeContext(), /No paused page/);
+    recipe.rectangle(40, 40, 20, 20).endPage();
+    assert.throws(() => recipe.pauseContext(), /No active page/);
+    assert.throws(() => recipe.resumeContext(), /No paused page/);
+    recipe.endPDF();
   });
 
   it("tracks named-page metadata, margins, and rotation", function () {

--- a/packages/wasm/tests/recipe/foundation.test.mjs
+++ b/packages/wasm/tests/recipe/foundation.test.mjs
@@ -104,13 +104,13 @@ describe("Recipe foundation", function () {
     assert.equal(recipe.pageInfo(1), null);
     recipe = new Recipe(source, { compress: false });
     assert.deepEqual(recipe.pageInfo(1).mediaBox, [0, 0, 200, 300]);
-    recipe
-      .editPage(1)
-      .rectangle(30, 30, 20, 20, { fill: "#000000" })
-      .pauseContext()
-      .resumeContext()
-      .rectangle(60, 60, 20, 20, { fill: "#000000" })
-      .endPage();
+    recipe.editPage(1).rectangle(30, 30, 20, 20, { fill: "#000000" });
+    assert.throws(() => recipe.resumeContext(), /No paused page/);
+    assert.equal(recipe.pauseContext(), recipe);
+    assert.throws(() => recipe.pauseContext(), /No active page/);
+    assert.equal(recipe.resumeContext(), recipe);
+    assert.throws(() => recipe.resumeContext(), /No paused page/);
+    recipe.rectangle(60, 60, 20, 20, { fill: "#000000" }).endPage();
     var bytes = recipe.endPDF();
     assert.ok(bytes instanceof Uint8Array);
     var reader = (await createMuhammaraWasm()).createReader(bytes);
@@ -150,6 +150,7 @@ describe("Recipe foundation", function () {
     assert.throws(() => recipe.read(new Blob()), /Async API/);
     assert.throws(() => recipe.editPage(1), /constructed from PDF bytes/);
     assert.throws(() => recipe.pauseContext(), /No active page/);
+    assert.throws(() => recipe.resumeContext(), /No paused page/);
     var source = new Recipe().createPage().endPage().endPDF();
     recipe = new Recipe(source);
     assert.throws(() => recipe.editPage(2), /pageNumber/);


### PR DESCRIPTION
## Summary

- make native `register()`, `pauseContext()`, and `resumeContext()` chainable
- enforce matching `pauseContext()` and `resumeContext()` transitions on native and Wasm instead of silently accepting invalid lifecycle calls
- support pausing and resuming newly created pages on Wasm, matching native
- add explicit created-page and edited-page context state, mirrored runtime tests, strict type coverage, docs, changelogs, and native breaking-change guidance

## Verification

- focused native Recipe tests: 7 passed
- focused Wasm Recipe tests: 16 passed
- all strict native and Wasm type suites
- native and Wasm strict documentation builds
- Wasm export validation
- targeted Prettier and `git diff --check`

## Browser Example

No browser example was added because this changes lifecycle validation rather than introducing a browser-facing workflow.

Closes #608
